### PR TITLE
bugfix: docs duplicated methods

### DIFF
--- a/docs/_templates/modifierclass.rst
+++ b/docs/_templates/modifierclass.rst
@@ -1,4 +1,4 @@
-{{ fullname | escape | underline}}
+{{ name | escape | underline}}
 
 .. currentmodule:: {{ module }}
 

--- a/docs/_templates/modifierclass.rst
+++ b/docs/_templates/modifierclass.rst
@@ -3,8 +3,6 @@
 .. currentmodule:: {{ module }}
 
 .. autoclass:: {{ name }}
-   :members:
-   :inherited-members:
    :show-inheritance:
 
    {% block attributes %}

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4,6 +4,8 @@ API
 Top-Level
 ---------
 
+.. note:: These are generally uncategorized.
+
 .. currentmodule:: pyhf
 
 .. autosummary::
@@ -25,6 +27,8 @@ Top-Level
 
 Backends
 --------
+
+The computational backends that `pyhf` provides interfacing for the vector-based calculations.
 
 .. currentmodule:: pyhf.tensor
 
@@ -71,6 +75,8 @@ Modifiers
 
 Exceptions
 ----------
+
+Various exceptions, apart from standard python exceptions, that are raised from using the `pyhf` API.
 
 .. currentmodule:: pyhf.exceptions
 


### PR DESCRIPTION
# Description

Fixes #169 and improves documentation a bit more. Duplicated methods were showing because of the `autoclass` and the `autosummary` conflicting with each other in the template we use. This is now cleaned up and also improved. Titles of generated API documentation pages are less verbose and exclude the package/module name as it is not needed at first glance.

# Checklist Before Requesting Approver

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
