### PR TITLE
Run CI on Travis CI 'push' type builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: python
 python:
   - '2.7'
   - '3.6'
-# only test 'push' builds to master (including PRs that target master)
-branches:
-  only: master
 install:
   - sudo apt-get update
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
@@ -25,8 +22,8 @@ script:
   - pytest --ignore tests/benchmarks/
 after_success: coveralls
 
-# always test
-# benchmark, build docs, deploy to PyPI only when merged into master
+# always test (on both 'push' and 'pr' builds in Travis)
+# benchmark, build docs, deploy to PyPI only when merged into master (those mereges are 'push' builds)
 stages:
   - test
   - name: benchmark


### PR DESCRIPTION
The 'push' builds were originally removed, but they are added back in
for the following reason (kindly provided by Lukas):
If you work on a feature you can very well have a self-consistent
branch that you are developing on. However, if the master has
been further developed the 'pr' type builds will fail until you rebase.
If you want to check if your feature branch is self-consistent then you
need only care about the 'push' build results, and then if the 'pr'
build tests fail you need only rebase once at the very end rather then
continually.

# Checklist Before Requesting Approver

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
