### PR TITLE
Add MXNet backend

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,111 @@
+name: pyhf
+channels:
+- pytorch
+- https://conda.anaconda.org/NLeSC
+- defaults
+dependencies:
+- ca-certificates=2017.08.26=h1d4fec5_0
+- certifi=2018.1.18=py36_0
+- cffi=1.11.4=py36h9745a5d_0
+- cudatoolkit=8.0=3
+- cudnn=7.0.5=cuda8.0_0
+- freetype=2.8=hab7d2ae_1
+- intel-openmp=2018.0.0=hc7b2577_8
+- jpeg=9b=h024ee3a_2
+- libedit=3.1=heed3624_0
+- libffi=3.2.1=hd88cf55_4
+- libgcc-ng=7.2.0=h7cc24e2_2
+- libgfortran-ng=7.2.0=h9f7466a_2
+- libpng=1.6.34=hb9fc6fc_0
+- libstdcxx-ng=7.2.0=h7a57d05_2
+- libtiff=4.0.9=h28f6b97_0
+- mkl=2018.0.1=h19d6760_4
+- nccl=1.3.4=cuda8.0_1
+- ncurses=6.0=h9df7e31_2
+- numpy=1.14.0=py36h3dfced4_1
+- olefile=0.45.1=py36_0
+- openssl=1.0.2n=hb7f436b_0
+- pillow=5.0.0=py36h3deb7b8_0
+- pip=9.0.1=py36h6c6f9ce_4
+- pycparser=2.18=py36hf9f622e_1
+- python=3.6.4=hc3d631a_1
+- pytorch=0.3.0=py36cuda8.0cudnn7.0_0
+- readline=7.0=ha6073c6_4
+- setuptools=38.4.0=py36_0
+- six=1.11.0=py36h372c433_1
+- sqlite=3.22.0=h1bed415_0
+- tk=8.6.7=hc745277_3
+- torchvision=0.2.0=py36_0
+- wheel=0.30.0=py36hfd4bba0_1
+- xz=5.2.3=h55aa19d_2
+- zlib=1.2.11=ha838bed_2
+- cuda90=1.0=h6433d27_0
+- pip:
+  - absl-py>=0.1.10
+  - ansiwrap>=0.8.3
+  - attrs>=17.4.0
+  - bleach>=1.5.0
+  - boto3>=1.5.26
+  - botocore>=1.8.40
+  - chardet>=3.0.4
+  - click>=6.7
+  - coverage>=4.5.1
+  - cycler>=0.10.0
+  - decorator>=4.2.1
+  - docutils>=0.14
+  - entrypoints>=0.2.3
+  - future>=0.16.0
+  - graphviz>=0.8.1
+  - html5lib>=0.9999999
+  - idna>=2.6
+  - ipython>=6.2.1
+  - ipython-genutils>=0.2.0
+  - jedi>=0.11.1
+  - jinja2>=2.10
+  - jmespath>=0.9.3
+  - jsonschema>=2.6.0
+  - jupyter-client>=5.2.2
+  - jupyter-core>=4.4.0
+  - markdown>=2.6.11
+  - markupsafe>=1.0
+  - matplotlib>=2.1.2
+  - mistune>=0.8.3
+  - mxnet>=1.0.0.post4
+  - nbconvert>=5.3.1
+  - nbformat>=4.4.0
+  - pandas>=0.22.0
+  - pandocfilters>=1.4.2
+  - papermill>=0.12.2
+  - parso>=0.1.1
+  - pexpect>=4.4.0
+  - pickleshare>=0.7.4
+  - pluggy>=0.6.0
+  - prompt-toolkit>=1.0.15
+  - protobuf>=3.5.1
+  - ptyprocess>=0.5.2
+  - py>=1.5.2
+  - pygments>=2.2.0
+  - pyhf>=0.0.4
+  - pyparsing>=2.2.0
+  - pytest>=3.4.0
+  - pytest-cov>=2.5.1
+  - python-dateutil>=2.6.1
+  - pytz>=2018.3
+  - pyyaml>=3.12
+  - pyzmq>=17.0.0
+  - requests>=2.18.4
+  - s3transfer>=0.1.12
+  - scipy>=1.0.0
+  - simplegeneric>=0.8.1
+  - tensorflow>=1.5.0
+  - tensorflow-tensorboard>=1.5.1
+  - testpath>=0.3.1
+  - textwrap3>=0.9.1
+  - torch>=0.3.0
+  - tornado>=4.5.3
+  - tqdm>=4.19.5
+  - traitlets>=4.3.2
+  - uproot>=2.6.10
+  - urllib3>=1.22
+  - wcwidth>=0.1.7
+  - werkzeug>=0.14.1

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,6 +1,0 @@
-matplotlib
-numpy
-papermill
-pyhf
-scipy
-uproot

--- a/examples/notebooks/example-mxnet.ipynb
+++ b/examples/notebooks/example-mxnet.ipynb
@@ -1,0 +1,96 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Populating the interactive namespace from numpy and matplotlib\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pylab inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pyhf\n",
+    "from pyhf import hfpdf\n",
+    "from pyhf.simplemodels import hepdata_like\n",
+    "import mxnet as mx"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--------\n",
+      "as MXNet\n",
+      "--------\n",
+      "<class 'mxnet.ndarray.ndarray.NDArray'> \n",
+      "[-22.87784958]\n",
+      "<NDArray 1 @cpu(0)>\n"
+     ]
+    }
+   ],
+   "source": [
+    "source = {\n",
+    "  \"binning\": [2,-0.5,1.5],\n",
+    "  \"bindata\": {\n",
+    "    \"data\": [120.0, 180.0],\n",
+    "    \"bkg\": [100.0, 150.0],\n",
+    "    \"bkgerr\": [10.0, 10.0],\n",
+    "    \"sig\": [30.0, 95.0]\n",
+    "  }\n",
+    "}\n",
+    "\n",
+    "pdf = hepdata_like(source['bindata']['sig'], source['bindata']['bkg'], source['bindata']['bkgerr'])\n",
+    "data = source['bindata']['data'] + pdf.config.auxdata\n",
+    "\n",
+    "init_pars = pdf.config.suggested_init()\n",
+    "par_bounds = pdf.config.suggested_bounds()\n",
+    "\n",
+    "\n",
+    "print('--------\\nas MXNet\\n--------')\n",
+    "pyhf.tensorlib = pyhf.mxnet_backend()\n",
+    "v = pdf.logpdf(init_pars, data)\n",
+    "print(type(v),v)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/pyhf/__init__.py
+++ b/pyhf/__init__.py
@@ -18,6 +18,12 @@ try:
 except ImportError:
     pass
 
+try:
+    from .tensor.mxnet_backend import mxnet_backend
+    assert mxnet_backend
+except ImportError:
+    pass
+
 
 tensorlib = numpy_backend()
 optimizer = scipy_optimizer()

--- a/pyhf/tensor/mxnet_backend.py
+++ b/pyhf/tensor/mxnet_backend.py
@@ -39,9 +39,9 @@ class mxnet_backend(object):
         tensor_1_shape = tensor_in_1.shape
         tensor_2_shape = tensor_in_2.shape
         if len(tensor_1_shape) == 1:
-            tensor_1_shape = (*tensor_1_shape, 1)
+            tensor_1_shape = (tensor_1_shape[0], 1)
         if len(tensor_2_shape) == 1:
-            tensor_2_shape = (*tensor_2_shape, 1)
+            tensor_2_shape = (tensor_2_shape[0], 1)
 
         rows1, cols1 = tensor_1_shape
         rows2, cols2 = tensor_2_shape

--- a/pyhf/tensor/mxnet_backend.py
+++ b/pyhf/tensor/mxnet_backend.py
@@ -1,0 +1,183 @@
+import mxnet as mx
+from mxnet import nd
+import logging
+log = logging.getLogger(__name__)
+
+
+class mxnet_backend(object):
+    """Backend for MXNet"""
+
+    def __init__(self, **kwargs):
+        self.session = kwargs.get('session')
+
+    def tolist(self, tensor_in):
+        """
+        Convert a tensor to a list
+
+        Args:
+            tensor_in: MXNet tensor
+
+        Returns:
+            The possibly nested list of tensor elements.
+        """
+        tensor_in = self.astensor(tensor_in)
+        return tensor_in.asnumpy().tolist()
+
+    def outer(self, tensor_in_1, tensor_in_2):
+        """
+        The outer product of two tensors: u.v^T
+
+        Args:
+            tensor_in_1: tensor object
+            tensor_in_2: tensor object
+
+        Returns:
+            MXNet NDArray: The outer product
+        """
+        tensor_in_1 = self.astensor(tensor_in_1)
+        tensor_in_2 = self.astensor(tensor_in_2)
+        pass
+
+    def astensor(self, tensor_in):
+        """
+        Convert a tensor to an MXNet NDArray
+
+        Args:
+            tensor_in: tensor object
+
+        Returns:
+            MXNet NDArray: a multi-dimensional, fixed-size homogenous array.
+        """
+        return nd.array(tensor_in)
+
+    def sum(self, tensor_in, axis=None):
+        """
+        Compute the sum of array elements over given axes.
+
+        Args:
+            tensor_in: tensor object
+            axis: the axes over which to sum
+
+        Returns:
+            MXNet NDArray: ndarray of the sum over the axes
+        """
+        tensor_in = self.astensor(tensor_in)
+        if axis is None or tensor_in.shape == nd.Size([]):
+            return nd.sum(tensor_in)
+        else:
+            return nd.sum(tensor_in, axis)
+
+    def product(self, tensor_in, axis=None):
+        pass
+
+    def ones(self, shape):
+        """
+        A new array filled with all ones, with the given shape.
+
+        Args:
+            shape: the shape of the array
+
+        Returns:
+            MXNet NDArray: ndarray of 1's with given shape
+        """
+        return nd.ones(shape)
+
+    def zeros(self, shape):
+        """
+        A new array filled with all zeros, with the given shape.
+
+        Args:
+            shape: the shape of the array
+
+        Returns:
+            MXNet NDArray: ndarray of 0's with given shape
+        """
+        return nd.zeros(shape)
+
+    def power(self, tensor_in_1, tensor_in_2):
+        """
+        Result of first array elements raised to powers from second array,
+        element-wise with broadcasting.
+
+        Args:
+            tensor_in_1: tensor object
+            tensor_in_2: tensor object
+
+        Returns:
+            MXNet NDArray: first array elements raised to powers from second array
+        """
+        tensor_in_1 = self.astensor(tensor_in_1)
+        tensor_in_2 = self.astensor(tensor_in_2)
+        return nd.power(tensor_in_1, tensor_in_2)
+
+    def sqrt(self, tensor_in):
+        """
+        Element-wise square-root value of the input.
+
+        Args:
+            tensor_in: tensor object
+
+        Returns:
+            MXNet NDArray: element-wise square-root value
+        """
+        tensor_in = self.astensor(tensor_in)
+        return nd.sqrt(tensor_in)
+
+    def divide(self, tensor_in_1, tensor_in_2):
+        """
+        Element-wise division of the input arrays with broadcasting.
+
+        Args:
+            tensor_in_1: tensor object
+            tensor_in_2: tensor object
+
+        Returns:
+            MXNet NDArray: element-wise division of the input arrays
+        """
+        tensor_in_1 = self.astensor(tensor_in_1)
+        tensor_in_2 = self.astensor(tensor_in_2)
+        return nd.divide(tensor_in_1, tensor_in_2)
+
+    def log(self, tensor_in):
+        """
+        Element-wise Natural logarithmic value of the input.
+
+        Args:
+            tensor_in: tensor object
+
+        Returns:
+            MXNet NDArray: element-wise Natural logarithmic value
+        """
+        tensor_in = self.astensor(tensor_in)
+        return nd.log(tensor_in)
+
+    def exp(self, tensor_in):
+        """
+        Element-wise exponential value of the input.
+
+        Args:
+            tensor_in: tensor object
+
+        Returns:
+            MXNet NDArray: element-wise exponential value
+        """
+        tensor_in = self.astensor(tensor_in)
+        return nd.exp(tensor_in)
+
+    def stack(self, sequence, axis=0):
+        pass
+
+    def where(self, mask, tensor_in_1, tensor_in_2):
+        pass
+
+    def concatenate(self, sequence):
+        pass
+
+    def simple_broadcast(self, *args):
+        pass
+
+    def poisson(self, n, lam):
+        pass
+
+    def normal(self, x, mu, sigma):
+        pass

--- a/pyhf/tensor/mxnet_backend.py
+++ b/pyhf/tensor/mxnet_backend.py
@@ -8,7 +8,7 @@ class mxnet_backend(object):
     """Backend for MXNet"""
 
     def __init__(self, **kwargs):
-        self.session = kwargs.get('session')
+        pass
 
     def tolist(self, tensor_in):
         """
@@ -62,13 +62,27 @@ class mxnet_backend(object):
             MXNet NDArray: ndarray of the sum over the axes
         """
         tensor_in = self.astensor(tensor_in)
-        if axis is None or tensor_in.shape == nd.Size([]):
+        if axis is None or tensor_in.shape == nd.array([]).size:
             return nd.sum(tensor_in)
         else:
             return nd.sum(tensor_in, axis)
 
     def product(self, tensor_in, axis=None):
-        pass
+        """
+        Product of array elements over given axes.
+
+        Args:
+            tensor_in: tensor object
+            axis: the axes over which to take the product
+
+        Returns:
+            MXNet NDArray: ndarray of the product over the axes
+        """
+        tensor_in = self.astensor(tensor_in)
+        if axis is None:
+            return nd.prod(tensor_in)
+        else:
+            return nd.prod(tensor_in, axis)
 
     def ones(self, shape):
         """
@@ -165,19 +179,85 @@ class mxnet_backend(object):
         return nd.exp(tensor_in)
 
     def stack(self, sequence, axis=0):
-        pass
+        """
+        Join a sequence of arrays along a new axis.
+
+        The axis parameter specifies the index of the new axis in the dimensions
+        of the result. For example, if axis=0 it will be the first dimension and
+        if axis=-1 it will be the last dimension.
+
+        Args:
+            sequence: sequence of arrays
+            axis: the axis along which to join the arrays
+
+        Returns:
+            MXNet NDArray: ndarray comprised of the elements of the sequence
+        """
+        return nd.stack(*sequence, axis=axis)
 
     def where(self, mask, tensor_in_1, tensor_in_2):
-        pass
+        """
+        Apply a boolean selection mask to the elements of the input tensors
+
+        Example:
+            >>> mxnet_backend.where(
+                mxnet_backend.astensor([1, 0, 1]),
+                mxnet_backend.astensor([1, 1, 1]),
+                mxnet_backend.astensor([2, 2, 2]))
+            >>> [1. 2. 1.]
+
+        Args:
+            mask: Boolean mask (boolean or tensor object of booleans)
+            tensor_in_1: tensor object
+            tensor_in_2: tensor object
+
+        Returns:
+            MXNet NDArray: The result of the mask being applied to the tensors
+        """
+        mask = self.astensor(mask)
+        tensor_in_1 = self.astensor(tensor_in_1)
+        tensor_in_2 = self.astensor(tensor_in_2)
+        return nd.multiply(mask, tensor_in_1) + nd.multiply(nd.subtract(1, mask), tensor_in_2)
 
     def concatenate(self, sequence):
-        pass
+        """
+        Join the elements of the sequence
+
+        Args:
+            sequence: the sequence of arrays to join
+
+        Returns:
+            MXNet NDArray: The ndarray of the joined elements
+        """
+        return nd.concat(*sequence, dim=0)
 
     def simple_broadcast(self, *args):
-        pass
+        """
+        Does this work?
+        There should be a more MXNet-style way to do this
+        """
+        broadcast = []
+        max_dim = max(map(len, args))
+        for arg in args:
+            broadcast.append(self.astensor(arg)
+                             if len(arg) > 1 else arg * self.ones(max_dim))
+        return broadcast
 
     def poisson(self, n, lam):
-        pass
+        return self.normal(n, lam, self.sqrt(lam))
 
     def normal(self, x, mu, sigma):
-        pass
+        import math
+        from numbers import Number
+        x = self.astensor(x)
+        mu = self.astensor(mu)
+        sigma = self.astensor(sigma)
+        # Is needed?
+        # normal = nd.random.normal(loc=mu, scale=sigma)
+
+        def log_prob(value, loc, scale):
+            variance = scale ** 2
+            log_scale = math.log(scale) if isinstance(
+                scale, Number) else scale.log()
+            return -((value - loc) ** 2) / (2 * variance) - log_scale - math.log(math.sqrt(2 * math.pi))
+        return self.exp(log_prob(x, mu, sigma))

--- a/pyhf/tensor/mxnet_backend.py
+++ b/pyhf/tensor/mxnet_backend.py
@@ -6,34 +6,34 @@ log = logging.getLogger(__name__)
 
 
 class mxnet_backend(object):
-    """Backend for MXNet"""
+    """MXNet backend for pyhf"""
 
     def __init__(self, **kwargs):
         pass
 
     def tolist(self, tensor_in):
         """
-        Convert a tensor to a list
+        Convert a tensor to a list.
 
         Args:
-            tensor_in: MXNet tensor
+            tensor_in (Tensor): Input MXNet tensor
 
         Returns:
-            The possibly nested list of tensor elements.
+            list: The possibly nested list of tensor elements.
         """
         tensor_in = self.astensor(tensor_in)
         return tensor_in.asnumpy().tolist()
 
     def outer(self, tensor_in_1, tensor_in_2):
         """
-        The outer product of two tensors
+        The outer product of two tensors.
 
         Args:
-            tensor_in_1: tensor object
-            tensor_in_2: tensor object
+            tensor_in_1 (Tensor): Tensor object
+            tensor_in_2 (Tensor): Tensor object
 
         Returns:
-            MXNet NDArray: The outer product
+            MXNet NDArray: The outer product.
         """
         tensor_in_1 = self.astensor(tensor_in_1)
         tensor_in_2 = self.astensor(tensor_in_2)
@@ -53,13 +53,13 @@ class mxnet_backend(object):
 
     def astensor(self, tensor_in):
         """
-        Convert a tensor to an MXNet NDArray
+        Convert a tensor to an MXNet NDArray.
 
         Args:
-            tensor_in: tensor object
+            tensor_in (Number or Tensor): Tensor object
 
         Returns:
-            MXNet NDArray: a multi-dimensional, fixed-size homogenous array.
+            MXNet NDArray: A multi-dimensional, fixed-size homogenous array.
         """
         return nd.array(tensor_in)
 
@@ -68,11 +68,11 @@ class mxnet_backend(object):
         Compute the sum of array elements over given axes.
 
         Args:
-            tensor_in: tensor object
-            axis: the axes over which to sum
+            tensor_in (Tensor): Tensor object
+            axis (Number): The axes over which to sum
 
         Returns:
-            MXNet NDArray: ndarray of the sum over the axes
+            MXNet NDArray: ndarray of the sum over the axes.
         """
         tensor_in = self.astensor(tensor_in)
         if axis is None or tensor_in.shape == nd.array([]).size:
@@ -85,11 +85,11 @@ class mxnet_backend(object):
         Product of array elements over given axes.
 
         Args:
-            tensor_in: tensor object
-            axis: the axes over which to take the product
+            tensor_in (Tensor): Tensor object
+            axis (Number): The axes over which to take the product
 
         Returns:
-            MXNet NDArray: ndarray of the product over the axes
+            MXNet NDArray: ndarray of the product over the axes.
         """
         tensor_in = self.astensor(tensor_in)
         if axis is None:
@@ -102,10 +102,10 @@ class mxnet_backend(object):
         A new array filled with all ones, with the given shape.
 
         Args:
-            shape: the shape of the array
+            shape (Number): The shape of the array
 
         Returns:
-            MXNet NDArray: ndarray of 1's with given shape
+            MXNet NDArray: ndarray of 1's with given shape.
         """
         return nd.ones(shape)
 
@@ -114,10 +114,10 @@ class mxnet_backend(object):
         A new array filled with all zeros, with the given shape.
 
         Args:
-            shape: the shape of the array
+            shape (Number): The shape of the array
 
         Returns:
-            MXNet NDArray: ndarray of 0's with given shape
+            MXNet NDArray: ndarray of 0's with given shape.
         """
         return nd.zeros(shape)
 
@@ -127,11 +127,11 @@ class mxnet_backend(object):
         element-wise with broadcasting.
 
         Args:
-            tensor_in_1: tensor object
-            tensor_in_2: tensor object
+            tensor_in_1 (Tensor): Tensor object
+            tensor_in_2 (Tensor): Tensor object
 
         Returns:
-            MXNet NDArray: first array elements raised to powers from second array
+            MXNet NDArray: First array elements raised to powers from second array.
         """
         tensor_in_1 = self.astensor(tensor_in_1)
         tensor_in_2 = self.astensor(tensor_in_2)
@@ -142,10 +142,10 @@ class mxnet_backend(object):
         Element-wise square-root value of the input.
 
         Args:
-            tensor_in: tensor object
+            tensor_in (Tensor): Tensor object
 
         Returns:
-            MXNet NDArray: element-wise square-root value
+            MXNet NDArray: Element-wise square-root value.
         """
         tensor_in = self.astensor(tensor_in)
         return nd.sqrt(tensor_in)
@@ -155,11 +155,11 @@ class mxnet_backend(object):
         Element-wise division of the input arrays with broadcasting.
 
         Args:
-            tensor_in_1: tensor object
-            tensor_in_2: tensor object
+            tensor_in_1 (Tensor): Tensor object
+            tensor_in_2 (Tensor): Tensor object
 
         Returns:
-            MXNet NDArray: element-wise division of the input arrays
+            MXNet NDArray: Element-wise division of the input arrays.
         """
         tensor_in_1 = self.astensor(tensor_in_1)
         tensor_in_2 = self.astensor(tensor_in_2)
@@ -170,10 +170,10 @@ class mxnet_backend(object):
         Element-wise Natural logarithmic value of the input.
 
         Args:
-            tensor_in: tensor object
+            tensor_in (Tensor): Tensor object
 
         Returns:
-            MXNet NDArray: element-wise Natural logarithmic value
+            MXNet NDArray: Element-wise Natural logarithmic value.
         """
         tensor_in = self.astensor(tensor_in)
         return nd.log(tensor_in)
@@ -183,10 +183,10 @@ class mxnet_backend(object):
         Element-wise exponential value of the input.
 
         Args:
-            tensor_in: tensor object
+            tensor_in (Tensor): Tensor object
 
         Returns:
-            MXNet NDArray: element-wise exponential value
+            MXNet NDArray: Element-wise exponential value.
         """
         tensor_in = self.astensor(tensor_in)
         return nd.exp(tensor_in)
@@ -200,19 +200,20 @@ class mxnet_backend(object):
         if axis=-1 it will be the last dimension.
 
         Args:
-            sequence: sequence of arrays
-            axis: the axis along which to join the arrays
+            sequence (Array of Tensors): Sequence of arrays
+            axis (Number): The axis along which to join the arrays
 
         Returns:
-            MXNet NDArray: ndarray comprised of the elements of the sequence
+            MXNet NDArray: ndarray comprised of the elements of the sequence.
         """
         return nd.stack(*sequence, axis=axis)
 
     def where(self, mask, tensor_in_1, tensor_in_2):
         """
-        Apply a boolean selection mask to the elements of the input tensors
+        Apply a boolean selection mask to the elements of the input tensors.
 
-        Example:
+        Example::
+
             >>> where(
                 astensor([1, 0, 1]),
                 astensor([1, 1, 1]),
@@ -220,12 +221,12 @@ class mxnet_backend(object):
             [1. 2. 1.]
 
         Args:
-            mask: Boolean mask (boolean or tensor object of booleans)
-            tensor_in_1: tensor object
-            tensor_in_2: tensor object
+            mask (bool): Boolean mask (boolean or tensor object of booleans)
+            tensor_in_1 (Tensor): Tensor object
+            tensor_in_2 (Tensor): Tensor object
 
         Returns:
-            MXNet NDArray: The result of the mask being applied to the tensors
+            MXNet NDArray: The result of the mask being applied to the tensors.
         """
         mask = self.astensor(mask)
         tensor_in_1 = self.astensor(tensor_in_1)
@@ -235,21 +236,22 @@ class mxnet_backend(object):
 
     def concatenate(self, sequence):
         """
-        Join the elements of the sequence
+        Join the elements of the sequence.
 
         Args:
-            sequence: the sequence of arrays to join
+            sequence (Array of Tensors): The sequence of arrays to join
 
         Returns:
-            MXNet NDArray: The ndarray of the joined elements
+            MXNet NDArray: The ndarray of the joined elements.
         """
         return nd.concat(*sequence, dim=0)
 
     def simple_broadcast(self, *args):
         """
-        Broadcast a sequence of 1 dimensional arrays
+        Broadcast a sequence of 1 dimensional arrays.
 
-        Example:
+        Example::
+
             >>> simple_broadcast(
                 astensor([1]),
                 astensor([2, 2]),
@@ -259,10 +261,10 @@ class mxnet_backend(object):
              [3. 3. 3.]]
 
         Args:
-            args: sequence of arrays
+            args (Array of Tensors): Sequence of arrays
 
         Returns:
-            MXNet NDArray: The sequence broadcast together
+            MXNet NDArray: The sequence broadcast together.
         """
         max_dim = max(map(len, args))
         broadcast = []
@@ -275,16 +277,41 @@ class mxnet_backend(object):
         return nd.stack(*broadcast)
 
     def poisson(self, n, lam):
+        """
+        The continous approximation to the probability density function of the Poisson
+        distribution given the parameters evaluated at `n`.
+
+        Args:
+            n (Number or Tensor): The value at which to evaluate the Poisson distribution p.d.f.
+                                  (the observed number of events)
+            lam (Number or Tensor): The mean of the Poisson distribution p.d.f.
+                                    (the expected number of events)
+
+        Returns:
+            MXNet NDArray: Value of N(n|lam, sqrt(lam)), the continous approximation to Poisson(n|lam).
+        """
         return self.normal(n, lam, self.sqrt(lam))
 
     def normal(self, x, mu, sigma):
         """
-        Currently copying from PyTorch's source until can find a better way to do this
+        The probability density function of the Normal distribution given the parameters
+        evaluated at `x`.
+
+        Args:
+            x (Number or Tensor): The point at which to evaluate the Normal distribution p.d.f.
+            mu (Number or Tensor): The mean of the Normal distribution p.d.f.
+            sigma(Number or Tensor): The standard deviation of the Normal distribution p.d.f.
+
+        Returns:
+            MXNet NDArray: Value of N(x|mu, sigma).
         """
         x = self.astensor(x)
         mu = self.astensor(mu)
         sigma = self.astensor(sigma)
 
+        # This is currently copied directly from PyTorch's source until a better
+        # way can be found to do this in MXNet
+        # https://github.com/pytorch/pytorch/blob/master/torch/distributions/normal.py#L61-L66
         def log_prob(value, loc, scale):
             variance = scale ** 2
             log_scale = math.log(scale) if isinstance(

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,9 @@ setup(
     'torch': [
       'torch'
     ],
+    'mxnet':[
+      'mxnet',
+    ],
     'develop': [
        'pyflakes',
        'pytest>=3.2.0',
@@ -29,7 +32,9 @@ setup(
        'uproot',
        'papermill',
        'torch',
-       'tensorflow'
+       'tensorflow',
+       'mxnet>=1.0.0',
+       'graphviz'
     ]
   },
   entry_points = {

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1,33 +1,39 @@
 from pyhf.tensor.pytorch_backend import pytorch_backend
 from pyhf.tensor.numpy_backend import numpy_backend
 from pyhf.tensor.tensorflow_backend import tensorflow_backend
+from pyhf.tensor.mxnet_backend import mxnet_backend
 from pyhf.simplemodels import hepdata_like
 import tensorflow as tf
 
 
 def test_common_tensor_backends():
     tf_sess = tf.Session()
-    for tb in [numpy_backend(), pytorch_backend(), tensorflow_backend(session = tf_sess)]:
-        assert tb.tolist(tb.astensor([1,2,3])) == [1,2,3]
-        assert tb.tolist(tb.ones((2,3))) == [[1,1,1],[1,1,1]]
-        assert tb.tolist(tb.sum([[1,2,3],[4,5,6]], axis = 0)) == [5,7,9]
-        assert tb.tolist(tb.product([[1,2,3],[4,5,6]], axis = 0)) == [4,10,18]
-        assert tb.tolist(tb.power([1,2,3],[1,2,3])) == [1,4,27]
-        assert tb.tolist(tb.divide([4,9,16],[2,3,4])) == [2,3,4]
-        assert tb.tolist(tb.outer([1,2,3],[4,5,6])) == [[4,5,6],[8,10,12],[12,15,18]]
-        assert tb.tolist(tb.sqrt([4,9,16])) == [2,3,4]
-        assert tb.tolist(tb.stack([tb.astensor([1,2,3]),tb.astensor([4,5,6])])) == [[1,2,3],[4,5,6]]
-        assert tb.tolist(tb.concatenate([tb.astensor([1,2,3]),tb.astensor([4,5,6])])) == [1,2,3,4,5,6]
-        assert tb.tolist(tb.log(tb.exp([2,3,4]))) == [2,3,4]
+    for tb in [numpy_backend(), pytorch_backend(),
+               tensorflow_backend(session=tf_sess), mxnet_backend()]:
+        assert tb.tolist(tb.astensor([1, 2, 3])) == [1, 2, 3]
+        assert tb.tolist(tb.ones((2, 3))) == [[1, 1, 1], [1, 1, 1]]
+        assert tb.tolist(tb.sum([[1, 2, 3], [4, 5, 6]], axis=0)) == [5, 7, 9]
+        assert tb.tolist(
+            tb.product([[1, 2, 3], [4, 5, 6]], axis=0)) == [4, 10, 18]
+        assert tb.tolist(tb.power([1, 2, 3], [1, 2, 3])) == [1, 4, 27]
+        assert tb.tolist(tb.divide([4, 9, 16], [2, 3, 4])) == [2, 3, 4]
+        assert tb.tolist(
+            tb.outer([1, 2, 3], [4, 5, 6])) == [[4, 5, 6], [8, 10, 12], [12, 15, 18]]
+        assert tb.tolist(tb.sqrt([4, 9, 16])) == [2, 3, 4]
+        assert tb.tolist(tb.stack(
+            [tb.astensor([1, 2, 3]), tb.astensor([4, 5, 6])])) == [[1, 2, 3], [4, 5, 6]]
+        assert tb.tolist(tb.concatenate(
+            [tb.astensor([1, 2, 3]), tb.astensor([4, 5, 6])])) == [1, 2, 3, 4, 5, 6]
+        assert tb.tolist(tb.log(tb.exp([2, 3, 4]))) == [2, 3, 4]
         assert tb.tolist(tb.where(
-            tb.astensor([1,0,1]),
-            tb.astensor([1,1,1]),
-            tb.astensor([2,2,2]))) == [1,2,1]
+            tb.astensor([1, 0, 1]),
+            tb.astensor([1, 1, 1]),
+            tb.astensor([2, 2, 2]))) == [1, 2, 1]
 
-        assert list(map(tb.tolist,tb.simple_broadcast(
-            tb.astensor([1,1,1]),
+        assert list(map(tb.tolist, tb.simple_broadcast(
+            tb.astensor([1, 1, 1]),
             tb.astensor([2]),
-            tb.astensor([3,3,3])))) == [[1,1,1],[2,2,2],[3,3,3]]
+            tb.astensor([3, 3, 3])))) == [[1, 1, 1], [2, 2, 2], [3, 3, 3]]
 
 
 def test_pdf_eval():
@@ -36,38 +42,40 @@ def test_pdf_eval():
     oldlib = pyhf.tensorlib
 
     tf_sess = tf.Session()
-    backends = [numpy_backend(poisson_from_normal = True), pytorch_backend(), tensorflow_backend(session = tf_sess)]
+    backends = [numpy_backend(poisson_from_normal=True),
+                pytorch_backend(),
+                tensorflow_backend(session=tf_sess),
+                mxnet_backend()]
 
     values = []
     for b in backends:
-
         pyhf.tensorlib = b
 
         source = {
-          "binning": [2,-0.5,1.5],
-          "bindata": {
-            "data":    [120.0, 180.0],
-            "bkg":     [100.0, 150.0],
-            "bkgsys_up":  [102, 190],
-            "bkgsys_dn":  [98, 100],
-            "sig":     [30.0, 95.0]
-          }
+            "binning": [2, -0.5, 1.5],
+            "bindata": {
+                "data":    [120.0, 180.0],
+                "bkg":     [100.0, 150.0],
+                "bkgsys_up":  [102, 190],
+                "bkgsys_dn":  [98, 100],
+                "sig":     [30.0, 95.0]
+            }
         }
         spec = {
             'singlechannel': {
                 'signal': {
                     'data': source['bindata']['sig'],
-                    'mods': [{'name': 'mu','type': 'normfactor','data': None}]
+                    'mods': [{'name': 'mu', 'type': 'normfactor', 'data': None}]
                 },
                 'background': {
                     'data': source['bindata']['bkg'],
-                    'mods': [{'name': 'bkg_norm','type': 'histosys','data': {
+                    'mods': [{'name': 'bkg_norm', 'type': 'histosys', 'data': {
                         'lo_hist': source['bindata']['bkgsys_dn'], 'hi_hist': source['bindata']['bkgsys_up'],
                     }}]
                 }
             }
         }
-        pdf  = pyhf.hfpdf(spec)
+        pdf = pyhf.hfpdf(spec)
         data = source['bindata']['data'] + pdf.config.auxdata
 
         v1 = pdf.logpdf(pdf.config.suggested_init(), data)
@@ -84,24 +92,27 @@ def test_pdf_eval_2():
     oldlib = pyhf.tensorlib
 
     tf_sess = tf.Session()
-    backends = [numpy_backend(poisson_from_normal = True), pytorch_backend(), tensorflow_backend(session = tf_sess)]
+    backends = [numpy_backend(poisson_from_normal=True),
+                pytorch_backend(),
+                tensorflow_backend(session=tf_sess),
+                mxnet_backend()]
 
     values = []
     for b in backends:
-
         pyhf.tensorlib = b
 
         source = {
-          "binning": [2,-0.5,1.5],
-          "bindata": {
-            "data":    [120.0, 180.0],
-            "bkg":     [100.0, 150.0],
-            "bkgerr":     [10.0, 10.0],
-            "sig":     [30.0, 95.0]
-          }
+            "binning": [2, -0.5, 1.5],
+            "bindata": {
+                "data":    [120.0, 180.0],
+                "bkg":     [100.0, 150.0],
+                "bkgerr":     [10.0, 10.0],
+                "sig":     [30.0, 95.0]
+            }
         }
 
-        pdf  = hepdata_like(source['bindata']['sig'], source['bindata']['bkg'], source['bindata']['bkgerr'])
+        pdf = hepdata_like(source['bindata']['sig'], source['bindata'][
+                           'bkg'], source['bindata']['bkgerr'])
         data = source['bindata']['data'] + pdf.config.auxdata
 
         v1 = pdf.logpdf(pdf.config.suggested_init(), data)


### PR DESCRIPTION
Add in a backend for [MXNet](https://mxnet.incubator.apache.org) as described in Issue #80.

TODO:
- [x] Finish the `mxnet_backend.py` methods
- [x] Get all tests passing
- [x] Refactor methods to use as few dependencies beyond `mxnet` as possible
- [x] Add [Sphinx compliant](https://pythonhosted.org/an_example_pypi_project/sphinx.html#function-definitions) doc strings
- [x] Add an example Jupyter Notebook
- [x] Add [Binder support](https://mybinder.readthedocs.io/en/latest/sample_repos.html#conda-environment-with-environment-yml)

This was made easier by the ["PyTorch to MXNet" README](https://github.com/zackchase/mxnet-the-straight-dope/blob/master/cheatsheets/pytorch_gluon.md) from the online book "[Deep Learning - The Straight Dope](https://github.com/zackchase/mxnet-the-straight-dope)"