### PR TITLE
Remove Python 3.5 testing support and fix testing on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 language: python
 python:
   - '2.7'
-  - '3.5'
   - '3.6'
 # only test 'push' builds to master (including PRs that target master)
 branches:
@@ -31,11 +30,11 @@ after_success: coveralls
 stages:
   - test
   - name: benchmark
-    if: (branch = master) AND (NOT (type IN (push, pull_request)))
+    if: (branch = master) AND (NOT (type IN (pull_request)))
   - name: docs
-    if: (branch = master) AND (NOT (type IN (push, pull_request)))
+    if: (branch = master) AND (NOT (type IN (pull_request)))
   - name: deploy
-    if: (branch = master) AND (NOT (type IN (push, pull_request)))
+    if: (branch = master) AND (NOT (type IN (pull_request)))
 
 env:
   global:


### PR DESCRIPTION
Remove Python 3.5 testing and only support Python 2.7 and Python 3.6.

The CI should run tests, benchmarking, docs, deploy when merged into
master, but doesn't. This should fix that.

# Checklist Before Requesting Approver

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
