### PR TITLE
Use pytest fixtures in tests

### DIFF
--- a/pyhf/__init__.py
+++ b/pyhf/__init__.py
@@ -40,7 +40,9 @@ def set_backend(backend):
         None
 
     Example:
-        pyhf.set_backend(pyhf.tensor.tensorflow_backend(session=tf.Session()))
+        import pyhf.tensor as tensor
+        import tensorflow as tf
+        pyhf.set_backend(tensor.tensorflow_backend(session=tf.Session()))
     """
     global tensorlib
     global optimizer

--- a/pyhf/__init__.py
+++ b/pyhf/__init__.py
@@ -24,8 +24,9 @@ def get_backend():
     return tensorlib, optimizer
 
 # modifiers need access to tensorlib
-#   make sure import is below get_backend()
+# make sure import is below get_backend()
 from . import modifiers
+
 
 def set_backend(backend):
     """
@@ -39,7 +40,7 @@ def set_backend(backend):
         None
 
     Example:
-        pyhf.set_backend(tensorflow_backend(session=tf.Session()))
+        pyhf.set_backend(pyhf.tensor.tensorflow_backend(session=tf.Session()))
     """
     global tensorlib
     global optimizer
@@ -47,10 +48,10 @@ def set_backend(backend):
     tensorlib = backend
     if isinstance(tensorlib, tensor.tensorflow_backend):
         optimizer = optimize.tflow_optimizer(tensorlib)
-    elif isinstance(tensorlib,tensor.pytorch_backend):
+    elif isinstance(tensorlib, tensor.pytorch_backend):
         optimizer = optimize.pytorch_optimizer(tensorlib=tensorlib)
     # TODO: Add support for mxnet_optimizer()
-    # elif isinstance(tensorlib, mxnet_backend):
+    # elif isinstance(tensorlib, tensor.mxnet_backend):
     #     optimizer = mxnet_optimizer()
     else:
         optimizer = optimize.scipy_optimizer()

--- a/tests/benchmarks/test_benchmark.py
+++ b/tests/benchmarks/test_benchmark.py
@@ -85,7 +85,7 @@ bin_ids = ['{}_bins'.format(n_bins) for n_bins in bins]
                              pyhf.tensor.numpy_backend(poisson_from_normal=True),
                              pyhf.tensor.tensorflow_backend(session=tf.Session()),
                              pyhf.tensor.pytorch_backend(),
-                             # mxnet_backend(),
+                             # pyhf.tensor.mxnet_backend(),
                          ],
                          ids=[
                              'numpy',
@@ -113,10 +113,4 @@ def test_runOnePoint(benchmark, backend, n_bins):
                        source['bindata']['bkg'],
                        source['bindata']['bkgerr'])
     data = source['bindata']['data'] + pdf.config.auxdata
-    try:
-        assert benchmark(runOnePoint, pdf, data) is not None
-    except AssertionError:
-        print('benchmarking has failed for n_bins = {}'.formant(n_bins))
-        assert False
-
-    # Reset backend
+    assert benchmark(runOnePoint, pdf, data)

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -4,7 +4,7 @@ import pytest
 
 
 @pytest.fixture
-def source():
+def source(scope='module'):
     source = {
         'binning': [2, -0.5, 1.5],
         'bindata': {
@@ -19,30 +19,36 @@ def source():
 
 
 @pytest.fixture
-def spec(source):
+def spec(source, scope='module'):
     spec = {
-        'channels': [{
-            'name': 'singlechannel',
-            'samples': [{
+        'channels': [
+            {
+                'name': 'singlechannel',
+                'samples': [
+                    {
                         'name': 'signal',
                         'data': source['bindata']['sig'],
-                        'modifiers': [{
+                        'modifiers': [
+                            {
                                 'name': 'mu',
                                 'type': 'normfactor',
                                 'data': None
-                        }]},
-                        {
+                            }]
+                    },
+                    {
                         'name': 'background',
                         'data': source['bindata']['bkg'],
-                        'modifiers': [{
+                        'modifiers': [
+                            {
                                 'name': 'bkg_norm',
                                 'type': 'histosys',
                                 'data': {
                                     'lo_data': source['bindata']['bkgsys_dn'],
                                     'hi_data': source['bindata']['bkgsys_up']
                                 }
-                        }]}]
-        }]
+                            }]
+                    }]
+            }]
     }
     return spec
 

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -70,6 +70,9 @@ def test_optim(source, spec, backend):
     pyhf.set_backend(pyhf.tensor.tensorflow_backend())
     pyhf.tensorlib.session = tf.Session()
     optim = pyhf.optimizer
+    if isinstance(pyhf.tensorlib, tensorflow_backend):
+        tf.reset_default_graph()
+        pyhf.tensorlib.session = tf.Session()
 
     result = optim.unconstrained_bestfit(
         pyhf.loglambdav, data, pdf, init_pars, par_bounds)

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -57,6 +57,13 @@ def spec(source):
     return spec
 
 
+@pytest.mark.parametrize('mu',
+                         [
+                             1.,
+                         ],
+                         ids=[
+                             'mu=1',
+                         ])
 @pytest.mark.parametrize('backend',
                          [
                              pyhf.tensor.numpy_backend(poisson_from_normal=True),
@@ -70,7 +77,7 @@ def spec(source):
                              'pytorch',
                              # 'mxnet',
                          ])
-def test_optim(source, spec, backend):
+def test_optim(source, spec, mu, backend):
     pdf = pyhf.hfpdf(spec)
     data = source['bindata']['data'] + pdf.config.auxdata
 
@@ -88,5 +95,5 @@ def test_optim(source, spec, backend):
     assert pyhf.tensorlib.tolist(result)
 
     result = optim.constrained_bestfit(
-        pyhf.loglambdav, 1.0, data, pdf, init_pars, par_bounds)
+        pyhf.loglambdav, mu, data, pdf, init_pars, par_bounds)
     assert pyhf.tensorlib.tolist(result)

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -33,7 +33,8 @@ def spec(source, scope='module'):
                                 'name': 'mu',
                                 'type': 'normfactor',
                                 'data': None
-                            }]
+                            }
+                        ]
                     },
                     {
                         'name': 'background',
@@ -46,9 +47,12 @@ def spec(source, scope='module'):
                                     'lo_data': source['bindata']['bkgsys_dn'],
                                     'hi_data': source['bindata']['bkgsys_up']
                                 }
-                            }]
-                    }]
-            }]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
     }
     return spec
 

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -1,142 +1,66 @@
 import pyhf
 import tensorflow as tf
+import pytest
 
 
-def test_optim_numpy():
+@pytest.fixture
+def source():
     source = {
-      "binning": [2,-0.5,1.5],
-      "bindata": {
-        "data":    [120.0, 180.0],
-        "bkg":     [100.0, 150.0],
-        "bkgsys_up":  [102, 190],
-        "bkgsys_dn":  [98, 100],
-        "sig":     [30.0, 95.0]
-      }
+        'binning': [2, -0.5, 1.5],
+        'bindata': {
+            'data': [120.0, 180.0],
+            'bkg': [100.0, 150.0],
+            'bkgsys_up': [102, 190],
+            'bkgsys_dn': [98, 100],
+            'sig': [30.0, 95.0]
+        }
     }
+    return source
+
+
+@pytest.fixture
+def spec(source):
     spec = {
-        'channels': [
-            {
-                'name': 'singlechannel',
-                'samples': [
-                    {
+        'channels': [{
+            'name': 'singlechannel',
+            'samples': [{
                         'name': 'signal',
                         'data': source['bindata']['sig'],
-                        'modifiers': [
-                            {'name': 'mu', 'type': 'normfactor', 'data': None}
-                        ]
-                    },
-                    {
+                        'modifiers': [{
+                                'name': 'mu',
+                                'type': 'normfactor',
+                                'data': None
+                        }]},
+                        {
                         'name': 'background',
                         'data': source['bindata']['bkg'],
-                        'modifiers': [
-                            {'name': 'bkg_norm', 'type': 'histosys', 'data': {'lo_data': source['bindata']['bkgsys_dn'], 'hi_data': source['bindata']['bkgsys_up']}}
-                        ]
-                    }
-                ]
-            }
-        ]
+                        'modifiers': [{
+                                'name': 'bkg_norm',
+                                'type': 'histosys',
+                                'data': {
+                                    'lo_data': source['bindata']['bkgsys_dn'],
+                                    'hi_data': source['bindata']['bkgsys_up']
+                                }
+                        }]}]
+        }]
     }
-    pdf = pyhf.hfpdf(spec)
-    data = source['bindata']['data'] + pdf.config.auxdata
-
-    init_pars = pdf.config.suggested_init()
-    par_bounds = pdf.config.suggested_bounds()
-
-    pyhf.set_backend(pyhf.tensor.numpy_backend(poisson_from_normal=True))
-    optim = pyhf.optimizer
-
-    v1 = pdf.logpdf(init_pars, data)
-    result = optim.unconstrained_bestfit(pyhf.loglambdav, data, pdf, init_pars, par_bounds)
-    assert pyhf.tensorlib.tolist(result)
-
-    result = optim.constrained_bestfit(pyhf.loglambdav, 1.0, data, pdf, init_pars, par_bounds)
-    assert pyhf.tensorlib.tolist(result)
+    return spec
 
 
-def test_optim_pytorch():
-    source = {
-      "binning": [2,-0.5,1.5],
-      "bindata": {
-        "data":    [120.0, 180.0],
-        "bkg":     [100.0, 150.0],
-        "bkgsys_up":  [102, 190],
-        "bkgsys_dn":  [98, 100],
-        "sig":     [30.0, 95.0]
-      }
-    }
-    spec = {
-        'channels': [
-            {
-                'name': 'singlechannel',
-                'samples': [
-                    {
-                        'name': 'signal',
-                        'data': source['bindata']['sig'],
-                        'modifiers': [
-                            {'name': 'mu', 'type': 'normfactor', 'data': None}
-                        ]
-                    },
-                    {
-                        'name': 'background',
-                        'data': source['bindata']['bkg'],
-                        'modifiers': [
-                            {'name': 'bkg_norm', 'type': 'histosys', 'data': {'lo_data': source['bindata']['bkgsys_dn'], 'hi_data': source['bindata']['bkgsys_up']}}
-                        ]
-                    }
-                ]
-            }
-        ]
-    }
-    pdf = pyhf.hfpdf(spec)
-    data = source['bindata']['data'] + pdf.config.auxdata
-
-    init_pars = pdf.config.suggested_init()
-    par_bounds = pdf.config.suggested_bounds()
-
-    pyhf.set_backend(pyhf.tensor.pytorch_backend(poisson_from_normal=True))
-    optim = pyhf.optimizer
-
-    result = optim.unconstrained_bestfit(pyhf.loglambdav, data, pdf, init_pars, par_bounds)
-    assert pyhf.tensorlib.tolist(result)
-
-    result = optim.constrained_bestfit(pyhf.loglambdav, 1.0, data, pdf, init_pars, par_bounds)
-    assert pyhf.tensorlib.tolist(result)
-
-
-def test_optim_tflow():
-    source = {
-      "binning": [2,-0.5,1.5],
-      "bindata": {
-        "data":    [120.0, 180.0],
-        "bkg":     [100.0, 150.0],
-        "bkgsys_up":  [102, 190],
-        "bkgsys_dn":  [98, 100],
-        "sig":     [30.0, 95.0]
-      }
-    }
-    spec = {
-        'channels': [
-            {
-                'name': 'singlechannel',
-                'samples': [
-                    {
-                        'name': 'signal',
-                        'data': source['bindata']['sig'],
-                        'modifiers': [
-                            {'name': 'mu', 'type': 'normfactor', 'data': None}
-                        ]
-                    },
-                    {
-                        'name': 'background',
-                        'data': source['bindata']['bkg'],
-                        'modifiers': [
-                            {'name': 'bkg_norm', 'type': 'histosys', 'data': {'lo_data': source['bindata']['bkgsys_dn'], 'hi_data': source['bindata']['bkgsys_up']}}
-                        ]
-                    }
-                ]
-            }
-        ]
-    }
+@pytest.mark.parametrize('backend',
+                         [
+                             numpy_backend(poisson_from_normal=True),
+                             tensorflow_backend(session=tf.Session()),
+                             pytorch_backend(poisson_from_normal=True),
+                             # mxnet_backend(),
+                         ],
+                         ids=[
+                             'numpy',
+                             'tensorflow',
+                             'pytorch',
+                             # 'mxnet',
+                         ])
+def test_optim(source, spec, backend):
     pdf = pyhf.hfpdf(spec)
     data = source['bindata']['data'] + pdf.config.auxdata
 
@@ -147,8 +71,20 @@ def test_optim_tflow():
     pyhf.tensorlib.session = tf.Session()
     optim = pyhf.optimizer
 
-    result = optim.unconstrained_bestfit(pyhf.loglambdav, data, pdf, init_pars, par_bounds)
-    assert pyhf.tensorlib.tolist(result)
+    result = optim.unconstrained_bestfit(
+        pyhf.loglambdav, data, pdf, init_pars, par_bounds)
+    try:
+        assert pyhf.tensorlib.tolist(result)
+    except AssertionError:
+        print('unconstrained_bestfit failed')
+        pyhf.set_backend(oldlib)
+        assert False
 
-    result = optim.constrained_bestfit(pyhf.loglambdav, 1.0, data, pdf, init_pars, par_bounds)
-    assert pyhf.tensorlib.tolist(result)
+    result = optim.constrained_bestfit(
+        pyhf.loglambdav, 1.0, data, pdf, init_pars, par_bounds)
+    try:
+        assert pyhf.tensorlib.tolist(result)
+    except AssertionError:
+        print('constrained_bestfit failed')
+        pyhf.set_backend(oldlib)
+        assert False

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -5,13 +5,13 @@ import json
 import pytest
 
 
-@pytest.fixture
-def source_1bin_example1(scope='module'):
+@pytest.fixture(scope='module')
+def source_1bin_example1():
     return json.load(open('validation/data/1bin_example1.json'))
 
 
-@pytest.fixture
-def source_1bin_normsys(scope='module'):
+@pytest.fixture(scope='module')
+def source_1bin_normsys():
     source = {
         'binning': [2, -0.5, 1.5],
         'bindata': {
@@ -23,8 +23,8 @@ def source_1bin_normsys(scope='module'):
     return source
 
 
-@pytest.fixture
-def spec_1bin_normsys(source=source_1bin_normsys(), scope='module'):
+@pytest.fixture(scope='module')
+def spec_1bin_normsys(source=source_1bin_normsys()):
     spec = {
         'channels': [
             {
@@ -59,8 +59,8 @@ def spec_1bin_normsys(source=source_1bin_normsys(), scope='module'):
     return spec
 
 
-@pytest.fixture
-def expected_result_1bin_normsys(mu=1., scope='module'):
+@pytest.fixture(scope='module')
+def expected_result_1bin_normsys(mu=1.):
     if mu == 1:
         expected_result = {
             'obs': 0.0007930094233140433,
@@ -75,13 +75,13 @@ def expected_result_1bin_normsys(mu=1., scope='module'):
     return expected_result
 
 
-@pytest.fixture
-def source_2bin_histosys_example2(scope='module'):
+@pytest.fixture(scope='module')
+def source_2bin_histosys_example2():
     return json.load(open('validation/data/2bin_histosys_example2.json'))
 
 
-@pytest.fixture
-def spec_2bin_histosys(source=source_2bin_histosys_example2(), scope='module'):
+@pytest.fixture(scope='module')
+def spec_2bin_histosys(source=source_2bin_histosys_example2()):
     spec = {
         'channels': [
             {
@@ -119,8 +119,8 @@ def spec_2bin_histosys(source=source_2bin_histosys_example2(), scope='module'):
     return spec
 
 
-@pytest.fixture
-def expected_result_2bin_histosys(mu=1, scope='module'):
+@pytest.fixture(scope='module')
+def expected_result_2bin_histosys(mu=1):
     if mu == 1:
         expected_result = {
             'obs': 0.10014623469489856,
@@ -135,13 +135,13 @@ def expected_result_2bin_histosys(mu=1, scope='module'):
     return expected_result
 
 
-@pytest.fixture
-def source_2bin_2channel_example1(scope='module'):
+@pytest.fixture(scope='module')
+def source_2bin_2channel_example1():
     return json.load(open('validation/data/2bin_2channel_example1.json'))
 
 
-@pytest.fixture
-def spec_2bin_2channel(source=source_2bin_2channel_example1(), scope='module'):
+@pytest.fixture(scope='module')
+def spec_2bin_2channel(source=source_2bin_2channel_example1()):
     spec = {
         'channels': [
             {
@@ -192,8 +192,8 @@ def spec_2bin_2channel(source=source_2bin_2channel_example1(), scope='module'):
     return spec
 
 
-@pytest.fixture
-def expected_result_2bin_2channel(mu=1., scope='module'):
+@pytest.fixture(scope='module')
+def expected_result_2bin_2channel(mu=1.):
     if mu == 1:
         expected_result = {
             'obs': 0.05691881515460979,
@@ -208,13 +208,13 @@ def expected_result_2bin_2channel(mu=1., scope='module'):
     return expected_result
 
 
-@pytest.fixture
-def source_2bin_2channel_couplednorm(scope='module'):
+@pytest.fixture(scope='module')
+def source_2bin_2channel_couplednorm():
     return json.load(open('validation/data/2bin_2channel_couplednorm.json'))
 
 
-@pytest.fixture
-def spec_2bin_2channel_couplednorm(source_2bin_2channel_couplednorm, scope='module'):
+@pytest.fixture(scope='module')
+def spec_2bin_2channel_couplednorm(source_2bin_2channel_couplednorm):
     source = source_2bin_2channel_couplednorm
     spec = {
         'channels': [
@@ -277,13 +277,13 @@ def spec_2bin_2channel_couplednorm(source_2bin_2channel_couplednorm, scope='modu
     return spec
 
 
-@pytest.fixture
-def source_2bin_2channel_coupledhisto(scope='module'):
+@pytest.fixture(scope='module')
+def source_2bin_2channel_coupledhisto():
     return json.load(open('validation/data/2bin_2channel_coupledhisto.json'))
 
 
-@pytest.fixture
-def spec_2bin_2channel_coupledhistosys(source_2bin_2channel_coupledhisto, scope='module'):
+@pytest.fixture(scope='module')
+def spec_2bin_2channel_coupledhistosys(source_2bin_2channel_coupledhisto):
     source = source_2bin_2channel_coupledhisto
     spec = {
         'channels': [
@@ -355,13 +355,13 @@ def spec_2bin_2channel_coupledhistosys(source_2bin_2channel_coupledhisto, scope=
     return spec
 
 
-@pytest.fixture
-def source_2bin_2channel_coupledshapefactor(scope='module'):
+@pytest.fixture(scope='module')
+def source_2bin_2channel_coupledshapefactor():
     return json.load(open('validation/data/2bin_2channel_coupledshapefactor.json'))
 
 
-@pytest.fixture
-def spec_2bin_2channel_coupledshapefactor(source_2bin_2channel_coupledshapefactor, scope='module'):
+@pytest.fixture(scope='module')
+def spec_2bin_2channel_coupledshapefactor(source_2bin_2channel_coupledshapefactor):
     source = source_2bin_2channel_coupledshapefactor
     spec = {
         'channels': [
@@ -540,8 +540,8 @@ def test_validation(source, spec, mu, expected_result, config_len):
 #     validate_runOnePoint(pdf, data, mu, expected_result)
 
 
-def test_validation_2bin_2channel_couplednorm(source_2bin_2channel_couplednorm,
-                                              spec_2bin_2channel_couplednorm):
+def test_validation_2bin_2channel_couplednorm(source_2bin_2channel_couplednorm(),
+                                              spec_2bin_2channel_couplednorm(source_2bin_2channel_couplednorm)):
     expected_result = {
         'obs': 0.5999662863185762,
         'exp': [

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -2,13 +2,9 @@ import pyhf
 import pyhf.simplemodels
 
 import json
-import pytest
-
-VALIDATION_TOLERANCE = 1e-5
 
 
-@pytest.fixture
-def validate_runOnePoint(pdf, data, mu_test, expected_result, scope='function'):
+def validate_runOnePoint(pdf, data, mu_test, expected_result, tolerance=1e-5):
     init_pars = pdf.config.suggested_init()
     par_bounds = pdf.config.suggested_bounds()
 
@@ -17,10 +13,10 @@ def validate_runOnePoint(pdf, data, mu_test, expected_result, scope='function'):
     CLs_obs = 1. / CLs_obs
     CLs_exp = [1. / x for x in CLs_exp]
     assert (CLs_obs - expected_result['obs']) / \
-        expected_result['obs'] < VALIDATION_TOLERANCE
+        expected_result['obs'] < tolerance
     for result, expected_result in zip(CLs_exp, expected_result['exp']):
         assert (result - expected_result) / \
-            expected_result < VALIDATION_TOLERANCE
+            expected_result < tolerance
 
 
 def test_validation_1bin_shapesys():
@@ -130,7 +126,8 @@ def test_validation_2bin_histosys():
                             {
                                 'name': 'mu',
                                 'type': 'normfactor',
-                                'data': None}
+                                'data': None
+                            }
                         ]
                     },
                     {
@@ -234,12 +231,13 @@ def test_validation_2bin_2channel():
 def test_validation_2bin_2channel_couplednorm():
     expected_result = {
         'obs': 0.5999662863185762,
-        'exp': [0.06596134134354742,
-                0.15477912571478988,
-                0.33323967895587736,
-                0.6096429330789306,
-                0.8688213053042003
-                ]
+        'exp': [
+            0.06596134134354742,
+            0.15477912571478988,
+            0.33323967895587736,
+            0.6096429330789306,
+            0.8688213053042003
+        ]
     }
     source = json.load(open('validation/data/2bin_2channel_couplednorm.json'))
     spec = {
@@ -431,7 +429,8 @@ def test_validation_2bin_2channel_coupledshapefactor():
                             {
                                 'name': 'mu',
                                 'type': 'normfactor',
-                                'data': None}
+                                'data': None
+                            }
                         ]
                     },
                     {

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -2,58 +2,16 @@ import pyhf
 import pyhf.simplemodels
 
 import json
+import pytest
 
 
-def validate_runOnePoint(pdf, data, mu_test, expected_result, tolerance=1e-5):
-    init_pars = pdf.config.suggested_init()
-    par_bounds = pdf.config.suggested_bounds()
-
-    CLs_obs, CLs_exp = pyhf.runOnePoint(
-        mu_test, data, pdf, init_pars, par_bounds)[-2:]
-    CLs_obs = 1. / CLs_obs
-    CLs_exp = [1. / x for x in CLs_exp]
-    assert (CLs_obs - expected_result['obs']) / \
-        expected_result['obs'] < tolerance
-    for result, expected_result in zip(CLs_exp, expected_result['exp']):
-        assert (result - expected_result) / \
-            expected_result < tolerance
+@pytest.fixture
+def source_1bin_example1(scope='module'):
+    return json.load(open('validation/data/1bin_example1.json'))
 
 
-def test_validation_1bin_shapesys():
-    expected_result = {
-        'obs': 0.4541865416107029,
-        'exp': [
-            0.06371799398864626,
-            0.15096503398048894,
-            0.3279606950533305,
-            0.6046087303039118,
-            0.8662627605298466
-        ]
-    }
-
-    source = json.load(open('validation/data/1bin_example1.json'))
-    pdf = pyhf.simplemodels.hepdata_like(source['bindata']['sig'],
-                                         source['bindata']['bkg'],
-                                         source['bindata']['bkgerr'])
-
-    data = source['bindata']['data'] + pdf.config.auxdata
-
-    assert len(pdf.config.suggested_init()) == 2
-    assert len(pdf.config.suggested_bounds()) == 2
-    validate_runOnePoint(pdf, data, 1.0, expected_result)
-
-
-def test_validation_1bin_normsys():
-    expected_result = {
-        'obs': 0.0007930094233140433,
-        'exp': [
-            1.2529050370718884e-09,
-            8.932001833559302e-08,
-            5.3294967286010575e-06,
-            0.00022773982308763686,
-            0.0054897420571466075
-        ]
-    }
+@pytest.fixture
+def source_1bin_normsys(scope='module'):
     source = {
         'binning': [2, -0.5, 1.5],
         'bindata': {
@@ -62,6 +20,12 @@ def test_validation_1bin_normsys():
             'sig': [30.0, 95.0]
         }
     }
+    return source
+
+
+@pytest.fixture
+def spec_1bin_normsys(source_1bin_normsys, scope='module'):
+    source = source_1bin_normsys
     spec = {
         'channels': [
             {
@@ -93,27 +57,17 @@ def test_validation_1bin_normsys():
             }
         ]
     }
-    pdf = pyhf.hfpdf(spec)
-
-    data = source['bindata']['data'] + pdf.config.auxdata
-
-    assert len(pdf.config.suggested_init()) == 2
-    assert len(pdf.config.suggested_bounds()) == 2
-    validate_runOnePoint(pdf, data, 1.0, expected_result)
+    return spec
 
 
-def test_validation_2bin_histosys():
-    expected_result = {
-        'obs': 0.10014623469489856,
-        'exp': [
-            8.131143652258812e-06,
-            0.0001396307700293439,
-            0.0020437905684851376,
-            0.022094931468776054,
-            0.14246926685789288,
-        ]
-    }
-    source = json.load(open('validation/data/2bin_histosys_example2.json'))
+@pytest.fixture
+def source_2bin_histosys_example2(scope='module'):
+    return json.load(open('validation/data/2bin_histosys_example2.json'))
+
+
+@pytest.fixture
+def spec_2bin_histosys(source_2bin_histosys_example2, scope='module'):
+    source = source_2bin_histosys_example2
     spec = {
         'channels': [
             {
@@ -148,27 +102,17 @@ def test_validation_2bin_histosys():
             }
         ]
     }
-    pdf = pyhf.hfpdf(spec)
-
-    data = source['bindata']['data'] + pdf.config.auxdata
-
-    assert len(pdf.config.suggested_init()) == 2
-    assert len(pdf.config.suggested_bounds()) == 2
-    validate_runOnePoint(pdf, data, 1.0, expected_result)
+    return spec
 
 
-def test_validation_2bin_2channel():
-    expected_result = {
-        'obs': 0.05691881515460979,
-        'exp': [
-            0.0004448774256747925,
-            0.0034839534635069816,
-            0.023684793938725246,
-            0.12294326553585197,
-            0.4058143629613449
-        ]
-    }
-    source = json.load(open('validation/data/2bin_2channel_example1.json'))
+@pytest.fixture
+def source_2bin_2channel_example1(scope='module'):
+    return json.load(open('validation/data/2bin_2channel_example1.json'))
+
+
+@pytest.fixture
+def spec_2bin_2channel(source_2bin_2channel_example1, scope='module'):
+    source = source_2bin_2channel_example1
     spec = {
         'channels': [
             {
@@ -216,30 +160,17 @@ def test_validation_2bin_2channel():
             }
         ]
     }
-    pdf = pyhf.hfpdf(spec)
-    data = []
-    for c in pdf.spec['channels']:
-        data += source['channels'][c['name']]['bindata']['data']
-    data = data + pdf.config.auxdata
-
-    # 1 mu + 2 gammas for 2 channels each
-    assert len(pdf.config.suggested_init()) == 5
-    assert len(pdf.config.suggested_bounds()) == 5
-    validate_runOnePoint(pdf, data, 1.0, expected_result)
+    return spec
 
 
-def test_validation_2bin_2channel_couplednorm():
-    expected_result = {
-        'obs': 0.5999662863185762,
-        'exp': [
-            0.06596134134354742,
-            0.15477912571478988,
-            0.33323967895587736,
-            0.6096429330789306,
-            0.8688213053042003
-        ]
-    }
-    source = json.load(open('validation/data/2bin_2channel_couplednorm.json'))
+@pytest.fixture
+def source_2bin_2channel_couplednorm(scope='module'):
+    return json.load(open('validation/data/2bin_2channel_couplednorm.json'))
+
+
+@pytest.fixture
+def spec_2bin_2channel_couplednorm(source_2bin_2channel_couplednorm, scope='module'):
+    source = source_2bin_2channel_couplednorm
     spec = {
         'channels': [
             {
@@ -298,29 +229,17 @@ def test_validation_2bin_2channel_couplednorm():
             }
         ]
     }
-    pdf = pyhf.hfpdf(spec)
-    data = []
-    for c in pdf.spec['channels']:
-        data += source['channels'][c['name']]['bindata']['data']
-    data = data + pdf.config.auxdata
-
-    assert len(pdf.config.suggested_init()) == 2  # 1 mu + 1 alpha
-    assert len(pdf.config.suggested_bounds()) == 2  # 1 mu + 1 alpha
-    validate_runOnePoint(pdf, data, 1.0, expected_result)
+    return spec
 
 
-def test_validation_2bin_2channel_coupledhistosys():
-    expected_result = {
-        'obs': 0.0796739833305826,
-        'exp': [
-            1.765372502072074e-05,
-            0.00026265618793683054,
-            0.003340033567379219,
-            0.03152233566143051,
-            0.17907736639946248
-        ]
-    }
-    source = json.load(open('validation/data/2bin_2channel_coupledhisto.json'))
+@pytest.fixture
+def source_2bin_2channel_coupledhisto(scope='module'):
+    return json.load(open('validation/data/2bin_2channel_coupledhisto.json'))
+
+
+@pytest.fixture
+def spec_2bin_2channel_coupledhistosys(source_2bin_2channel_coupledhisto, scope='module'):
+    source = source_2bin_2channel_coupledhisto
     spec = {
         'channels': [
             {
@@ -388,35 +307,17 @@ def test_validation_2bin_2channel_coupledhistosys():
             }
         ]
     }
-    pdf = pyhf.hfpdf(spec)
-    data = []
-    for c in pdf.spec['channels']:
-        data += source['channels'][c['name']]['bindata']['data']
-    data = data + pdf.config.auxdata
-
-    init_pars = pdf.config.suggested_init()
-    par_bounds = pdf.config.suggested_bounds()
-
-    assert len(pdf.config.auxdata) == 1
-    assert len(init_pars) == 2  # 1 mu 1 shared histosys
-    assert len(par_bounds) == 2
-
-    validate_runOnePoint(pdf, data, 1.0, expected_result)
+    return spec
 
 
-def test_validation_2bin_2channel_coupledshapefactor():
-    expected_result = {
-        'obs': 0.5421679124909312,
-        'exp': [
-            0.013753299929451691,
-            0.048887400056355966,
-            0.15555296253957684,
-            0.4007561343326305,
-            0.7357169630955912
-        ]
-    }
-    source = json.load(
-        open('validation/data/2bin_2channel_coupledshapefactor.json'))
+@pytest.fixture
+def source_2bin_2channel_coupledshapefactor(scope='module'):
+    return json.load(open('validation/data/2bin_2channel_coupledshapefactor.json'))
+
+
+@pytest.fixture
+def spec_2bin_2channel_coupledshapefactor(source_2bin_2channel_coupledshapefactor, scope='module'):
+    source = source_2bin_2channel_coupledshapefactor
     spec = {
         'channels': [
             {
@@ -464,6 +365,200 @@ def test_validation_2bin_2channel_coupledshapefactor():
             }
         ]
     }
+    return spec
+
+
+def validate_runOnePoint(pdf, data, mu_test, expected_result, tolerance=1e-5):
+    init_pars = pdf.config.suggested_init()
+    par_bounds = pdf.config.suggested_bounds()
+
+    CLs_obs, CLs_exp = pyhf.runOnePoint(
+        mu_test, data, pdf, init_pars, par_bounds)[-2:]
+    CLs_obs = 1. / CLs_obs
+    CLs_exp = [1. / x for x in CLs_exp]
+    assert (CLs_obs - expected_result['obs']) / \
+        expected_result['obs'] < tolerance
+    for result, expected_result in zip(CLs_exp, expected_result['exp']):
+        assert (result - expected_result) / \
+            expected_result < tolerance
+
+
+def test_validation_1bin_shapesys(source_1bin_example1):
+    expected_result = {
+        'obs': 0.4541865416107029,
+        'exp': [
+            0.06371799398864626,
+            0.15096503398048894,
+            0.3279606950533305,
+            0.6046087303039118,
+            0.8662627605298466
+        ]
+    }
+
+    source = source_1bin_example1
+    pdf = pyhf.simplemodels.hepdata_like(source['bindata']['sig'],
+                                         source['bindata']['bkg'],
+                                         source['bindata']['bkgerr'])
+
+    data = source['bindata']['data'] + pdf.config.auxdata
+
+    assert len(pdf.config.suggested_init()) == 2
+    assert len(pdf.config.suggested_bounds()) == 2
+    validate_runOnePoint(pdf, data, 1.0, expected_result)
+
+
+def test_validation_1bin_normsys(source_1bin_normsys, spec_1bin_normsys):
+    expected_result = {
+        'obs': 0.0007930094233140433,
+        'exp': [
+            1.2529050370718884e-09,
+            8.932001833559302e-08,
+            5.3294967286010575e-06,
+            0.00022773982308763686,
+            0.0054897420571466075
+        ]
+    }
+
+    source = source_1bin_normsys
+    spec = spec_1bin_normsys
+
+    pdf = pyhf.hfpdf(spec)
+    data = source['bindata']['data'] + pdf.config.auxdata
+
+    assert len(pdf.config.suggested_init()) == 2
+    assert len(pdf.config.suggested_bounds()) == 2
+
+    validate_runOnePoint(pdf, data, 1.0, expected_result)
+
+
+def test_validation_2bin_histosys(source_2bin_histosys_example2, spec_2bin_histosys):
+    expected_result = {
+        'obs': 0.10014623469489856,
+        'exp': [
+            8.131143652258812e-06,
+            0.0001396307700293439,
+            0.0020437905684851376,
+            0.022094931468776054,
+            0.14246926685789288,
+        ]
+    }
+
+    source = source_2bin_histosys_example2
+    spec = spec_2bin_histosys
+
+    pdf = pyhf.hfpdf(spec)
+    data = source['bindata']['data'] + pdf.config.auxdata
+
+    assert len(pdf.config.suggested_init()) == 2
+    assert len(pdf.config.suggested_bounds()) == 2
+
+    validate_runOnePoint(pdf, data, 1.0, expected_result)
+
+
+def test_validation_2bin_2channel(source_2bin_2channel_example1, spec_2bin_2channel):
+    expected_result = {
+        'obs': 0.05691881515460979,
+        'exp': [
+            0.0004448774256747925,
+            0.0034839534635069816,
+            0.023684793938725246,
+            0.12294326553585197,
+            0.4058143629613449
+        ]
+    }
+
+    source = source_2bin_2channel_example1
+    spec = spec_2bin_2channel
+
+    pdf = pyhf.hfpdf(spec)
+    data = []
+    for c in pdf.spec['channels']:
+        data += source['channels'][c['name']]['bindata']['data']
+    data = data + pdf.config.auxdata
+
+    # 1 mu + 2 gammas for 2 channels each
+    assert len(pdf.config.suggested_init()) == 5
+    assert len(pdf.config.suggested_bounds()) == 5
+
+    validate_runOnePoint(pdf, data, 1.0, expected_result)
+
+
+def test_validation_2bin_2channel_couplednorm(source_2bin_2channel_couplednorm,
+                                              spec_2bin_2channel_couplednorm):
+    expected_result = {
+        'obs': 0.5999662863185762,
+        'exp': [
+            0.06596134134354742,
+            0.15477912571478988,
+            0.33323967895587736,
+            0.6096429330789306,
+            0.8688213053042003
+        ]
+    }
+
+    source = source_2bin_2channel_couplednorm
+    spec = spec_2bin_2channel_couplednorm
+
+    pdf = pyhf.hfpdf(spec)
+    data = []
+    for c in pdf.spec['channels']:
+        data += source['channels'][c['name']]['bindata']['data']
+    data = data + pdf.config.auxdata
+
+    assert len(pdf.config.suggested_init()) == 2  # 1 mu + 1 alpha
+    assert len(pdf.config.suggested_bounds()) == 2  # 1 mu + 1 alpha
+
+    validate_runOnePoint(pdf, data, 1.0, expected_result)
+
+
+def test_validation_2bin_2channel_coupledhistosys(source_2bin_2channel_coupledhisto,
+                                                  spec_2bin_2channel_coupledhistosys):
+    expected_result = {
+        'obs': 0.0796739833305826,
+        'exp': [
+            1.765372502072074e-05,
+            0.00026265618793683054,
+            0.003340033567379219,
+            0.03152233566143051,
+            0.17907736639946248
+        ]
+    }
+
+    source = source_2bin_2channel_coupledhisto
+    spec = spec_2bin_2channel_coupledhistosys
+
+    pdf = pyhf.hfpdf(spec)
+    data = []
+    for c in pdf.spec['channels']:
+        data += source['channels'][c['name']]['bindata']['data']
+    data = data + pdf.config.auxdata
+
+    init_pars = pdf.config.suggested_init()
+    par_bounds = pdf.config.suggested_bounds()
+
+    assert len(pdf.config.auxdata) == 1
+    assert len(init_pars) == 2  # 1 mu 1 shared histosys
+    assert len(par_bounds) == 2
+
+    validate_runOnePoint(pdf, data, 1.0, expected_result)
+
+
+def test_validation_2bin_2channel_coupledshapefactor(source_2bin_2channel_coupledshapefactor,
+                                                     spec_2bin_2channel_coupledshapefactor):
+    expected_result = {
+        'obs': 0.5421679124909312,
+        'exp': [
+            0.013753299929451691,
+            0.048887400056355966,
+            0.15555296253957684,
+            0.4007561343326305,
+            0.7357169630955912
+        ]
+    }
+
+    source = source_2bin_2channel_coupledshapefactor
+    spec = spec_2bin_2channel_coupledshapefactor
+
     pdf = pyhf.hfpdf(spec)
     data = []
     for c in pdf.spec['channels']:

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -24,8 +24,7 @@ def source_1bin_normsys(scope='module'):
 
 
 @pytest.fixture
-def spec_1bin_normsys(source_1bin_normsys, scope='module'):
-    source = source_1bin_normsys
+def spec_1bin_normsys(source=source_1bin_normsys(), scope='module'):
     spec = {
         'channels': [
             {
@@ -58,6 +57,20 @@ def spec_1bin_normsys(source_1bin_normsys, scope='module'):
         ]
     }
     return spec
+
+
+@pytest.fixture
+def expected_result_1bin_normsys(scope='module'):
+    return {
+        'obs': 0.0007930094233140433,
+        'exp': [
+            1.2529050370718884e-09,
+            8.932001833559302e-08,
+            5.3294967286010575e-06,
+            0.00022773982308763686,
+            0.0054897420571466075
+        ]
+    }
 
 
 @pytest.fixture
@@ -407,28 +420,25 @@ def test_validation_1bin_shapesys(source_1bin_example1):
     validate_runOnePoint(pdf, data, 1.0, expected_result)
 
 
-def test_validation_1bin_normsys(source_1bin_normsys, spec_1bin_normsys):
-    expected_result = {
-        'obs': 0.0007930094233140433,
-        'exp': [
-            1.2529050370718884e-09,
-            8.932001833559302e-08,
-            5.3294967286010575e-06,
-            0.00022773982308763686,
-            0.0054897420571466075
-        ]
-    }
-
-    source = source_1bin_normsys
-    spec = spec_1bin_normsys
+@pytest.mark.parametrize('source, spec, mu, expected_result, config_len', [
+    (source_1bin_normsys(),
+     spec_1bin_normsys(source_1bin_normsys()),
+     1.,
+     expected_result_1bin_normsys(),
+     {'init_pars': 2, 'par_bounds': 2}),
+],
+    ids=[
+    '1bin_normsys_mu1'
+])
+def test_validation_normsys(source, spec, mu, expected_result, config_len):
 
     pdf = pyhf.hfpdf(spec)
     data = source['bindata']['data'] + pdf.config.auxdata
 
-    assert len(pdf.config.suggested_init()) == 2
-    assert len(pdf.config.suggested_bounds()) == 2
+    assert len(pdf.config.suggested_init()) == config_len['init_pars']
+    assert len(pdf.config.suggested_bounds()) == config_len['par_bounds']
 
-    validate_runOnePoint(pdf, data, 1.0, expected_result)
+    validate_runOnePoint(pdf, data, mu, expected_result)
 
 
 def test_validation_2bin_histosys(source_2bin_histosys_example2, spec_2bin_histosys):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,7 +1,7 @@
 import pyhf
-import pyhf.simplemodels
 
 import json
+import jsonschema
 import pytest
 
 
@@ -12,9 +12,39 @@ def source_1bin_example1():
 
 @pytest.fixture(scope='module')
 def spec_1bin_shapesys(source=source_1bin_example1()):
-    spec = source['bindata']['sig'], \
-        source['bindata']['bkg'], \
-        source['bindata']['bkgerr']
+    spec = {
+        'channels': [
+            {
+                'name': 'singlechannel',
+                'samples': [
+                    {
+                        'name': 'signal',
+                        'data': source['bindata']['sig'],
+                        'modifiers': [
+                            {
+                                'name': 'mu',
+                                'type': 'normfactor',
+                                'data': None
+                            }
+                        ]
+                    },
+                    {
+                        'name': 'background',
+                        'data': source['bindata']['bkg'],
+                        'modifiers': [
+                            {
+                                'name': 'uncorr_bkguncrt',
+                                'type': 'shapesys',
+                                'data': source['bindata']['bkgerr']
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+    schema = json.load(open('validation/spec.json'))
+    jsonschema.validate(spec, schema)
     return spec
 
 
@@ -47,8 +77,7 @@ def setup_1bin_shapesys(source=source_1bin_example1(),
         'expected': {
             'result': expected_result,
             'config': config
-        },
-        'pdf_type': 'hepdata_like'
+        }
     }
 
 
@@ -98,6 +127,8 @@ def spec_1bin_normsys(source=source_1bin_normsys()):
             }
         ]
     }
+    schema = json.load(open('validation/spec.json'))
+    jsonschema.validate(spec, schema)
     return spec
 
 
@@ -130,8 +161,7 @@ def setup_1bin_normsys(source=source_1bin_normsys(),
         'expected': {
             'result': expected_result,
             'config': config
-        },
-        'pdf_type': 'hfpdf'
+        }
     }
 
 
@@ -176,6 +206,8 @@ def spec_2bin_histosys(source=source_2bin_histosys_example2()):
             }
         ]
     }
+    schema = json.load(open('validation/spec.json'))
+    jsonschema.validate(spec, schema)
     return spec
 
 
@@ -209,8 +241,7 @@ def setup_2bin_histosys(source=source_2bin_histosys_example2(),
         'expected': {
             'result': expected_result,
             'config': config
-        },
-        'pdf_type': 'hfpdf'
+        }
     }
 
 
@@ -268,6 +299,8 @@ def spec_2bin_2channel(source=source_2bin_2channel_example1()):
             }
         ]
     }
+    schema = json.load(open('validation/spec.json'))
+    jsonschema.validate(spec, schema)
     return spec
 
 
@@ -302,8 +335,7 @@ def setup_2bin_2channel(source=source_2bin_2channel_example1(),
         'expected': {
             'result': expected_result,
             'config': config
-        },
-        'pdf_type': 'hfpdf'
+        }
     }
 
 
@@ -372,6 +404,8 @@ def spec_2bin_2channel_couplednorm(source=source_2bin_2channel_couplednorm()):
             }
         ]
     }
+    schema = json.load(open('validation/spec.json'))
+    jsonschema.validate(spec, schema)
     return spec
 
 
@@ -407,8 +441,7 @@ def setup_2bin_2channel_couplednorm(
         'expected': {
             'result': expected_result,
             'config': config
-        },
-        'pdf_type': 'hfpdf'
+        }
     }
 
 
@@ -486,6 +519,8 @@ def spec_2bin_2channel_coupledhistosys(source=source_2bin_2channel_coupledhisto(
             }
         ]
     }
+    schema = json.load(open('validation/spec.json'))
+    jsonschema.validate(spec, schema)
     return spec
 
 
@@ -521,8 +556,7 @@ def setup_2bin_2channel_coupledhistosys(
         'expected': {
             'result': expected_result,
             'config': config
-        },
-        'pdf_type': 'hfpdf'
+        }
     }
 
 
@@ -580,6 +614,8 @@ def spec_2bin_2channel_coupledshapefactor(source=source_2bin_2channel_coupledsha
             }
         ]
     }
+    schema = json.load(open('validation/spec.json'))
+    jsonschema.validate(spec, schema)
     return spec
 
 
@@ -615,8 +651,7 @@ def setup_2bin_2channel_coupledshapefactor(
         'expected': {
             'result': expected_result,
             'config': config
-        },
-        'pdf_type': 'hfpdf'
+        }
     }
 
 
@@ -655,10 +690,7 @@ def validate_runOnePoint(pdf, data, mu_test, expected_result, tolerance=1e-5):
 ])
 def test_validation(setup):
     source = setup['source']
-    if setup['pdf_type'] == 'hepdata_like':
-        pdf = pyhf.simplemodels.hepdata_like(*setup['spec'])
-    else:
-        pdf = pyhf.hfpdf(setup['spec'])
+    pdf = pyhf.hfpdf(setup['spec'])
 
     if 'channels' in source:
         data = []

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -214,8 +214,7 @@ def source_2bin_2channel_couplednorm():
 
 
 @pytest.fixture(scope='module')
-def spec_2bin_2channel_couplednorm(source_2bin_2channel_couplednorm):
-    source = source_2bin_2channel_couplednorm
+def spec_2bin_2channel_couplednorm(source=source_2bin_2channel_couplednorm()):
     spec = {
         'channels': [
             {
@@ -278,13 +277,28 @@ def spec_2bin_2channel_couplednorm(source_2bin_2channel_couplednorm):
 
 
 @pytest.fixture(scope='module')
+def expected_result_2bin_2channel_couplednorm(mu=1.):
+    if mu == 1:
+        expected_result = {
+            'obs': 0.5999662863185762,
+            'exp': [
+                0.06596134134354742,
+                0.15477912571478988,
+                0.33323967895587736,
+                0.6096429330789306,
+                0.8688213053042003
+            ]
+        }
+    return expected_result
+
+
+@pytest.fixture(scope='module')
 def source_2bin_2channel_coupledhisto():
     return json.load(open('validation/data/2bin_2channel_coupledhisto.json'))
 
 
 @pytest.fixture(scope='module')
-def spec_2bin_2channel_coupledhistosys(source_2bin_2channel_coupledhisto):
-    source = source_2bin_2channel_coupledhisto
+def spec_2bin_2channel_coupledhistosys(source=source_2bin_2channel_coupledhisto()):
     spec = {
         'channels': [
             {
@@ -356,13 +370,28 @@ def spec_2bin_2channel_coupledhistosys(source_2bin_2channel_coupledhisto):
 
 
 @pytest.fixture(scope='module')
+def expected_result_2bin_2channel_coupledhistosys(mu=1.):
+    if mu == 1:
+        expected_result = {
+            'obs': 0.0796739833305826,
+            'exp': [
+                1.765372502072074e-05,
+                0.00026265618793683054,
+                0.003340033567379219,
+                0.03152233566143051,
+                0.17907736639946248
+            ]
+        }
+    return expected_result
+
+
+@pytest.fixture(scope='module')
 def source_2bin_2channel_coupledshapefactor():
     return json.load(open('validation/data/2bin_2channel_coupledshapefactor.json'))
 
 
 @pytest.fixture(scope='module')
-def spec_2bin_2channel_coupledshapefactor(source_2bin_2channel_coupledshapefactor):
-    source = source_2bin_2channel_coupledshapefactor
+def spec_2bin_2channel_coupledshapefactor(source=source_2bin_2channel_coupledshapefactor()):
     spec = {
         'channels': [
             {
@@ -413,6 +442,22 @@ def spec_2bin_2channel_coupledshapefactor(source_2bin_2channel_coupledshapefacto
     return spec
 
 
+@pytest.fixture(scope='module')
+def expected_result_2bin_2channel_coupledshapefactor(mu=1.):
+    if mu == 1:
+        expected_result = {
+            'obs': 0.5421679124909312,
+            'exp': [
+                0.013753299929451691,
+                0.048887400056355966,
+                0.15555296253957684,
+                0.4007561343326305,
+                0.7357169630955912
+            ]
+        }
+    return expected_result
+
+
 def validate_runOnePoint(pdf, data, mu_test, expected_result, tolerance=1e-5):
     init_pars = pdf.config.suggested_init()
     par_bounds = pdf.config.suggested_bounds()
@@ -453,13 +498,13 @@ def test_validation_1bin_shapesys(source_1bin_example1):
 
 
 @pytest.mark.parametrize('source, spec, mu, expected_result, config_len', [
-    # normsys
+    # 1bin_normsys
     (source_1bin_normsys(),
      spec_1bin_normsys(source_1bin_normsys()),
      1.,
      expected_result_1bin_normsys(1.),
      {'init_pars': 2, 'par_bounds': 2}),
-    # histosys
+    # 2bin_histosys
     (source_2bin_histosys_example2(),
      spec_2bin_histosys(source_2bin_histosys_example2()),
      1.,
@@ -471,15 +516,35 @@ def test_validation_1bin_shapesys(source_1bin_example1):
      1.,
      expected_result_2bin_2channel(1.),
      {'init_pars': 5, 'par_bounds': 5}),  # 1 mu + 2 gammas for 2 channels each
+    # 2bin_2channel_couplednorm
+    (source_2bin_2channel_couplednorm(),
+     spec_2bin_2channel_couplednorm(source_2bin_2channel_couplednorm()),
+     1.,
+     expected_result_2bin_2channel_couplednorm(1.),
+     {'init_pars': 2, 'par_bounds': 2}),  # 1 mu + 1 alpha
+    # 2bin_2channel_coupledhistosys
+    (source_2bin_2channel_coupledhisto(),
+     spec_2bin_2channel_coupledhistosys(source_2bin_2channel_coupledhisto()),
+     1.,
+     expected_result_2bin_2channel_coupledhistosys(1.),
+     {'auxdata': 1, 'init_pars': 2, 'par_bounds': 2}),  # 1 mu 1 shared histosys
+    # 2bin_2channel_coupledshapefactor
+    (source_2bin_2channel_coupledshapefactor(),
+     spec_2bin_2channel_coupledshapefactor(
+         source_2bin_2channel_coupledshapefactor()),
+     1.,
+     expected_result_2bin_2channel_coupledshapefactor(1.),
+     {'auxdata': 0, 'init_pars': 3, 'par_bounds': 3}),  # 1 mu 2 shared shapefactors
 ],
     ids=[
     '1bin_normsys_mu1',
     '2bin_histosys_mu1',
-    '2bin_2channel_mu1'
+    '2bin_2channel_mu1',
+    '2bin_2channel_couplednorm_mu1',
+    '2bin_2channel_coupledhistosys_mu1',
+    '2bin_2channel_coupledshapefactor_mu1'
 ])
 def test_validation(source, spec, mu, expected_result, config_len):
-    # def test_validation_normsys(source, spec, mu, expected_result,
-    # config_len):
     pdf = pyhf.hfpdf(spec)
 
     if 'channels' in source:
@@ -490,143 +555,9 @@ def test_validation(source, spec, mu, expected_result, config_len):
     else:
         data = source['bindata']['data'] + pdf.config.auxdata
 
+    if 'auxdata' in config_len:
+        assert len(pdf.config.auxdata) == config_len['auxdata']
     assert len(pdf.config.suggested_init()) == config_len['init_pars']
     assert len(pdf.config.suggested_bounds()) == config_len['par_bounds']
 
     validate_runOnePoint(pdf, data, mu, expected_result)
-
-
-# @pytest.mark.parametrize('source, spec, mu, expected_result, config_len', [
-#     (source_2bin_histosys_example2(),
-#      spec_2bin_histosys(source_2bin_histosys_example2()),
-#      1.,
-#      expected_result_2bin_histosys(1.),
-#      {'init_pars': 2, 'par_bounds': 2}),
-# ],
-#     ids=[
-#     '2bin_histosys_mu1'
-# ])
-# def test_validation_histosys(source, spec, mu, expected_result, config_len):
-#     pdf = pyhf.hfpdf(spec)
-#     data = source['bindata']['data'] + pdf.config.auxdata
-#
-#     assert len(pdf.config.suggested_init()) == config_len['init_pars']
-#     assert len(pdf.config.suggested_bounds()) == config_len['par_bounds']
-#
-#     validate_runOnePoint(pdf, data, mu, expected_result)
-#
-#
-# @pytest.mark.parametrize('source, spec, mu, expected_result, config_len', [
-#     (source_2bin_2channel_example1(),
-#      spec_2bin_2channel(source_2bin_2channel_example1()),
-#      1.,
-#      expected_result_2bin_2channel(1.),
-#      {'init_pars': 5, 'par_bounds': 5}),
-# ],
-#     ids=[
-#     '2bin_2channel_mu1'
-# ])
-# def test_validation_2bin_2channel(source, spec, mu, expected_result, config_len):
-#     pdf = pyhf.hfpdf(spec)
-#     data = []
-#     for c in pdf.spec['channels']:
-#         data += source['channels'][c['name']]['bindata']['data']
-#     data = data + pdf.config.auxdata
-#
-#     # 1 mu + 2 gammas for 2 channels each
-#     assert len(pdf.config.suggested_init()) == config_len['init_pars']
-#     assert len(pdf.config.suggested_bounds()) == config_len['par_bounds']
-#
-#     validate_runOnePoint(pdf, data, mu, expected_result)
-
-
-def test_validation_2bin_2channel_couplednorm(source_2bin_2channel_couplednorm(),
-                                              spec_2bin_2channel_couplednorm(source_2bin_2channel_couplednorm)):
-    expected_result = {
-        'obs': 0.5999662863185762,
-        'exp': [
-            0.06596134134354742,
-            0.15477912571478988,
-            0.33323967895587736,
-            0.6096429330789306,
-            0.8688213053042003
-        ]
-    }
-
-    source = source_2bin_2channel_couplednorm
-    spec = spec_2bin_2channel_couplednorm
-
-    pdf = pyhf.hfpdf(spec)
-    data = []
-    for c in pdf.spec['channels']:
-        data += source['channels'][c['name']]['bindata']['data']
-    data = data + pdf.config.auxdata
-
-    assert len(pdf.config.suggested_init()) == 2  # 1 mu + 1 alpha
-    assert len(pdf.config.suggested_bounds()) == 2  # 1 mu + 1 alpha
-
-    validate_runOnePoint(pdf, data, 1.0, expected_result)
-
-
-def test_validation_2bin_2channel_coupledhistosys(source_2bin_2channel_coupledhisto,
-                                                  spec_2bin_2channel_coupledhistosys):
-    expected_result = {
-        'obs': 0.0796739833305826,
-        'exp': [
-            1.765372502072074e-05,
-            0.00026265618793683054,
-            0.003340033567379219,
-            0.03152233566143051,
-            0.17907736639946248
-        ]
-    }
-
-    source = source_2bin_2channel_coupledhisto
-    spec = spec_2bin_2channel_coupledhistosys
-
-    pdf = pyhf.hfpdf(spec)
-    data = []
-    for c in pdf.spec['channels']:
-        data += source['channels'][c['name']]['bindata']['data']
-    data = data + pdf.config.auxdata
-
-    init_pars = pdf.config.suggested_init()
-    par_bounds = pdf.config.suggested_bounds()
-
-    assert len(pdf.config.auxdata) == 1
-    assert len(init_pars) == 2  # 1 mu 1 shared histosys
-    assert len(par_bounds) == 2
-
-    validate_runOnePoint(pdf, data, 1.0, expected_result)
-
-
-def test_validation_2bin_2channel_coupledshapefactor(source_2bin_2channel_coupledshapefactor,
-                                                     spec_2bin_2channel_coupledshapefactor):
-    expected_result = {
-        'obs': 0.5421679124909312,
-        'exp': [
-            0.013753299929451691,
-            0.048887400056355966,
-            0.15555296253957684,
-            0.4007561343326305,
-            0.7357169630955912
-        ]
-    }
-
-    source = source_2bin_2channel_coupledshapefactor
-    spec = spec_2bin_2channel_coupledshapefactor
-
-    pdf = pyhf.hfpdf(spec)
-    data = []
-    for c in pdf.spec['channels']:
-        data += source['channels'][c['name']]['bindata']['data']
-    data = data + pdf.config.auxdata
-
-    init_pars = pdf.config.suggested_init()
-    par_bounds = pdf.config.suggested_bounds()
-
-    assert len(pdf.config.auxdata) == 0
-    assert len(init_pars) == 3  # 1 mu 2 shared shapefactors
-    assert len(par_bounds) == 3
-
-    validate_runOnePoint(pdf, data, 1.0, expected_result)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -11,6 +11,48 @@ def source_1bin_example1():
 
 
 @pytest.fixture(scope='module')
+def spec_1bin_shapesys(source=source_1bin_example1()):
+    spec = source['bindata']['sig'], \
+        source['bindata']['bkg'], \
+        source['bindata']['bkgerr']
+    return spec
+
+
+@pytest.fixture(scope='module')
+def expected_result_1bin_shapesys(mu=1.):
+    if mu == 1:
+        expected_result = {
+            'obs': 0.4541865416107029,
+            'exp': [
+                0.06371799398864626,
+                0.15096503398048894,
+                0.3279606950533305,
+                0.6046087303039118,
+                0.8662627605298466
+            ]
+        }
+    return expected_result
+
+
+@pytest.fixture(scope='module')
+def setup_1bin_shapesys(source=source_1bin_example1(),
+                        spec=spec_1bin_shapesys(source_1bin_example1()),
+                        mu=1,
+                        expected_result=expected_result_1bin_shapesys(1.),
+                        config={'init_pars': 2, 'par_bounds': 2}):
+    return {
+        'source': source,
+        'spec': spec,
+        'mu': mu,
+        'expected': {
+            'result': expected_result,
+            'config': config
+        },
+        'pdf_type': 'hepdata_like'
+    }
+
+
+@pytest.fixture(scope='module')
 def source_1bin_normsys():
     source = {
         'binning': [2, -0.5, 1.5],
@@ -76,6 +118,24 @@ def expected_result_1bin_normsys(mu=1.):
 
 
 @pytest.fixture(scope='module')
+def setup_1bin_normsys(source=source_1bin_normsys(),
+                       spec=spec_1bin_normsys(source_1bin_normsys()),
+                       mu=1,
+                       expected_result=expected_result_1bin_normsys(1.),
+                       config={'init_pars': 2, 'par_bounds': 2}):
+    return {
+        'source': source,
+        'spec': spec,
+        'mu': mu,
+        'expected': {
+            'result': expected_result,
+            'config': config
+        },
+        'pdf_type': 'hfpdf'
+    }
+
+
+@pytest.fixture(scope='module')
 def source_2bin_histosys_example2():
     return json.load(open('validation/data/2bin_histosys_example2.json'))
 
@@ -133,6 +193,25 @@ def expected_result_2bin_histosys(mu=1):
             ]
         }
     return expected_result
+
+
+@pytest.fixture(scope='module')
+def setup_2bin_histosys(source=source_2bin_histosys_example2(),
+                        spec=spec_2bin_histosys(
+                            source_2bin_histosys_example2()),
+                        mu=1,
+                        expected_result=expected_result_2bin_histosys(1.),
+                        config={'init_pars': 2, 'par_bounds': 2}):
+    return {
+        'source': source,
+        'spec': spec,
+        'mu': mu,
+        'expected': {
+            'result': expected_result,
+            'config': config
+        },
+        'pdf_type': 'hfpdf'
+    }
 
 
 @pytest.fixture(scope='module')
@@ -206,6 +285,26 @@ def expected_result_2bin_2channel(mu=1.):
             ]
         }
     return expected_result
+
+
+@pytest.fixture(scope='module')
+def setup_2bin_2channel(source=source_2bin_2channel_example1(),
+                        spec=spec_2bin_2channel(
+                            source_2bin_2channel_example1()),
+                        mu=1,
+                        expected_result=expected_result_2bin_2channel(1.),
+                        config={'init_pars': 5, 'par_bounds': 5}):
+    # 1 mu + 2 gammas for 2 channels each
+    return {
+        'source': source,
+        'spec': spec,
+        'mu': mu,
+        'expected': {
+            'result': expected_result,
+            'config': config
+        },
+        'pdf_type': 'hfpdf'
+    }
 
 
 @pytest.fixture(scope='module')
@@ -290,6 +389,27 @@ def expected_result_2bin_2channel_couplednorm(mu=1.):
             ]
         }
     return expected_result
+
+
+@pytest.fixture(scope='module')
+def setup_2bin_2channel_couplednorm(
+        source=source_2bin_2channel_couplednorm(),
+        spec=spec_2bin_2channel_couplednorm(
+            source_2bin_2channel_couplednorm()),
+        mu=1,
+        expected_result=expected_result_2bin_2channel_couplednorm(1.),
+        config={'init_pars': 2, 'par_bounds': 2}):
+    # 1 mu + 1 alpha
+    return {
+        'source': source,
+        'spec': spec,
+        'mu': mu,
+        'expected': {
+            'result': expected_result,
+            'config': config
+        },
+        'pdf_type': 'hfpdf'
+    }
 
 
 @pytest.fixture(scope='module')
@@ -386,6 +506,27 @@ def expected_result_2bin_2channel_coupledhistosys(mu=1.):
 
 
 @pytest.fixture(scope='module')
+def setup_2bin_2channel_coupledhistosys(
+        source=source_2bin_2channel_coupledhisto(),
+        spec=spec_2bin_2channel_coupledhistosys(
+            source_2bin_2channel_coupledhisto()),
+        mu=1,
+        expected_result=expected_result_2bin_2channel_coupledhistosys(1.),
+        config={'auxdata': 1, 'init_pars': 2, 'par_bounds': 2}):
+    # 1 mu 1 shared histosys
+    return {
+        'source': source,
+        'spec': spec,
+        'mu': mu,
+        'expected': {
+            'result': expected_result,
+            'config': config
+        },
+        'pdf_type': 'hfpdf'
+    }
+
+
+@pytest.fixture(scope='module')
 def source_2bin_2channel_coupledshapefactor():
     return json.load(open('validation/data/2bin_2channel_coupledshapefactor.json'))
 
@@ -458,6 +599,27 @@ def expected_result_2bin_2channel_coupledshapefactor(mu=1.):
     return expected_result
 
 
+@pytest.fixture(scope='module')
+def setup_2bin_2channel_coupledshapefactor(
+        source=source_2bin_2channel_coupledshapefactor(),
+        spec=spec_2bin_2channel_coupledshapefactor(
+            source_2bin_2channel_coupledshapefactor()),
+        mu=1,
+        expected_result=expected_result_2bin_2channel_coupledshapefactor(1.),
+        config={'auxdata': 0, 'init_pars': 3, 'par_bounds': 3}):
+    # 1 mu 2 shared shapefactors
+    return {
+        'source': source,
+        'spec': spec,
+        'mu': mu,
+        'expected': {
+            'result': expected_result,
+            'config': config
+        },
+        'pdf_type': 'hfpdf'
+    }
+
+
 def validate_runOnePoint(pdf, data, mu_test, expected_result, tolerance=1e-5):
     init_pars = pdf.config.suggested_init()
     par_bounds = pdf.config.suggested_bounds()
@@ -473,70 +635,17 @@ def validate_runOnePoint(pdf, data, mu_test, expected_result, tolerance=1e-5):
             expected_result < tolerance
 
 
-def test_validation_1bin_shapesys(source_1bin_example1):
-    expected_result = {
-        'obs': 0.4541865416107029,
-        'exp': [
-            0.06371799398864626,
-            0.15096503398048894,
-            0.3279606950533305,
-            0.6046087303039118,
-            0.8662627605298466
-        ]
-    }
-
-    source = source_1bin_example1
-    pdf = pyhf.simplemodels.hepdata_like(source['bindata']['sig'],
-                                         source['bindata']['bkg'],
-                                         source['bindata']['bkgerr'])
-
-    data = source['bindata']['data'] + pdf.config.auxdata
-
-    assert len(pdf.config.suggested_init()) == 2
-    assert len(pdf.config.suggested_bounds()) == 2
-    validate_runOnePoint(pdf, data, 1.0, expected_result)
-
-
-@pytest.mark.parametrize('source, spec, mu, expected_result, config_len', [
-    # 1bin_normsys
-    (source_1bin_normsys(),
-     spec_1bin_normsys(source_1bin_normsys()),
-     1.,
-     expected_result_1bin_normsys(1.),
-     {'init_pars': 2, 'par_bounds': 2}),
-    # 2bin_histosys
-    (source_2bin_histosys_example2(),
-     spec_2bin_histosys(source_2bin_histosys_example2()),
-     1.,
-     expected_result_2bin_histosys(1.),
-     {'init_pars': 2, 'par_bounds': 2}),
-    # 2bin_2channel
-    (source_2bin_2channel_example1(),
-     spec_2bin_2channel(source_2bin_2channel_example1()),
-     1.,
-     expected_result_2bin_2channel(1.),
-     {'init_pars': 5, 'par_bounds': 5}),  # 1 mu + 2 gammas for 2 channels each
-    # 2bin_2channel_couplednorm
-    (source_2bin_2channel_couplednorm(),
-     spec_2bin_2channel_couplednorm(source_2bin_2channel_couplednorm()),
-     1.,
-     expected_result_2bin_2channel_couplednorm(1.),
-     {'init_pars': 2, 'par_bounds': 2}),  # 1 mu + 1 alpha
-    # 2bin_2channel_coupledhistosys
-    (source_2bin_2channel_coupledhisto(),
-     spec_2bin_2channel_coupledhistosys(source_2bin_2channel_coupledhisto()),
-     1.,
-     expected_result_2bin_2channel_coupledhistosys(1.),
-     {'auxdata': 1, 'init_pars': 2, 'par_bounds': 2}),  # 1 mu 1 shared histosys
-    # 2bin_2channel_coupledshapefactor
-    (source_2bin_2channel_coupledshapefactor(),
-     spec_2bin_2channel_coupledshapefactor(
-         source_2bin_2channel_coupledshapefactor()),
-     1.,
-     expected_result_2bin_2channel_coupledshapefactor(1.),
-     {'auxdata': 0, 'init_pars': 3, 'par_bounds': 3}),  # 1 mu 2 shared shapefactors
+@pytest.mark.parametrize('setup', [
+    setup_1bin_shapesys(),
+    setup_1bin_normsys(),
+    setup_2bin_histosys(),
+    setup_2bin_2channel(),
+    setup_2bin_2channel_couplednorm(),
+    setup_2bin_2channel_coupledhistosys(),
+    setup_2bin_2channel_coupledshapefactor()
 ],
     ids=[
+    '1bin_shapesys_mu1',
     '1bin_normsys_mu1',
     '2bin_histosys_mu1',
     '2bin_2channel_mu1',
@@ -544,8 +653,12 @@ def test_validation_1bin_shapesys(source_1bin_example1):
     '2bin_2channel_coupledhistosys_mu1',
     '2bin_2channel_coupledshapefactor_mu1'
 ])
-def test_validation(source, spec, mu, expected_result, config_len):
-    pdf = pyhf.hfpdf(spec)
+def test_validation(setup):
+    source = setup['source']
+    if setup['pdf_type'] == 'hepdata_like':
+        pdf = pyhf.simplemodels.hepdata_like(*setup['spec'])
+    else:
+        pdf = pyhf.hfpdf(setup['spec'])
 
     if 'channels' in source:
         data = []
@@ -555,9 +668,12 @@ def test_validation(source, spec, mu, expected_result, config_len):
     else:
         data = source['bindata']['data'] + pdf.config.auxdata
 
-    if 'auxdata' in config_len:
-        assert len(pdf.config.auxdata) == config_len['auxdata']
-    assert len(pdf.config.suggested_init()) == config_len['init_pars']
-    assert len(pdf.config.suggested_bounds()) == config_len['par_bounds']
+    if 'auxdata' in setup['expected']['config']:
+        assert len(pdf.config.auxdata) == \
+            setup['expected']['config']['auxdata']
+    assert len(pdf.config.suggested_init()) == \
+        setup['expected']['config']['init_pars']
+    assert len(pdf.config.suggested_bounds()) == \
+        setup['expected']['config']['par_bounds']
 
-    validate_runOnePoint(pdf, data, mu, expected_result)
+    validate_runOnePoint(pdf, data, setup['mu'], setup['expected']['result'])

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,9 +1,27 @@
 import pyhf
 import pyhf.simplemodels
-import numpy as np
+
 import json
+import pytest
 
 VALIDATION_TOLERANCE = 1e-5
+
+
+@pytest.fixture
+def validate_runOnePoint(pdf, data, mu_test, expected_result, scope='function'):
+    init_pars = pdf.config.suggested_init()
+    par_bounds = pdf.config.suggested_bounds()
+
+    CLs_obs, CLs_exp = pyhf.runOnePoint(
+        mu_test, data, pdf, init_pars, par_bounds)[-2:]
+    CLs_obs = 1. / CLs_obs
+    CLs_exp = [1. / x for x in CLs_exp]
+    assert (CLs_obs - expected_result['obs']) / \
+        expected_result['obs'] < VALIDATION_TOLERANCE
+    for result, expected_result in zip(CLs_exp, expected_result['exp']):
+        assert (result - expected_result) / \
+            expected_result < VALIDATION_TOLERANCE
+
 
 def test_validation_1bin_shapesys():
     expected_result = {
@@ -17,24 +35,16 @@ def test_validation_1bin_shapesys():
         ]
     }
 
-
     source = json.load(open('validation/data/1bin_example1.json'))
-    pdf  = pyhf.simplemodels.hepdata_like(source['bindata']['sig'], source['bindata']['bkg'], source['bindata']['bkgerr'])
+    pdf = pyhf.simplemodels.hepdata_like(source['bindata']['sig'],
+                                         source['bindata']['bkg'],
+                                         source['bindata']['bkgerr'])
 
     data = source['bindata']['data'] + pdf.config.auxdata
-    muTest = 1.0
 
     assert len(pdf.config.suggested_init()) == 2
     assert len(pdf.config.suggested_bounds()) == 2
-    init_pars  = pdf.config.suggested_init()
-    par_bounds = pdf.config.suggested_bounds()
-
-    clsobs, cls_exp = pyhf.runOnePoint(muTest, data,pdf,init_pars,par_bounds)[-2:]
-    cls_obs = 1./clsobs
-    cls_exp = [1./x for x in cls_exp]
-    assert (cls_obs - expected_result['obs'])/expected_result['obs'] < VALIDATION_TOLERANCE
-    for result,expected_result in zip(cls_exp, expected_result['exp']):
-        assert (result-expected_result)/expected_result < VALIDATION_TOLERANCE
+    validate_runOnePoint(pdf, data, 1.0, expected_result)
 
 
 def test_validation_1bin_normsys():
@@ -49,12 +59,12 @@ def test_validation_1bin_normsys():
         ]
     }
     source = {
-      "binning": [2,-0.5,1.5],
-      "bindata": {
-        "data":    [120.0, 180.0],
-        "bkg":     [100.0, 150.0],
-        "sig":     [30.0, 95.0]
-      }
+        'binning': [2, -0.5, 1.5],
+        'bindata': {
+            'data': [120.0, 180.0],
+            'bkg': [100.0, 150.0],
+            'sig': [30.0, 95.0]
+        }
     }
     spec = {
         'channels': [
@@ -65,38 +75,35 @@ def test_validation_1bin_normsys():
                         'name': 'signal',
                         'data': source['bindata']['sig'],
                         'modifiers': [
-                            {'name': 'mu', 'type': 'normfactor', 'data': None}
+                            {
+                                'name': 'mu',
+                                'type': 'normfactor',
+                                'data': None
+                            }
                         ]
                     },
                     {
                         'name': 'background',
                         'data': source['bindata']['bkg'],
                         'modifiers': [
-                            {'name': 'bkg_norm', 'type': 'normsys', 'data': {'lo': 0.90, 'hi': 1.10}}
+                            {
+                                'name': 'bkg_norm',
+                                'type': 'normsys',
+                                'data': {'lo': 0.90, 'hi': 1.10}
+                            }
                         ]
                     }
                 ]
             }
         ]
     }
-    pdf  = pyhf.hfpdf(spec)
+    pdf = pyhf.hfpdf(spec)
 
     data = source['bindata']['data'] + pdf.config.auxdata
 
-    muTest = 1.0
-
     assert len(pdf.config.suggested_init()) == 2
     assert len(pdf.config.suggested_bounds()) == 2
-    init_pars  = pdf.config.suggested_init()
-    par_bounds = pdf.config.suggested_bounds()
-
-
-    clsobs, cls_exp = pyhf.runOnePoint(muTest, data,pdf,init_pars,par_bounds)[-2:]
-    cls_obs = 1./clsobs
-    cls_exp = [1./x for x in cls_exp]
-    assert (cls_obs - expected_result['obs'])/expected_result['obs'] < VALIDATION_TOLERANCE
-    for result,expected_result in zip(cls_exp, expected_result['exp']):
-        assert (result-expected_result)/expected_result < VALIDATION_TOLERANCE
+    validate_runOnePoint(pdf, data, 1.0, expected_result)
 
 
 def test_validation_2bin_histosys():
@@ -120,39 +127,37 @@ def test_validation_2bin_histosys():
                         'name': 'signal',
                         'data': source['bindata']['sig'],
                         'modifiers': [
-                            {'name': 'mu', 'type': 'normfactor', 'data': None}
+                            {
+                                'name': 'mu',
+                                'type': 'normfactor',
+                                'data': None}
                         ]
                     },
                     {
                         'name': 'background',
                         'data': source['bindata']['bkg'],
                         'modifiers': [
-                            {'name': 'bkg_norm', 'type': 'histosys', 'data': {'lo_data': source['bindata']['bkgsys_dn'], 'hi_data': source['bindata']['bkgsys_up']}}
+                            {
+                                'name': 'bkg_norm',
+                                'type': 'histosys',
+                                'data': {
+                                    'lo_data': source['bindata']['bkgsys_dn'],
+                                    'hi_data': source['bindata']['bkgsys_up']
+                                }
+                            }
                         ]
                     }
                 ]
             }
         ]
     }
-    pdf  = pyhf.hfpdf(spec)
+    pdf = pyhf.hfpdf(spec)
 
     data = source['bindata']['data'] + pdf.config.auxdata
 
-    muTest = 1.0
-
     assert len(pdf.config.suggested_init()) == 2
     assert len(pdf.config.suggested_bounds()) == 2
-    init_pars  = pdf.config.suggested_init()
-    par_bounds = pdf.config.suggested_bounds()
-
-
-    clsobs, cls_exp = pyhf.runOnePoint(muTest, data,pdf,init_pars,par_bounds)[-2:]
-    cls_obs = 1./clsobs
-    cls_exp = [1./x for x in cls_exp]
-    assert (cls_obs - expected_result['obs'])/expected_result['obs'] < VALIDATION_TOLERANCE
-    for result,expected_result in zip(cls_exp, expected_result['exp']):
-        assert (result-expected_result)/expected_result < VALIDATION_TOLERANCE
-
+    validate_runOnePoint(pdf, data, 1.0, expected_result)
 
 
 def test_validation_2bin_2channel():
@@ -167,7 +172,7 @@ def test_validation_2bin_2channel():
         ]
     }
     source = json.load(open('validation/data/2bin_2channel_example1.json'))
-    spec =  {
+    spec = {
         'channels': [
             {
                 'name': 'signal',
@@ -176,14 +181,22 @@ def test_validation_2bin_2channel():
                         'name': 'signal',
                         'data': source['channels']['signal']['bindata']['sig'],
                         'modifiers': [
-                            {'name': 'mu', 'type': 'normfactor', 'data': None}
+                            {
+                                'name': 'mu',
+                                'type': 'normfactor',
+                                'data': None
+                            }
                         ]
                     },
                     {
                         'name': 'background',
                         'data': source['channels']['signal']['bindata']['bkg'],
                         'modifiers': [
-                            {'name': 'uncorr_bkguncrt_signal', 'type': 'shapesys', 'data': source['channels']['signal']['bindata']['bkgerr']}
+                            {
+                                'name': 'uncorr_bkguncrt_signal',
+                                'type': 'shapesys',
+                                'data': source['channels']['signal']['bindata']['bkgerr']
+                            }
                         ]
                     }
                 ]
@@ -195,47 +208,41 @@ def test_validation_2bin_2channel():
                         'name': 'background',
                         'data': source['channels']['control']['bindata']['bkg'],
                         'modifiers': [
-                            {'name': 'uncorr_bkguncrt_control', 'type': 'shapesys', 'data': source['channels']['control']['bindata']['bkgerr']}
+                            {
+                                'name': 'uncorr_bkguncrt_control',
+                                'type': 'shapesys',
+                                'data': source['channels']['control']['bindata']['bkgerr']
+                            }
                         ]
                     }
                 ]
             }
         ]
     }
-    pdf  = pyhf.hfpdf(spec)
+    pdf = pyhf.hfpdf(spec)
     data = []
     for c in pdf.spec['channels']:
         data += source['channels'][c['name']]['bindata']['data']
     data = data + pdf.config.auxdata
 
-    muTest = 1.0
-
-    assert len(pdf.config.suggested_init())   == 5 # 1 mu + 2 gammas for 2 channels each
+    # 1 mu + 2 gammas for 2 channels each
+    assert len(pdf.config.suggested_init()) == 5
     assert len(pdf.config.suggested_bounds()) == 5
-    init_pars  = pdf.config.suggested_init()
-    par_bounds = pdf.config.suggested_bounds()
-
-    clsobs, cls_exp = pyhf.runOnePoint(muTest, data,pdf,init_pars,par_bounds)[-2:]
-    cls_obs = 1./clsobs
-    cls_exp = [1./x for x in cls_exp]
-    assert (cls_obs - expected_result['obs'])/expected_result['obs'] < VALIDATION_TOLERANCE
-    for result,expected_result in zip(cls_exp, expected_result['exp']):
-        assert (result-expected_result)/expected_result < VALIDATION_TOLERANCE
-
+    validate_runOnePoint(pdf, data, 1.0, expected_result)
 
 
 def test_validation_2bin_2channel_couplednorm():
     expected_result = {
         'obs': 0.5999662863185762,
         'exp': [0.06596134134354742,
-          0.15477912571478988,
-          0.33323967895587736,
-          0.6096429330789306,
-          0.8688213053042003
-        ]
+                0.15477912571478988,
+                0.33323967895587736,
+                0.6096429330789306,
+                0.8688213053042003
+                ]
     }
     source = json.load(open('validation/data/2bin_2channel_couplednorm.json'))
-    spec =  {
+    spec = {
         'channels': [
             {
                 'name': 'signal',
@@ -244,21 +251,33 @@ def test_validation_2bin_2channel_couplednorm():
                         'name': 'signal',
                         'data': source['channels']['signal']['bindata']['sig'],
                         'modifiers': [
-                            {'name': 'mu', 'type': 'normfactor', 'data': None}
+                            {
+                                'name': 'mu',
+                                'type': 'normfactor',
+                                'data': None
+                            }
                         ]
                     },
                     {
                         'name': 'bkg1',
                         'data': source['channels']['signal']['bindata']['bkg1'],
                         'modifiers': [
-                            {'name': 'coupled_normsys', 'type': 'normsys', 'data':  {'lo': 0.9, 'hi': 1.1}}
+                            {
+                                'name': 'coupled_normsys',
+                                'type': 'normsys',
+                                'data':  {'lo': 0.9, 'hi': 1.1}
+                            }
                         ]
                     },
                     {
                         'name': 'bkg2',
                         'data': source['channels']['signal']['bindata']['bkg2'],
                         'modifiers': [
-                            {'name': 'coupled_normsys', 'type': 'normsys', 'data':  {'lo': 0.5, 'hi': 1.5}}
+                            {
+                                'name': 'coupled_normsys',
+                                'type': 'normsys',
+                                'data':  {'lo': 0.5, 'hi': 1.5}
+                            }
                         ]
                     }
                 ]
@@ -270,48 +289,41 @@ def test_validation_2bin_2channel_couplednorm():
                         'name': 'background',
                         'data': source['channels']['control']['bindata']['bkg1'],
                         'modifiers': [
-                            {'name': 'coupled_normsys', 'type': 'normsys', 'data': {'lo': 0.9, 'hi': 1.1}}
+                            {
+                                'name': 'coupled_normsys',
+                                'type': 'normsys',
+                                'data': {'lo': 0.9, 'hi': 1.1}
+                            }
                         ]
                     }
                 ]
             }
         ]
     }
-    pdf  = pyhf.hfpdf(spec)
+    pdf = pyhf.hfpdf(spec)
     data = []
     for c in pdf.spec['channels']:
         data += source['channels'][c['name']]['bindata']['data']
     data = data + pdf.config.auxdata
 
-
-    muTest = 1.0
-    assert len(pdf.config.suggested_init())   == 2 # 1 mu + 1 alpha
-    assert len(pdf.config.suggested_bounds()) == 2 # 1 mu + 1 alpha
-    init_pars  = pdf.config.suggested_init()
-    par_bounds = pdf.config.suggested_bounds()
-
-    clsobs, cls_exp = pyhf.runOnePoint(muTest, data,pdf,init_pars,par_bounds)[-2:]
-    cls_obs = 1./clsobs
-    cls_exp = [1./x for x in cls_exp]
-    assert (cls_obs - expected_result['obs'])/expected_result['obs'] < VALIDATION_TOLERANCE
-    for result,expected_result in zip(cls_exp, expected_result['exp']):
-        assert (result-expected_result)/expected_result < VALIDATION_TOLERANCE
-
+    assert len(pdf.config.suggested_init()) == 2  # 1 mu + 1 alpha
+    assert len(pdf.config.suggested_bounds()) == 2  # 1 mu + 1 alpha
+    validate_runOnePoint(pdf, data, 1.0, expected_result)
 
 
 def test_validation_2bin_2channel_coupledhistosys():
     expected_result = {
-    'obs': 0.0796739833305826,
-     'exp': [
-        1.765372502072074e-05,
-        0.00026265618793683054,
-        0.003340033567379219,
-        0.03152233566143051,
-        0.17907736639946248
-    ]
+        'obs': 0.0796739833305826,
+        'exp': [
+            1.765372502072074e-05,
+            0.00026265618793683054,
+            0.003340033567379219,
+            0.03152233566143051,
+            0.17907736639946248
+        ]
     }
     source = json.load(open('validation/data/2bin_2channel_coupledhisto.json'))
-    spec   =  {
+    spec = {
         'channels': [
             {
                 'name': 'signal',
@@ -320,21 +332,39 @@ def test_validation_2bin_2channel_coupledhistosys():
                         'name': 'signal',
                         'data': source['channels']['signal']['bindata']['sig'],
                         'modifiers': [
-                            {'name': 'mu', 'type': 'normfactor', 'data': None}
+                            {
+                                'name': 'mu',
+                                'type': 'normfactor',
+                                'data': None
+                            }
                         ]
                     },
                     {
                         'name': 'bkg1',
                         'data': source['channels']['signal']['bindata']['bkg1'],
                         'modifiers': [
-                            {'name': 'coupled_histosys','type': 'histosys', 'data': {'lo_data': source['channels']['signal']['bindata']['bkg1_dn'], 'hi_data': source['channels']['signal']['bindata']['bkg1_up']}}
+                            {
+                                'name': 'coupled_histosys',
+                                'type': 'histosys',
+                                'data': {
+                                    'lo_data': source['channels']['signal']['bindata']['bkg1_dn'],
+                                    'hi_data': source['channels']['signal']['bindata']['bkg1_up']
+                                }
+                            }
                         ]
                     },
                     {
                         'name': 'bkg2',
                         'data': source['channels']['signal']['bindata']['bkg2'],
                         'modifiers': [
-                            {'name': 'coupled_histosys', 'type': 'histosys', 'data': {'lo_data': source['channels']['signal']['bindata']['bkg2_dn'], 'hi_data': source['channels']['signal']['bindata']['bkg2_up']}}
+                            {
+                                'name': 'coupled_histosys',
+                                'type': 'histosys',
+                                'data': {
+                                    'lo_data': source['channels']['signal']['bindata']['bkg2_dn'],
+                                    'hi_data': source['channels']['signal']['bindata']['bkg2_up']
+                                }
+                            }
                         ]
                     }
                 ]
@@ -346,14 +376,21 @@ def test_validation_2bin_2channel_coupledhistosys():
                         'name': 'background',
                         'data': source['channels']['control']['bindata']['bkg1'],
                         'modifiers': [
-                            {'name': 'coupled_histosys', 'type': 'histosys', 'data': {'lo_data': source['channels']['control']['bindata']['bkg1_dn'], 'hi_data': source['channels']['control']['bindata']['bkg1_up']}}
+                            {
+                                'name': 'coupled_histosys',
+                                'type': 'histosys',
+                                'data': {
+                                    'lo_data': source['channels']['control']['bindata']['bkg1_dn'],
+                                    'hi_data': source['channels']['control']['bindata']['bkg1_up']
+                                }
+                            }
                         ]
                     }
                 ]
             }
         ]
     }
-    pdf  = pyhf.hfpdf(spec)
+    pdf = pyhf.hfpdf(spec)
     data = []
     for c in pdf.spec['channels']:
         data += source['channels'][c['name']]['bindata']['data']
@@ -363,31 +400,26 @@ def test_validation_2bin_2channel_coupledhistosys():
     par_bounds = pdf.config.suggested_bounds()
 
     assert len(pdf.config.auxdata) == 1
-    assert len(init_pars)  == 2 #1 mu 1 shared histosys
+    assert len(init_pars) == 2  # 1 mu 1 shared histosys
     assert len(par_bounds) == 2
 
-    muTest = 1.0
-    clsobs, cls_exp = pyhf.runOnePoint(muTest, data,pdf,init_pars,par_bounds)[-2:]
-    cls_obs = 1./clsobs
-    cls_exp = [1./x for x in cls_exp]
-    assert (cls_obs - expected_result['obs'])/expected_result['obs'] < VALIDATION_TOLERANCE
-    for result,expected_result in zip(cls_exp, expected_result['exp']):
-        assert (result-expected_result)/expected_result < VALIDATION_TOLERANCE
+    validate_runOnePoint(pdf, data, 1.0, expected_result)
 
 
 def test_validation_2bin_2channel_coupledshapefactor():
     expected_result = {
-    'obs': 0.5421679124909312,
-     'exp': [
-        0.013753299929451691,
-        0.048887400056355966,
-        0.15555296253957684,
-        0.4007561343326305,
-        0.7357169630955912
+        'obs': 0.5421679124909312,
+        'exp': [
+            0.013753299929451691,
+            0.048887400056355966,
+            0.15555296253957684,
+            0.4007561343326305,
+            0.7357169630955912
         ]
     }
-    source = json.load(open('validation/data/2bin_2channel_coupledshapefactor.json'))
-    spec =  {
+    source = json.load(
+        open('validation/data/2bin_2channel_coupledshapefactor.json'))
+    spec = {
         'channels': [
             {
                 'name': 'signal',
@@ -396,14 +428,21 @@ def test_validation_2bin_2channel_coupledshapefactor():
                         'name': 'signal',
                         'data': source['channels']['signal']['bindata']['sig'],
                         'modifiers': [
-                            {'name': 'mu', 'type': 'normfactor', 'data': None}
+                            {
+                                'name': 'mu',
+                                'type': 'normfactor',
+                                'data': None}
                         ]
                     },
                     {
                         'name': 'bkg1',
                         'data': source['channels']['signal']['bindata']['bkg1'],
                         'modifiers': [
-                            {'name': 'coupled_shapefactor', 'type': 'shapefactor', 'data': None}
+                            {
+                                'name': 'coupled_shapefactor',
+                                'type': 'shapefactor',
+                                'data': None
+                            }
                         ]
                     }
                 ]
@@ -415,14 +454,18 @@ def test_validation_2bin_2channel_coupledshapefactor():
                         'name': 'background',
                         'data': source['channels']['control']['bindata']['bkg1'],
                         'modifiers': [
-                            {'name': 'coupled_shapefactor', 'type': 'shapefactor', 'data': None}
+                            {
+                                'name': 'coupled_shapefactor',
+                                'type': 'shapefactor',
+                                'data': None
+                            }
                         ]
                     }
                 ]
             }
         ]
     }
-    pdf  = pyhf.hfpdf(spec)
+    pdf = pyhf.hfpdf(spec)
     data = []
     for c in pdf.spec['channels']:
         data += source['channels'][c['name']]['bindata']['data']
@@ -432,13 +475,7 @@ def test_validation_2bin_2channel_coupledshapefactor():
     par_bounds = pdf.config.suggested_bounds()
 
     assert len(pdf.config.auxdata) == 0
-    assert len(init_pars)  == 3 #1 mu 2 shared shapefactors
+    assert len(init_pars) == 3  # 1 mu 2 shared shapefactors
     assert len(par_bounds) == 3
 
-    muTest = 1.0
-    clsobs, cls_exp = pyhf.runOnePoint(muTest, data,pdf,init_pars,par_bounds)[-2:]
-    cls_obs = 1./clsobs
-    cls_exp = [1./x for x in cls_exp]
-    assert (cls_obs - expected_result['obs'])/expected_result['obs'] < VALIDATION_TOLERANCE
-    for result,expected_result in zip(cls_exp, expected_result['exp']):
-        assert (result-expected_result)/expected_result < VALIDATION_TOLERANCE
+    validate_runOnePoint(pdf, data, 1.0, expected_result)


### PR DESCRIPTION
This resolves #66.

- [x] Identify all tests that fixtures could be used in:
   - `test_optim.py `
   - `test_validation.py` (not so much as data isn't shared, but can make the validation part a function)
- [x] Determine if a single `conftest.py` can be used across all tests (not so helpful as data isn't shared across tests)
- [x] Beautify the spec for readability (use [PEP8](https://www.python.org/dev/peps/pep-0008/) and ad hoc choice of [standard-json](https://github.com/standard/standard-json) style)

# Checklist Before Requesting Approver

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
