### PR TITLE
Install pyhf from master to get notebooks to run on binder

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -85,7 +85,6 @@ dependencies:
   - ptyprocess>=0.5.2
   - py>=1.5.2
   - pygments>=2.2.0
-  - pyhf>=0.0.8
   - pyparsing>=2.2.0
   - pytest>=3.4.0
   - pytest-cov>=2.5.1

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -85,7 +85,7 @@ dependencies:
   - ptyprocess>=0.5.2
   - py>=1.5.2
   - pygments>=2.2.0
-  - pyhf>=0.0.4
+  - pyhf>=0.0.8
   - pyparsing>=2.2.0
   - pytest>=3.4.0
   - pytest-cov>=2.5.1

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,1 @@
+pip install .


### PR DESCRIPTION
# Description

I have observed that currently on binder, I get the following error in various locations.  For example, this code block in `ShapeFactor.ipynb` on binder: 

```
import json

source = {
  "channels": {
    "signal": {
      "binning": [2,-0.5,1.5],
      "bindata": {
        "data":     [220.0, 230.0],
        "bkg1":     [100.0, 70.0],
        "sig":      [ 20.0, 20.0]
      }
    },
    "control": {
      "binning": [2,-0.5,1.5],
      "bindata": {
        "data":    [200.0, 300.0],
        "bkg1":    [100.0, 100.0]
      }
    }
  }
}

d,pdf = prep_data(source['channels'])

print (d)

init_pars = pdf.config.suggested_init()


print (pdf.expected_data(init_pars))

par_bounds = pdf.config.suggested_bounds()

# unconpars = pyhf.unconstrained_bestfit(d,pdf,init_pars,par_bounds)
# print ('UNCON',unconpars)

# conpars = pyhf.constrained_bestfit(0.0,d,pdf,init_pars,par_bounds)
# print ('CONS', conpars)

# pdf.expected_data(conpars)
```
returns:

```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-3-2b449209ab35> in <module>()
     21 }
     22 
---> 23 d,pdf = prep_data(source['channels'])
     24 
     25 print (d)

<ipython-input-2-743a6f76e3d1> in prep_data(sourcedata)
     51         ]
     52     }
---> 53     pdf  = hfpdf(spec)
     54     data = []
     55     for c in pdf.spec['channels']:

/srv/conda/lib/python3.6/site-packages/pyhf/__init__.py in __init__(self, spec, **config_kwargs)
    255 class hfpdf(object):
    256     def __init__(self, spec, **config_kwargs):
--> 257         self.config = modelconfig.from_spec(spec,**config_kwargs)
    258         self.channels = spec
    259 

/srv/conda/lib/python3.6/site-packages/pyhf/__init__.py in from_spec(cls, spec, poiname)
    137         for ch, samples in spec.items():
    138             instance.channel_order.append(ch)
--> 139             for sample, sample_def in samples.items():
    140                 for mod_def in sample_def['mods']:
    141                     instance.add_mod_from_def(ch, sample, sample_def, mod_def)

AttributeError: 'list' object has no attribute 'items'

```

Using the master version of `pyhf` makes the error go away.  As a result, my fork takes out `pyhf` from `binder/environment.yml` and calls `pip install .` in `binder/postBuild`.  I'd appreciate suggestions or alternative methods to resolve the error on binder.

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
