### PR TITLE
Add Binder example notebook to docs examples

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -94,7 +94,7 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', '**.ipynb_checkpoints', 'examples/experiments', 'examples/notebooks/binderexample']
+exclude_patterns = ['_build', '**.ipynb_checkpoints', 'examples/experiments']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -12,6 +12,7 @@ Notebooks:
    :maxdepth: 2
 
    examples/notebooks/binderexample/StatisticalAnalysis.ipynb
+   examples/notebooks/Recast.ipynb
    examples/notebooks/ShapeFactor.ipynb
    examples/notebooks/StatError.ipynb
    examples/notebooks/example-mxnet.ipynb

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -6,6 +6,7 @@ Notebooks:
 .. toctree::
    :maxdepth: 2
 
+   examples/notebooks/binderexample/StatisticalAnalysis.ipynb
    examples/notebooks/ShapeFactor.ipynb
    examples/notebooks/StatError.ipynb
    examples/notebooks/example-mxnet.ipynb

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1,6 +1,11 @@
 Examples
 ========
 
+Try out in Binder! |Binder|
+
+.. |Binder| image:: https://mybinder.org/badge.svg
+    :target: https://mybinder.org/v2/gh/diana-hep/pyhf/master?filepath=docs%2Fexamples%2Fnotebooks%2Fbinderexample%2FStatisticalAnalysis.ipynb
+
 Notebooks:
 
 .. toctree::


### PR DESCRIPTION
Resolves #173 

This is what the docs look like with the addition of the Binder example
![examples_with_pr](https://user-images.githubusercontent.com/5142394/40012007-b1f2d6d0-57a9-11e8-97a2-e6e8bc54846d.png)

It should be noted that the interactive plotting doesn't display (as expected as these are static pages) but I don't think that is a big enough detractor from the high quality of the notebook to keep it out of the docs.

- [x] Also add in the [RECAST example notebook](https://github.com/diana-hep/pyhf/blob/master/docs/examples/notebooks/Recast.ipynb) to the docs examples TOC

# Checklist Before Requesting Approver

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
