### PR TITLE
better default options

### DIFF
--- a/pyhf/__init__.py
+++ b/pyhf/__init__.py
@@ -380,7 +380,33 @@ def pvals_from_teststat(sqrtqmu_v, sqrtqmuA_v):
     return CLsb, CLb, CLs
 
 
-def runOnePoint(muTest, data, pdf, init_pars, par_bounds):
+def runOnePoint(muTest, data, pdf, init_pars = None, par_bounds = None):
+    r"""
+    Computes test statistics (and expected statistics) for a single value
+    of the parameter of interest
+
+    Args:
+        muTest (Number or Tensor): The value of the parameter of interest (POI)
+        data (Number or Tensor): The root of the calculated test statistic given the Asimov data, :math:`\sqrt{q_{\mu,A}}`
+        init_pars (Array or Tensor): the initial parameter values to be used for minimization
+        par_bounds (Array or Tensor): the parameter value bounds to be used for minimization
+
+    Returns:
+        Tuple of Floats: a tuple containing (qmu, qmu_A, CLsb, CLb, CLs, CLs_exp)
+                         where qmu and qmu_A are the test statistics for the
+                         observerd and asimov datasets respectivleyself.
+                         CLsb, CLb are the signal + background and background-only p-values
+                         CLs is the modified p-value
+                         CLs_exp is a 5-tuple of expected CLs values at percentiles
+                         of the background-only test-statistics corresponding to
+                         percentiles of the normal distribution for
+                         (-2,-1,0,1,2) :math:`\sigma`
+    """
+
+    init_pars = init_pars or pdf.config.suggested_init()
+    par_bounds = par_bounds or pdf.config.suggested_bounds()
+
+
     asimov_mu = 0.
     asimov_data = generate_asimov_data(
         asimov_mu, data, pdf, init_pars, par_bounds)

--- a/pyhf/__init__.py
+++ b/pyhf/__init__.py
@@ -394,7 +394,7 @@ def runOnePoint(muTest, data, pdf, init_pars = None, par_bounds = None):
     Returns:
         Tuple of Floats: a tuple containing (qmu, qmu_A, CLsb, CLb, CLs, CLs_exp)
                          where qmu and qmu_A are the test statistics for the
-                         observerd and asimov datasets respectivleyself.
+                         observed and Asimov datasets respectively.
                          CLsb, CLb are the signal + background and background-only p-values
                          CLs is the modified p-value
                          CLs_exp is a 5-tuple of expected CLs values at percentiles


### PR DESCRIPTION
# Description

This adds some sane defaults for init and par bounds since we have access to the pdf config in the function anyways.

One could also think about automatically extending the data with the aux measurements, since right now we have this pattern

```
obs_data = [...]
pyhf.runOnePoint(1.0, obs_data + pdf.config.auxdata, pdf ...)
```

which could be handled for the user as well to be



```
obs_data = [...]
pyhf.runOnePoint(1.0, obs_data, pdf, ...)
```


 but either we make this automatic / "smart" or the default would change, which would be backward-compat. breaking (requiring a modification of notebooks etc)

# Checklist Before Requesting Approver

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
