### PR TITLE
fix non existent modifier handling in pdf construction

### DIFF
--- a/pyhf/__init__.py
+++ b/pyhf/__init__.py
@@ -147,7 +147,7 @@ class modelconfig(object):
             modifier_cls = modifiers.registry[modifier_def['type']]
         except KeyError:
             log.exception('Modifier type not implemented yet (processing {0:s}). Current modifier types: {1}'.format(modifier_def['type'], modifiers.registry.keys()))
-            raise
+            raise modifiers.InvalidModifier()
 
         # if modifier is shared, check if it already exists and use it
         if modifier_cls.is_shared and modifier_def['name'] in self.par_map:

--- a/pyhf/__init__.py
+++ b/pyhf/__init__.py
@@ -144,10 +144,10 @@ class modelconfig(object):
         """
         # get modifier class associated with modifier type
         try:
-            modifier_cls = modifiers.registry.get(modifier_def['type'])
+            modifier_cls = modifiers.registry[modifier_def['type']]
         except KeyError:
-            raise RuntimeError('Modifier type not implemented yet (processing {0:s}). Current modifier types: {1}'.format(modifier_def['type'], modifiers.registry.keys()))
-
+            log.exception('Modifier type not implemented yet (processing {0:s}). Current modifier types: {1}'.format(modifier_def['type'], modifiers.registry.keys()))
+            raise
 
         # if modifier is shared, check if it already exists and use it
         if modifier_cls.is_shared and modifier_def['name'] in self.par_map:

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -90,7 +90,8 @@ def test_add_unknown_modifier():
             }
         ]
     }
-    pyhf.hfpdf(spec)
+    with pytest.raises(KeyError):
+        pyhf.hfpdf(spec)
 
 
 def test_pdf_integration_histosys():

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -75,6 +75,24 @@ def test_core_pdf_broadcasting():
     assert broadcasted.shape    == np.array(data).shape
     assert np.all(naive_python  == broadcasted)
 
+def test_add_unknown_modifier():
+    spec = {
+        'channels': [
+            {
+                'name': 'channe',
+                'samples': [
+                    {
+                        'modifiers': [
+                            {'name': 'a_name', 'type': 'this_should_not_exist', 'data': None}
+                        ]
+                    },
+                ]
+            }
+        ]
+    }
+    pyhf.hfpdf(spec)
+
+
 def test_pdf_integration_histosys():
     schema = json.load(open('validation/spec.json'))
     source = json.load(open('validation/data/2bin_histosys_example2.json'))

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -1,4 +1,5 @@
 import pyhf
+import pytest
 import pyhf.simplemodels
 import numpy as np
 import json

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -1,6 +1,7 @@
 import pyhf
 import pytest
 import pyhf.simplemodels
+import pyhf.modifiers
 import numpy as np
 import json
 import jsonschema
@@ -91,7 +92,7 @@ def test_add_unknown_modifier():
             }
         ]
     }
-    with pytest.raises(KeyError):
+    with pytest.raises(pyhf.modifiers.InvalidModifier):
         pyhf.hfpdf(spec)
 
 


### PR DESCRIPTION
# Description

the behaviour for non-existing modifiers is wrong `.get(name)` should be `[name]`