### PR TITLE
add bib for adding talks to documentation

### DIFF
--- a/docs/bib/talks.bib
+++ b/docs/bib/talks.bib
@@ -1,0 +1,10 @@
+@unpublished{Heinrich20180515,
+  title  = {pyhf: A standalone HistFactory Implementation},
+  author = {Lukas Heinrich},
+  year   = {2018},
+  month  = {May},
+  day    = {5},
+  note   = {(Re)interpreting the results of new physics searches at the LHC Workshop},
+  organization = {CERN},
+  url    = {https://indico.cern.ch/event/702612/contributions/2958658/},
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,6 +37,7 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
     'sphinx.ext.githubpages',
+    'sphinxcontrib.bibtex',
     'sphinxcontrib.napoleon',
     'nbsphinx',
 ]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@ Contents:
    :maxdepth: 2
 
    examples
+   talks
    api
 
 Indices and tables

--- a/docs/talks.rst
+++ b/docs/talks.rst
@@ -1,0 +1,10 @@
+Presentations
+=============
+
+This list will be updated with talks given on `pyhf`:
+
+.. bibliography:: bib/talks.bib
+   :list: bullet
+   :all:
+   :style: plain
+

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
        'mxnet>=1.0.0',
        'graphviz',
        'sphinx',
+       'sphinxcontrib-bibtex',
        'sphinxcontrib-napoleon',
        'sphinx_rtd_theme',
        'nbsphinx',


### PR DESCRIPTION
# Description

This PR will use a sphinxcontrib for bibtex so that talks can be added using a `docs/bib/talks.bib` file and inserted in the documentation. This closes #178.

# Checklist Before Requesting Approver

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
