### PR TITLE
[WIP] Move modifier factor calculables into modifiers

### DIFF
--- a/pyhf/modifiers/__init__.py
+++ b/pyhf/modifiers/__init__.py
@@ -10,7 +10,7 @@ registry = {}
 Check if given object contains the right structure for constrained and unconstrained modifiers
 '''
 def validate_modifier_structure(modifier, constrained):
-    required_methods = ['__init__', 'add_sample']
+    required_methods = ['__init__', 'add_sample', 'apply']
     required_constrained_methods = ['alphas', 'pdf', 'expected_data']
 
     for method in required_methods + required_constrained_methods*constrained:
@@ -58,21 +58,25 @@ Examples:
   >>> ... class myCustomModifier(object):
   >>> ...   def __init__(self): pass
   >>> ...   def add_sample(self): pass
+  >>> ...   def apply(self): pass
 
   >>> @modifiers.modifier(name='myCustomNamer')
   >>> ... class myCustomModifier(object):
   >>> ...   def __init__(self): pass
   >>> ...   def add_sample(self): pass
+  >>> ...   def apply(self): pass
 
   >>> @modifiers.modifier(shared=True)
   >>> ... class myCustomSharedModifier(object):
   >>> ...   def __init__(self): pass
   >>> ...   def add_sample(self): pass
+  >>> ...   def apply(self): pass
 
   >>> @modifiers.modifier(constrained=True)
   >>> ... class myCustomModifier(object):
   >>> ...   def __init__(self): pass
   >>> ...   def add_sample(self): pass
+  >>> ...   def apply(self): pass
   >>> ...   def alphas(self): pass
   >>> ...   def pdf(self): pass
   >>> ...   def expected_data(self): pass
@@ -81,7 +85,8 @@ Examples:
   >>> ... class myCustomModifier(object):
   >>> ...   def __init__(self): pass
   >>> ...   def add_sample(self): pass
-  >>>
+  >>> ...   def apply(self): pass
+  >>> ...
   pyhf.exceptions.InvalidModifier: Expected alphas method on constrained modifier myCustomModifier
 '''
 def modifier(*args, **kwargs):

--- a/pyhf/modifiers/histosys.py
+++ b/pyhf/modifiers/histosys.py
@@ -33,4 +33,21 @@ class histosys(object):
         return tensorlib.normal(a, alpha, [1])
 
     def apply(self, channel, sample, pars):
-        pass
+        assert int(pars.shape[0]) == 1
+        return self._apply(self.at_minus_one[channel['name']][sample['name']],
+                           self.at_zero[channel['name']][sample['name']],
+                           self.at_plus_one[channel['name']][sample['name']],
+                           pars)[0]
+
+    @staticmethod
+    def _apply(at_minus_one, at_zero, at_plus_one, alphas):
+        tensorlib, _ = get_backend()
+        at_minus_one = tensorlib.astensor(at_minus_one)
+        at_zero = tensorlib.astensor(at_zero)
+        at_plus_one = tensorlib.astensor(at_plus_one)
+        alphas = tensorlib.astensor(alphas)
+
+        iplus_izero  = at_plus_one - at_zero
+        izero_iminus = at_zero - at_minus_one
+        mask = tensorlib.outer(alphas < 0, tensorlib.ones(iplus_izero.shape))
+        return tensorlib.where(mask, tensorlib.outer(alphas, izero_iminus), tensorlib.outer(alphas, iplus_izero))

--- a/pyhf/modifiers/histosys.py
+++ b/pyhf/modifiers/histosys.py
@@ -31,3 +31,6 @@ class histosys(object):
     def pdf(self, a, alpha):
         tensorlib, _ = get_backend()
         return tensorlib.normal(a, alpha, [1])
+
+    def apply(self, channel, sample, pars):
+        pass

--- a/pyhf/modifiers/normfactor.py
+++ b/pyhf/modifiers/normfactor.py
@@ -12,3 +12,6 @@ class normfactor(object):
 
     def add_sample(self, channel, sample, modifier_def):
         pass
+
+    def apply(self, channel, sample, pars):
+        pass

--- a/pyhf/modifiers/normsys.py
+++ b/pyhf/modifiers/normsys.py
@@ -30,3 +30,6 @@ class normsys(object):
     def pdf(self, a, alpha):
         tensorlib, _ = get_backend()
         return tensorlib.normal(a, alpha, 1)
+
+    def apply(self, channel, sample, pars):
+        pass

--- a/pyhf/modifiers/shapefactor.py
+++ b/pyhf/modifiers/shapefactor.py
@@ -12,3 +12,6 @@ class shapefactor(object):
 
     def add_sample(self, channel, sample, modifier_def):
         pass
+
+    def apply(self, channel, sample, pars):
+        pass

--- a/pyhf/modifiers/shapesys.py
+++ b/pyhf/modifiers/shapesys.py
@@ -33,3 +33,6 @@ class shapesys(object):
 
     def add_sample(self, channel, sample, modifier_def):
         pass
+
+    def apply(self, channel, sample, pars):
+        pass

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -25,6 +25,7 @@ def test_modifiers_structure():
     class myCustomModifier(object):
         def __init__(self): pass
         def add_sample(self): pass
+        def apply(self): pass
 
     assert inspect.isclass(myCustomModifier)
     assert 'myUnconstrainedModifier' in pyhf.modifiers.registry
@@ -37,6 +38,7 @@ def test_modifiers_structure():
     class myCustomModifier(object):
         def __init__(self): pass
         def add_sample(self): pass
+        def apply(self): pass
 
     assert inspect.isclass(myCustomModifier)
     assert 'mySharedModifier' in pyhf.modifiers.registry
@@ -48,6 +50,7 @@ def test_modifiers_structure():
     class myCustomModifier(object):
         def __init__(self): pass
         def add_sample(self): pass
+        def apply(self): pass
         def pdf(self): pass
         def alphas(self): pass
         def expected_data(self): pass
@@ -74,7 +77,7 @@ def test_modifiers_structure():
         class myCustomModifier(object):
             def __init__(self): pass
             def add_sample(self): pass
-
+            def apply(self): pass
 
 # we make sure decorate can use auto-naming
 def test_modifier_name_auto():
@@ -84,6 +87,7 @@ def test_modifier_name_auto():
     class myCustomModifier(object):
         def __init__(self): pass
         def add_sample(self): pass
+        def apply(self): pass
 
     assert inspect.isclass(myCustomModifier)
     assert 'myCustomModifier' in pyhf.modifiers.registry
@@ -99,6 +103,7 @@ def test_modifier_name_auto_withkwargs():
     class myCustomModifier(object):
         def __init__(self): pass
         def add_sample(self): pass
+        def apply(self): pass
 
     assert inspect.isclass(myCustomModifier)
     assert 'myCustomModifier' in pyhf.modifiers.registry
@@ -112,11 +117,9 @@ def test_modifier_name_custom():
 
     @modifier(name='myCustomName')
     class myCustomModifier(object):
-        def __init__(self):
-            pass
-
-        def add_sample(self):
-            pass
+        def __init__(self): pass
+        def add_sample(self): pass
+        def apply(self): pass
 
     assert inspect.isclass(myCustomModifier)
     assert 'myCustomModifier' not in pyhf.modifiers.registry

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -6,7 +6,7 @@ import json
 import jsonschema
 
 def test_interpcode_0():
-    f = lambda x: pyhf._hfinterp_code0(at_minus_one = 0.5, at_zero =1, at_plus_one = 2.0, alphas = x)
+    f = lambda x: pyhf.modifiers.histosys._apply(at_minus_one = 0.5, at_zero =1, at_plus_one = 2.0, alphas = x)
     assert 1+f(-2) == 0.0
     assert 1+f(-1) == 0.5
     assert 1+f(0) == 1.0
@@ -17,7 +17,7 @@ def test_interpcode_0():
     assert [1 + x for x in f([-2,-1,0,1,2]).reshape(-1)] == [0,0.5,1.0,2.0,3.0]
 
 def test_interpcode_1():
-    f = lambda x: pyhf._hfinterp_code1(at_minus_one = 0.9, at_zero =1, at_plus_one = 1.1, alphas = x)
+    f = lambda x: pyhf.modifiers.normsys._apply(at_minus_one = 0.9, at_zero =1, at_plus_one = 1.1, alphas = x)
     assert f(-2) == 0.9**2
     assert f(-1) == 0.9
     assert f(0) == 1.0


### PR DESCRIPTION
# Description

This will resolve #127.  The goal is to try and get the modifier code to calculate the relevant (multiplicative) factor that goes into the PDF calculation. This is very tricky as one needs to split up information specific to the modifier from information specific to the spec.

# Checklist Before Requesting Approver

- [ ] Tests are passing
- [ ] "WIP" removed from the title of the pull request
