### PR TITLE
Add starter json schema for spec

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ setup(
        'tensorflow',
        'mxnet>=1.0.0',
        'graphviz',
-       'sphinx'
+       'sphinx',
+       'jsonschema>=2.6.0'
     ]
   },
   entry_points = {

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -76,7 +76,7 @@ def test_core_pdf_broadcasting():
     assert np.all(naive_python  == broadcasted)
 
 def test_pdf_integration_histosys():
-    schema = json.load(file('validation/spec.json'))
+    schema = json.load(open('validation/spec.json'))
     source = json.load(open('validation/data/2bin_histosys_example2.json'))
     spec = {
         'singlechannel': {
@@ -122,7 +122,7 @@ def test_pdf_integration_histosys():
 
 
 def test_pdf_integration_normsys():
-    schema = json.load(file('validation/spec.json'))
+    schema = json.load(open('validation/spec.json'))
     source = json.load(open('validation/data/2bin_histosys_example2.json'))
     spec = {
         'singlechannel': {
@@ -154,7 +154,7 @@ def test_pdf_integration_normsys():
     assert pdf.expected_data(pars, include_auxdata = False).tolist()   == [100*0.9,150*0.9]
 
 def test_pdf_integration_shapesys():
-    schema = json.load(file('validation/spec.json'))
+    schema = json.load(open('validation/spec.json'))
     source = json.load(open('validation/data/2bin_histosys_example2.json'))
     spec = {
         'singlechannel': {

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -2,6 +2,7 @@ import pyhf
 import pyhf.simplemodels
 import numpy as np
 import json
+import jsonschema
 
 def test_interpcode_0():
     f = lambda x: pyhf._hfinterp_code0(at_minus_one = 0.5, at_zero =1, at_plus_one = 2.0, alphas = x)
@@ -75,6 +76,7 @@ def test_core_pdf_broadcasting():
     assert np.all(naive_python  == broadcasted)
 
 def test_pdf_integration_histosys():
+    schema = json.load(file('validation/spec.json'))
     source = json.load(open('validation/data/2bin_histosys_example2.json'))
     spec = {
         'singlechannel': {
@@ -93,6 +95,7 @@ def test_pdf_integration_histosys():
             }
         }
     }
+    jsonschema.validate(spec, schema)
     pdf  = pyhf.hfpdf(spec)
 
 
@@ -119,6 +122,7 @@ def test_pdf_integration_histosys():
 
 
 def test_pdf_integration_normsys():
+    schema = json.load(file('validation/spec.json'))
     source = json.load(open('validation/data/2bin_histosys_example2.json'))
     spec = {
         'singlechannel': {
@@ -136,6 +140,7 @@ def test_pdf_integration_normsys():
             }
         }
     }
+    jsonschema.validate(spec, schema)
     pdf  = pyhf.hfpdf(spec)
 
     pars = [None,None]
@@ -149,6 +154,7 @@ def test_pdf_integration_normsys():
     assert pdf.expected_data(pars, include_auxdata = False).tolist()   == [100*0.9,150*0.9]
 
 def test_pdf_integration_shapesys():
+    schema = json.load(file('validation/spec.json'))
     source = json.load(open('validation/data/2bin_histosys_example2.json'))
     spec = {
         'singlechannel': {
@@ -166,6 +172,7 @@ def test_pdf_integration_shapesys():
             }
         }
     }
+    jsonschema.validate(spec, schema)
     pdf  = pyhf.hfpdf(spec)
 
 

--- a/validation/spec.json
+++ b/validation/spec.json
@@ -1,0 +1,68 @@
+{
+	"$schema": "http://json-schema.org/draft-06/schema#",
+
+  "definitions": {
+    "channel": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z]+$": {
+          "$ref": "#/definitions/sample"
+        }
+      },
+      "additionalProperties": false
+    },
+    "sample": {
+      "type": "object",
+      "properties": {
+        "data": { "$ref": "#/definitions/data"},
+        "mods": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/modification"}
+        }
+      },
+      "required": ["data", "mods"],
+      "additionalProperties": false
+    },
+    "modification": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": ["shapesys","normfactor","histosys","normsys"]
+        },
+        "data": { "$ref": "#/definitions/data"}
+      },
+      "additionalProperties": false
+    },
+    "data": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {"type": "number"}
+        },
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "required": ["lo_hist", "hi_hist"]
+        },
+        {
+          "type": "object",
+          "required": ["lo", "hi"]
+        }
+      ]
+    }
+  },
+
+	"type": "object",
+	"patternProperties": {
+		"^[a-zA-Z]+$": {
+			"$ref": "#/definitions/channel"
+		}
+	},
+	"additionalProperties": false
+}


### PR DESCRIPTION
This PR adds a starter JSON schema that currently validates against all specs I could find in the pyhf code at the moment.

An interesting item was raised, during the writing of the spec, that the spec may need to be changed slightly in terms of modifications. Currently, modifications are defined like so:

```python
                'mods': [
                    {'name': 'mu', 'type': 'normfactor', 'data': None}
                ]   
```

however, this introduces the case where two modifications of different types might have the same name! This could easily be solved (where a JSON schema cannot validate such conflicts) by restructuring like so

```python
                'mods': {
                    'mu': {'type': 'normfactor', 'data': None}
                }   
```

which has the added benefit of making the structure a little bit more intuitive. Instead of modifications being literally a list of modification "objects" (the constraint, etc...), the modifications then becomes a list of Nuisance Parameter names (e.g. true, unknown `alpha` values), which gains some speed up from python's dict-lookups as well.