### PR TITLE
Fixnormsys

### DIFF
--- a/pyhf/modifiers/normsys.py
+++ b/pyhf/modifiers/normsys.py
@@ -8,19 +8,20 @@ from ..interpolate import interpolator
 @modifier(name='normsys', constrained=True, shared=True)
 class normsys(object):
     def __init__(self, nom_data, modifier_data):
-        self.n_parameters = 1
-        self.suggested_init = [0.0]
+        self.n_parameters     = 1
+        self.suggested_init   = [0.0]
         self.suggested_bounds = [[-5, 5]]
 
-        self.at_zero = 1
+        self.at_zero = [1]
+
         self.at_minus_one = {}
         self.at_plus_one = {}
         self.auxdata = [0]  # observed data is always at a = 1
 
     def add_sample(self, channel, sample, modifier_def):
         log.info('Adding sample {0:s} to channel {1:s}'.format(sample['name'], channel['name']))
-        self.at_minus_one.setdefault(channel['name'], {})[sample['name']] = modifier_def['data']['lo']
-        self.at_plus_one.setdefault(channel['name'], {})[sample['name']] = modifier_def['data']['hi']
+        self.at_minus_one.setdefault(channel['name'], {})[sample['name']] = [modifier_def['data']['lo']]
+        self.at_plus_one.setdefault(channel['name'], {})[sample['name']]  = [modifier_def['data']['hi']]
 
     def alphas(self, pars):
         return pars  # the nuisance parameters correspond directly to the alpha
@@ -30,7 +31,7 @@ class normsys(object):
 
     def pdf(self, a, alpha):
         tensorlib, _ = get_backend()
-        return tensorlib.normal(a, alpha, 1)
+        return tensorlib.normal(a, alpha, tensorlib.astensor([1]))
 
     def apply(self, channel, sample, pars):
         # normsysfactor(nom_sys_alphas)   = 1 + sum(interp(1, anchors[i][0], anchors[i][0], val=alpha)  for i in range(nom_sys_alphas))

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -188,6 +188,9 @@ def test_pdf_integration_histosys():
                          ])
 def test_pdf_integration_normsys(backend):
     pyhf.set_backend(backend)
+    if isinstance(pyhf.tensorlib, pyhf.tensor.tensorflow_backend):
+        tf.reset_default_graph()
+        pyhf.tensorlib.session = tf.Session()
     schema = json.load(open('validation/spec.json'))
     source = json.load(open('validation/data/2bin_histosys_example2.json'))
     spec = {

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -4,6 +4,7 @@ import pyhf.simplemodels
 import numpy as np
 import json
 import jsonschema
+import tensorflow as tf
 
 def test_numpy_pdf_inputs():
     source = {
@@ -173,7 +174,20 @@ def test_pdf_integration_histosys():
     assert pdf.expected_data(pars, include_auxdata = False).tolist() == [ 98+30,100+95]
 
 
-def test_pdf_integration_normsys():
+@pytest.mark.parametrize('backend',
+                         [
+                             pyhf.tensor.numpy_backend(poisson_from_normal=True),
+                             pyhf.tensor.tensorflow_backend(session=tf.Session()),
+                             pyhf.tensor.pytorch_backend(poisson_from_normal=True),
+                             # pyhf.tensor.mxnet_backend(),
+                         ],
+                         ids=[
+                             'numpy',
+                             'tensorflow',
+                             'pytorch',
+                         ])
+def test_pdf_integration_normsys(backend):
+    pyhf.set_backend(backend)
     schema = json.load(open('validation/spec.json'))
     source = json.load(open('validation/data/2bin_histosys_example2.json'))
     spec = {
@@ -204,13 +218,13 @@ def test_pdf_integration_normsys():
 
     pars = [None,None]
     pars[pdf.config.par_slice('mu')], pars[pdf.config.par_slice('bkg_norm')] = [[0.0], [0.0]]
-    assert pdf.expected_data(pars, include_auxdata = False).tolist()   == [100,150]
+    assert np.allclose(pyhf.tensorlib.tolist(pdf.expected_data(pars, include_auxdata = False)),[100,150])
 
     pars[pdf.config.par_slice('mu')], pars[pdf.config.par_slice('bkg_norm')] = [[0.0], [1.0]]
-    assert pdf.expected_data(pars, include_auxdata = False).tolist()   == [100*1.1,150*1.1]
+    assert np.allclose(pyhf.tensorlib.tolist(pdf.expected_data(pars, include_auxdata = False)),[100*1.1,150*1.1])
 
     pars[pdf.config.par_slice('mu')], pars[pdf.config.par_slice('bkg_norm')] = [[0.0], [-1.0]]
-    assert pdf.expected_data(pars, include_auxdata = False).tolist()   == [100*0.9,150*0.9]
+    assert np.allclose(pyhf.tensorlib.tolist(pdf.expected_data(pars, include_auxdata = False)),[100*0.9,150*0.9])
 
 def test_pdf_integration_shapesys():
     schema = json.load(open('validation/spec.json'))


### PR DESCRIPTION
# Description

Normsys was not working for PyTorch #144  because PyTorch does not have scalar types (as opposed to numpy) and we didn't catch this in our tests.


This PR:

* adds a test that would have caught this
* adds a fix for the test (make sure the at_minus, at_plus etc are added as shape = (1,) tensors and that in the pdf evaluation the widths is also a (1,) tensor

# Checklist Before Requesting Approver

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
