### PR TITLE
Fix headings of histogrammar notebook

### DIFF
--- a/docs/examples/notebooks/histogrammar.ipynb
+++ b/docs/examples/notebooks/histogrammar.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 111,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 112,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 113,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 114,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -82,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 115,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -105,12 +105,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Creating a Statistical model based on the Histograms (HistFactory)"
+    "## Creating a Statistical model based on the Histograms (HistFactory)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 116,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -126,7 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 117,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 118,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -169,7 +169,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 119,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,7 +193,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 120,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -216,7 +216,7 @@
        " 'obs': 1.2330688941880004}"
       ]
      },
-     "execution_count": 120,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -233,9 +233,10 @@
    ],
    "source": [
     "mutests = np.linspace(0,5,51)\n",
-    "tests = [runOnePoint(muTest,data,p,p.config.suggested_init(),p.config.suggested_bounds())[-2:] for muTest in mutests]\n",
-    "cls_obs = [test[0]  for test in tests]\n",
-    "cls_exp = [[test[1][i]  for test in tests] for i in range(5)]\n",
+    "tests = [runOnePoint(muTest, data, p, p.config.suggested_init(), p.config.suggested_bounds())[-2:] \n",
+    "         for muTest in mutests]\n",
+    "cls_obs = [test[0] for test in tests]\n",
+    "cls_exp = [[test[1][i] for test in tests] for i in range(5)]\n",
     "\n",
     "plot_results(mutests, cls_obs, cls_exp)\n",
     "invert_interval(mutests, cls_obs, cls_exp)"


### PR DESCRIPTION
Resolves #166 

If a notebook has multiple first level headings Sphinx will think that it should create a separate nav bar level entry for it, treating it like its own notebook. This enforces a single first level heading.

This is what the fix should look like:
![histogrammar_fix](https://user-images.githubusercontent.com/5142394/39967624-20f00274-56bf-11e8-85bb-3a94273ce687.png)


# Checklist Before Requesting Approver

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
