### PR TITLE
Change the optimizer with the backend

### DIFF
--- a/pyhf/__init__.py
+++ b/pyhf/__init__.py
@@ -20,7 +20,9 @@ except ImportError:
 
 try:
     from .tensor.mxnet_backend import mxnet_backend
+    # from .optimize.opt_mxnet import mxnet_optimizer
     assert mxnet_backend
+    # assert mxnet_optimizer
 except ImportError:
     pass
 
@@ -29,6 +31,36 @@ tensorlib = numpy_backend()
 optimizer = scipy_optimizer()
 
 log = logging.getLogger(__name__)
+
+
+def set_backend(backend):
+    """
+    Set the backend and the associated optimizer
+
+    Args:
+        backend: One of the supported pyhf backends: NumPy,
+                 TensorFlow, PyTorch, and MXNet
+
+    Returns:
+        None
+
+    Example:
+        pyhf.set_backend(tensorflow_backend(session=tf.Session()))
+    """
+    global tensorlib
+    global optimizer
+
+    tensorlib = backend
+    if isinstance(tensorlib, tensorflow_backend):
+        optimizer = tflow_optimizer(tensorlib)
+    elif isinstance(tensorlib, pytorch_backend):
+        optimizer = pytorch_optimizer(tensorlib=tensorlib)
+    # TODO: Add support for mxnet_optimizer()
+    # elif isinstance(tensorlib, mxnet_backend):
+    #     optimizer = mxnet_optimizer()
+    else:
+        optimizer = scipy_optimizer()
+
 
 def _poisson_impl(n, lam):
     return tensorlib.poisson(n,lam)

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -1,11 +1,15 @@
+import pyhf
+
 from pyhf.optimize.opt_scipy import scipy_optimizer
 from pyhf.tensor.pytorch_backend import pytorch_backend
 from pyhf.tensor.numpy_backend import numpy_backend
 from pyhf.optimize.opt_pytorch import pytorch_optimizer
 from pyhf.optimize.opt_tflow import tflow_optimizer
 
+import tensorflow as tf
+
+
 def test_optim_numpy():
-    import pyhf
     source = {
       "binning": [2,-0.5,1.5],
       "bindata": {
@@ -43,28 +47,27 @@ def test_optim_numpy():
             }
         }
     }
-    pdf  = pyhf.hfpdf(spec)
+    pdf = pyhf.hfpdf(spec)
     data = source['bindata']['data'] + pdf.config.auxdata
 
-    init_pars  = pdf.config.suggested_init()
+    init_pars = pdf.config.suggested_init()
     par_bounds = pdf.config.suggested_bounds()
 
     oldlib = pyhf.tensorlib
-    pyhf.tensorlib = pyhf.numpy_backend(poisson_from_normal = True)
-    optim  = scipy_optimizer()
+    pyhf.set_backend(pyhf.numpy_backend(poisson_from_normal=True))
+    optim = pyhf.optimizer
 
-    v1 =  pdf.logpdf(init_pars,data)
-    result = optim.unconstrained_bestfit(pyhf.loglambdav,data,pdf, init_pars, par_bounds)
+    v1 = pdf.logpdf(init_pars, data)
+    result = optim.unconstrained_bestfit(pyhf.loglambdav, data, pdf, init_pars, par_bounds)
     assert pyhf.tensorlib.tolist(result)
 
-
-    result = optim.constrained_bestfit(pyhf.loglambdav, 1.0, data,pdf, init_pars, par_bounds)
+    result = optim.constrained_bestfit(pyhf.loglambdav, 1.0, data, pdf, init_pars, par_bounds)
     assert pyhf.tensorlib.tolist(result)
-    pyhf.tensorlib = oldlib
+
+    pyhf.set_backend(oldlib)
 
 
 def test_optim_pytorch():
-    import pyhf
     source = {
       "binning": [2,-0.5,1.5],
       "bindata": {
@@ -102,29 +105,27 @@ def test_optim_pytorch():
             }
         }
     }
-    pdf  = pyhf.hfpdf(spec)
+    pdf = pyhf.hfpdf(spec)
     data = source['bindata']['data'] + pdf.config.auxdata
 
-    init_pars  = pdf.config.suggested_init()
+    init_pars = pdf.config.suggested_init()
     par_bounds = pdf.config.suggested_bounds()
 
     oldlib = pyhf.tensorlib
 
-    pyhf.tensorlib = pyhf.pytorch_backend(poisson_from_normal = True)
-    optim = pytorch_optimizer(tensorlib = pyhf.tensorlib)
+    pyhf.set_backend(pyhf.pytorch_backend(poisson_from_normal=True))
+    optim = pyhf.optimizer
 
-    result = optim.unconstrained_bestfit(pyhf.loglambdav,data,pdf, init_pars, par_bounds)
+    result = optim.unconstrained_bestfit(pyhf.loglambdav, data, pdf, init_pars, par_bounds)
     assert pyhf.tensorlib.tolist(result)
 
-    result = optim.constrained_bestfit(pyhf.loglambdav, 1.0, data,pdf, init_pars, par_bounds)
+    result = optim.constrained_bestfit(pyhf.loglambdav, 1.0, data, pdf, init_pars, par_bounds)
     assert pyhf.tensorlib.tolist(result)
 
-    pyhf.tensorlib = oldlib
+    pyhf.set_backend(oldlib)
 
 
 def test_optim_tflow():
-    import pyhf
-    import tensorflow as tf
     source = {
       "binning": [2,-0.5,1.5],
       "bindata": {
@@ -162,22 +163,22 @@ def test_optim_tflow():
             }
         }
     }
-    pdf  = pyhf.hfpdf(spec)
+    pdf = pyhf.hfpdf(spec)
     data = source['bindata']['data'] + pdf.config.auxdata
 
-    init_pars  = pdf.config.suggested_init()
+    init_pars = pdf.config.suggested_init()
     par_bounds = pdf.config.suggested_bounds()
 
     oldlib = pyhf.tensorlib
 
-    pyhf.tensorlib = pyhf.tensorflow_backend()
+    pyhf.set_backend(pyhf.tensorflow_backend())
     pyhf.tensorlib.session = tf.Session()
-    optim = tflow_optimizer(tensorlib = pyhf.tensorlib)
+    optim = pyhf.optimizer
 
-    result = optim.unconstrained_bestfit(pyhf.loglambdav,data,pdf, init_pars, par_bounds)
+    result = optim.unconstrained_bestfit(pyhf.loglambdav, data, pdf, init_pars, par_bounds)
     assert pyhf.tensorlib.tolist(result)
 
-    result = optim.constrained_bestfit(pyhf.loglambdav, 1.0, data,pdf, init_pars, par_bounds)
+    result = optim.constrained_bestfit(pyhf.loglambdav, 1.0, data, pdf, init_pars, par_bounds)
     assert pyhf.tensorlib.tolist(result)
 
-    pyhf.tensorlib = oldlib
+    pyhf.set_backend(oldlib)

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1,8 +1,12 @@
+import pyhf
+
 from pyhf.tensor.pytorch_backend import pytorch_backend
 from pyhf.tensor.numpy_backend import numpy_backend
 from pyhf.tensor.tensorflow_backend import tensorflow_backend
 from pyhf.tensor.mxnet_backend import mxnet_backend
 from pyhf.simplemodels import hepdata_like
+
+import numpy as np
 import tensorflow as tf
 
 
@@ -37,8 +41,6 @@ def test_common_tensor_backends():
 
 
 def test_pdf_eval():
-    import pyhf
-    import numpy as np
     oldlib = pyhf.tensorlib
 
     tf_sess = tf.Session()
@@ -49,7 +51,7 @@ def test_pdf_eval():
 
     values = []
     for b in backends:
-        pyhf.tensorlib = b
+        pyhf.set_backend(b)
 
         source = {
             "binning": [2, -0.5, 1.5],
@@ -83,12 +85,10 @@ def test_pdf_eval():
 
     assert np.std(values) < 1e-6
 
-    pyhf.tensorlib = oldlib
+    pyhf.set_backend(oldlib)
 
 
 def test_pdf_eval_2():
-    import pyhf
-    import numpy as np
     oldlib = pyhf.tensorlib
 
     tf_sess = tf.Session()
@@ -99,7 +99,7 @@ def test_pdf_eval_2():
 
     values = []
     for b in backends:
-        pyhf.tensorlib = b
+        pyhf.set_backend(b)
 
         source = {
             "binning": [2, -0.5, 1.5],
@@ -120,4 +120,4 @@ def test_pdf_eval_2():
 
     assert np.std(values) < 1e-6
 
-    pyhf.tensorlib = oldlib
+    pyhf.set_backend(oldlib)


### PR DESCRIPTION
`pyhf.set_backend()` detects the backend that is being set and then globally sets
the backend and the corresponding optimizer. This is necessary to avoid
errors in data types and would normally have to be done manually.

This solves Issue #99 and will be fully implemented for all optimizers once Issue #86 is finished.

# Checklist Before Requesting Approver

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
