### PR TITLE
Feature: spec validation on init, update logging, add staterror to schema

### DIFF
--- a/pyhf/__init__.py
+++ b/pyhf/__init__.py
@@ -1,8 +1,11 @@
 import logging
+logging.basicConfig()
+import pkg_resources
 
 import pyhf.optimize as optimize
 import pyhf.tensor as tensor
 from . import exceptions
+from . import utils
 
 log = logging.getLogger(__name__)
 tensorlib = tensor.numpy_backend()
@@ -153,8 +156,10 @@ class modelconfig(object):
 
 class hfpdf(object):
     def __init__(self, spec, **config_kwargs):
-        self.config = modelconfig.from_spec(spec,**config_kwargs)
         self.spec = spec
+        self.schema = config_kwargs.get('schema', pkg_resources.resource_filename(__name__,'../validation/spec.json'))
+        utils.validate(self.spec, self.schema)
+        self.config = modelconfig.from_spec(spec,**config_kwargs)
 
     def expected_sample(self, channel, sample, pars):
         """

--- a/pyhf/__init__.py
+++ b/pyhf/__init__.py
@@ -1,5 +1,4 @@
 import logging
-logging.basicConfig()
 import pkg_resources
 
 import pyhf.optimize as optimize

--- a/pyhf/__init__.py
+++ b/pyhf/__init__.py
@@ -1,5 +1,4 @@
 import logging
-import pkg_resources
 
 import pyhf.optimize as optimize
 import pyhf.tensor as tensor
@@ -156,7 +155,7 @@ class modelconfig(object):
 class hfpdf(object):
     def __init__(self, spec, **config_kwargs):
         self.spec = spec
-        self.schema = config_kwargs.get('schema', pkg_resources.resource_filename(__name__,'data/spec.json'))
+        self.schema = config_kwargs.get('schema', utils.get_default_schema())
         utils.validate(self.spec, self.schema)
         self.config = modelconfig.from_spec(spec,**config_kwargs)
 

--- a/pyhf/__init__.py
+++ b/pyhf/__init__.py
@@ -156,7 +156,7 @@ class modelconfig(object):
 class hfpdf(object):
     def __init__(self, spec, **config_kwargs):
         self.spec = spec
-        self.schema = config_kwargs.get('schema', pkg_resources.resource_filename(__name__,'../validation/spec.json'))
+        self.schema = config_kwargs.get('schema', pkg_resources.resource_filename(__name__,'data/spec.json'))
         utils.validate(self.spec, self.schema)
         self.config = modelconfig.from_spec(spec,**config_kwargs)
 

--- a/pyhf/__init__.py
+++ b/pyhf/__init__.py
@@ -65,6 +65,9 @@ def set_backend(backend):
         optimizer = optimize.scipy_optimizer()
 
 class modelconfig(object):
+    # set up the logging using the name of this class
+    log = logging.getLogger('.'.join([__name__, 'modelconfig']))
+
     @classmethod
     def from_spec(cls,spec,poiname = 'mu'):
         # hacky, need to keep track in which order we added the constraints
@@ -79,6 +82,7 @@ class modelconfig(object):
         return instance
 
     def __init__(self):
+        # set up all other bookkeeping variables
         self.poi_index = None
         self.par_map = {}
         self.par_order = []
@@ -127,19 +131,19 @@ class modelconfig(object):
         try:
             modifier_cls = modifiers.registry[modifier_def['type']]
         except KeyError:
-            log.exception('Modifier type not implemented yet (processing {0:s}). Current modifier types: {1}'.format(modifier_def['type'], modifiers.registry.keys()))
+            self.log.exception('Modifier type not implemented yet (processing {0:s}). Current modifier types: {1}'.format(modifier_def['type'], modifiers.registry.keys()))
             raise exceptions.InvalidModifier()
 
         # if modifier is shared, check if it already exists and use it
         if modifier_cls.is_shared and modifier_def['name'] in self.par_map:
-            log.info('using existing shared, {0:s}constrained modifier (name={1:s}, type={2:s})'.format('' if modifier_cls.is_constrained else 'un', modifier_def['name'], modifier_cls.__name__))
+            self.log.info('using existing shared, {0:s}constrained modifier (name={1:s}, type={2:s})'.format('' if modifier_cls.is_constrained else 'un', modifier_def['name'], modifier_cls.__name__))
             return self.par_map[modifier_def['name']]['modifier']
 
         # did not return, so create new modifier and return it
         modifier = modifier_cls(sample['data'], modifier_def['data'])
         npars = modifier.n_parameters
 
-        log.info('adding modifier %s (%s new nuisance parameters)', modifier_def['name'], npars)
+        self.log.info('adding modifier %s (%s new nuisance parameters)', modifier_def['name'], npars)
         sl = slice(self.next_index, self.next_index + npars)
         self.next_index = self.next_index + npars
         self.par_order.append(modifier_def['name'])
@@ -153,10 +157,16 @@ class modelconfig(object):
         return modifier
 
 class hfpdf(object):
+    # set up the logging using the name of this class
+    log = logging.getLogger('.'.join([__name__, 'hfpdf']))
+
     def __init__(self, spec, **config_kwargs):
         self.spec = spec
         self.schema = config_kwargs.get('schema', utils.get_default_schema())
+        # run jsonschema validation of input specification against the (provided) schema
+        self.log.info("Validating spec against schema: {0:s}".format(self.schema))
         utils.validate(self.spec, self.schema)
+        # build up our representation of the specification
         self.config = modelconfig.from_spec(spec,**config_kwargs)
 
     def expected_sample(self, channel, sample, pars):

--- a/pyhf/data/spec.json
+++ b/pyhf/data/spec.json
@@ -30,7 +30,8 @@
                             { "$ref": "#/definitions/modifier/normfactor" },
                             { "$ref": "#/definitions/modifier/normsys" },
                             { "$ref": "#/definitions/modifier/shapefactor" },
-                            { "$ref": "#/definitions/modifier/shapesys" }
+                            { "$ref": "#/definitions/modifier/shapesys" },
+                            { "$ref": "#/definitions/modifier/staterror" }
                         ]
                     }
                 }
@@ -84,6 +85,16 @@
                 "properties": {
                     "name": { "type": "string" },
                     "type": { "const": "shapesys" },
+                    "data": { "type": "array", "items": {"type": "number"} }
+                },
+                "required": ["name", "type", "data"],
+                "additionalProperties": false
+            },
+            "staterror": {
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" },
+                    "type": { "const": "staterror" },
                     "data": { "type": "array", "items": {"type": "number"} }
                 },
                 "required": ["name", "type", "data"],

--- a/pyhf/exceptions/__init__.py
+++ b/pyhf/exceptions/__init__.py
@@ -1,3 +1,25 @@
+import sys
+
+class InvalidSpecification(Exception):
+    """
+    InvalidSpecification is raised when a specification does not validate against the given schema.
+    """
+    def __init__(self, ValidationError):
+        self.exc_info = sys.exc_info()
+        self.parent = ValidationError
+        self.path = ''
+        for item in ValidationError.path:
+            if isinstance(item, int):
+                self.path += '[{}]'.format(item)
+            else:
+                self.path += '.{}'.format(item)
+        self.path = self.path.lstrip('.')
+        self.instance = ValidationError.instance
+        message = '{0}.\n\tPath: {1}\n\tInstance: {2}'.format(ValidationError.message, self.path, self.instance)
+        # Call the base class constructor with the parameters it needs
+        super(InvalidSpecification, self).__init__(message)
+
+
 class InvalidModifier(Exception):
     """
     InvalidModifier is raised when an invalid modifier is requested. This includes:

--- a/pyhf/utils.py
+++ b/pyhf/utils.py
@@ -1,0 +1,24 @@
+import json, jsonschema
+
+from .exceptions import InvalidSpecification
+
+SCHEMA_CACHE = {}
+def load_schema(schema):
+  global SCHEMA_CACHE
+  try:
+    return SCHEMA_CACHE[schema]
+  except KeyError:
+    pass
+
+  try:
+    SCHEMA_CACHE[schema] = json.load(open(schema))
+    return SCHEMA_CACHE[schema]
+  except:
+    raise
+
+def validate(spec, schema):
+  schema = load_schema(schema)
+  try:
+    return jsonschema.validate(spec, schema)
+  except jsonschema.ValidationError as err:
+    raise InvalidSpecification(err)

--- a/pyhf/utils.py
+++ b/pyhf/utils.py
@@ -16,11 +16,8 @@ def load_schema(schema):
     except KeyError:
         pass
 
-    try:
-        SCHEMA_CACHE[schema] = json.load(open(schema))
-        return SCHEMA_CACHE[schema]
-    except:
-        raise
+    SCHEMA_CACHE[schema] = json.load(open(schema))
+    return SCHEMA_CACHE[schema]
 
 def validate(spec, schema):
     schema = load_schema(schema)

--- a/pyhf/utils.py
+++ b/pyhf/utils.py
@@ -4,7 +4,7 @@ import pkg_resources
 from .exceptions import InvalidSpecification
 
 def get_default_schema():
-  return pkg_resources.resource_filename(__name__,'data/spec.json')
+    return pkg_resources.resource_filename(__name__,'data/spec.json')
 
 SCHEMA_CACHE = {}
 def load_schema(schema):

--- a/pyhf/utils.py
+++ b/pyhf/utils.py
@@ -1,6 +1,12 @@
 import json, jsonschema
+import pkg_resources
 
 from .exceptions import InvalidSpecification
+
+DEFAULT_SCHEMA = pkg_resources.resource_filename(__name__,'data/spec.json')
+def get_default_schema():
+  global DEFAULT_SCHEMA
+  return DEFAULT_SCHEMA
 
 SCHEMA_CACHE = {}
 def load_schema(schema):

--- a/pyhf/utils.py
+++ b/pyhf/utils.py
@@ -3,10 +3,8 @@ import pkg_resources
 
 from .exceptions import InvalidSpecification
 
-DEFAULT_SCHEMA = pkg_resources.resource_filename(__name__,'data/spec.json')
 def get_default_schema():
-  global DEFAULT_SCHEMA
-  return DEFAULT_SCHEMA
+  return pkg_resources.resource_filename(__name__,'data/spec.json')
 
 SCHEMA_CACHE = {}
 def load_schema(schema):

--- a/pyhf/utils.py
+++ b/pyhf/utils.py
@@ -4,21 +4,21 @@ from .exceptions import InvalidSpecification
 
 SCHEMA_CACHE = {}
 def load_schema(schema):
-  global SCHEMA_CACHE
-  try:
-    return SCHEMA_CACHE[schema]
-  except KeyError:
-    pass
+    global SCHEMA_CACHE
+    try:
+        return SCHEMA_CACHE[schema]
+    except KeyError:
+        pass
 
-  try:
-    SCHEMA_CACHE[schema] = json.load(open(schema))
-    return SCHEMA_CACHE[schema]
-  except:
-    raise
+    try:
+        SCHEMA_CACHE[schema] = json.load(open(schema))
+        return SCHEMA_CACHE[schema]
+    except:
+        raise
 
 def validate(spec, schema):
-  schema = load_schema(schema)
-  try:
-    return jsonschema.validate(spec, schema)
-  except jsonschema.ValidationError as err:
-    raise InvalidSpecification(err)
+    schema = load_schema(schema)
+    try:
+        return jsonschema.validate(spec, schema)
+    except jsonschema.ValidationError as err:
+        raise InvalidSpecification(err)

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
        'sphinx_rtd_theme',
        'nbsphinx',
        'jsonpatch',
-       'jsonschema>=2.6.0'
+       'jsonschema==v3.0.0a2'  # alpha-release for draft 6
     ]
   },
   entry_points = {

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -2,7 +2,6 @@ import pyhf
 import pyhf.readxml
 import json
 import pytest
-import pkg_resources
 
 def test_import_prepHistFactory():
     parsed_xml = pyhf.readxml.parse('validation/xmlimport_input/config/example.xml',

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,21 +1,15 @@
 import pyhf
 import pyhf.readxml
 import json
-import jsonschema
 import pytest
-import pkg_resources 
+import pkg_resources
 
-@pytest.fixture(scope='module')
-def schema():
-    return json.load(open(pkg_resources.resource_filename('pyhf','data/spec.json')))
-
-def test_import_prepHistFactory(schema):
+def test_import_prepHistFactory():
     parsed_xml = pyhf.readxml.parse('validation/xmlimport_input/config/example.xml',
                               'validation/xmlimport_input/')
 
     # build the spec, strictly checks properties included
     spec = {'channels': parsed_xml['channels']}
-    jsonschema.validate(spec, schema)
     pdf = pyhf.hfpdf(spec, poiname='SigXsecOverSM')
 
     data = [binvalue for k in pdf.spec['channels'] for binvalue
@@ -44,13 +38,12 @@ def test_import_prepHistFactory(schema):
     assert pdf.expected_data(
         pars, include_auxdata=False).tolist() == [140, 120]
 
-def test_import_histosys(schema):
+def test_import_histosys():
     parsed_xml = pyhf.readxml.parse('validation/xmlimport_input2/config/example.xml',
                               'validation/xmlimport_input2')
 
     # build the spec, strictly checks properties included
     spec = {'channels': parsed_xml['channels']}
-    jsonschema.validate(spec, schema)
     pdf = pyhf.hfpdf(spec, poiname='SigXsecOverSM')
 
     data = [binvalue for k in pdf.spec['channels'] for binvalue

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -103,27 +103,6 @@ def test_pdf_integration_staterror():
     for c,e in zip(computed,expected):
         assert c==e
 
-def test_add_unknown_modifier():
-    spec = {
-        'channels': [
-            {
-                'name': 'channel',
-                'samples': [
-                    {
-                        'name': 'ttbar',
-                        'data': [1],
-                        'modifiers': [
-                            {'name': 'a_name', 'type': 'this_should_not_exist', 'data': [1]}
-                        ]
-                    },
-                ]
-            }
-        ]
-    }
-    with pytest.raises(pyhf.exceptions.InvalidSpecification):
-        pyhf.hfpdf(spec)
-
-
 def test_pdf_integration_histosys():
     source = json.load(open('validation/data/2bin_histosys_example2.json'))
     spec = {

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -4,7 +4,6 @@ import pyhf.simplemodels
 import numpy as np
 import json
 import tensorflow as tf
-import pkg_resources
 
 def test_numpy_pdf_inputs():
     source = {

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -3,13 +3,8 @@ import pytest
 import pyhf.simplemodels
 import numpy as np
 import json
-import jsonschema
 import tensorflow as tf
 import pkg_resources
-
-@pytest.fixture(scope='module')
-def schema():
-    return json.load(open(pkg_resources.resource_filename('pyhf','data/spec.json')))
 
 def test_numpy_pdf_inputs():
     source = {
@@ -112,22 +107,24 @@ def test_add_unknown_modifier():
     spec = {
         'channels': [
             {
-                'name': 'channe',
+                'name': 'channel',
                 'samples': [
                     {
+                        'name': 'ttbar',
+                        'data': [1],
                         'modifiers': [
-                            {'name': 'a_name', 'type': 'this_should_not_exist', 'data': None}
+                            {'name': 'a_name', 'type': 'this_should_not_exist', 'data': [1]}
                         ]
                     },
                 ]
             }
         ]
     }
-    with pytest.raises(pyhf.exceptions.InvalidModifier):
+    with pytest.raises(pyhf.exceptions.InvalidSpecification):
         pyhf.hfpdf(spec)
 
 
-def test_pdf_integration_histosys(schema):
+def test_pdf_integration_histosys():
     source = json.load(open('validation/data/2bin_histosys_example2.json'))
     spec = {
         'channels': [
@@ -152,7 +149,6 @@ def test_pdf_integration_histosys(schema):
             }
         ]
     }
-    jsonschema.validate(spec, schema)
     pdf  = pyhf.hfpdf(spec)
 
 
@@ -190,7 +186,7 @@ def test_pdf_integration_histosys(schema):
                              'tensorflow',
                              'pytorch',
                          ])
-def test_pdf_integration_normsys(backend,schema):
+def test_pdf_integration_normsys(backend):
     pyhf.set_backend(backend)
     if isinstance(pyhf.tensorlib, pyhf.tensor.tensorflow_backend):
         tf.reset_default_graph()
@@ -219,7 +215,6 @@ def test_pdf_integration_normsys(backend,schema):
             }
         ]
     }
-    jsonschema.validate(spec, schema)
     pdf  = pyhf.hfpdf(spec)
 
     pars = [None,None]
@@ -232,7 +227,7 @@ def test_pdf_integration_normsys(backend,schema):
     pars[pdf.config.par_slice('mu')], pars[pdf.config.par_slice('bkg_norm')] = [[0.0], [-1.0]]
     assert np.allclose(pyhf.tensorlib.tolist(pdf.expected_data(pars, include_auxdata = False)),[100*0.9,150*0.9])
 
-def test_pdf_integration_shapesys(schema):
+def test_pdf_integration_shapesys():
     source = json.load(open('validation/data/2bin_histosys_example2.json'))
     spec = {
         'channels': [
@@ -257,7 +252,6 @@ def test_pdf_integration_shapesys(schema):
             }
         ]
     }
-    jsonschema.validate(spec, schema)
     pdf  = pyhf.hfpdf(spec)
 
 

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -251,3 +251,23 @@ def test_pdf_integration_shapesys():
 
     pars[pdf.config.par_slice('mu')], pars[pdf.config.par_slice('bkg_norm')] = [[0.0], [0.9,1.1]]
     assert pdf.expected_data(pars, include_auxdata = False).tolist()   == [100*0.9,150*1.1]
+
+def test_invalid_modifier():
+    spec = {
+        'channels': [
+            {
+                'name': 'channel',
+                'samples': [
+                    {
+                        'name': 'ttbar',
+                        'data': [1],
+                        'modifiers': [
+                            {'name': 'a_name', 'type': 'this_should_not_exist', 'data': [1]}
+                        ]
+                    },
+                ]
+            }
+        ]
+    }
+    with pytest.raises(pyhf.exceptions.InvalidModifier):
+        pyhf.modelconfig.from_spec(spec)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,5 +1,14 @@
 import pyhf
 import pytest
+import os
+import json
+import pkg_resources
+
+def test_schema_access():
+    assert os.isfile(pkg_resources.resource_filename('pyhf','data/spec.json'))
+
+def test_schema_access():
+    assert json.load(open(pkg_resources.resource_filename('pyhf','data/spec.json')))
 
 def test_missing_sample_name():
     spec = {

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,14 +1,5 @@
 import pyhf
 import pytest
-import os
-import json
-import pkg_resources
-
-def test_schema_access():
-    assert os.isfile(pkg_resources.resource_filename('pyhf','data/spec.json'))
-
-def test_schema_access():
-    assert json.load(open(pkg_resources.resource_filename('pyhf','data/spec.json')))
 
 def test_missing_sample_name():
     spec = {

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,39 @@
+import pyhf
+import pytest
+
+def test_missing_sample_name():
+    spec = {
+        'channels': [
+            {
+                'name': 'channel',
+                'samples': [
+                    {
+                        'data': [1],
+                        'modifiers': []
+                    },
+                ]
+            }
+        ]
+    }
+    with pytest.raises(pyhf.exceptions.InvalidSpecification):
+        pyhf.hfpdf(spec)
+
+def test_add_unknown_modifier():
+    spec = {
+        'channels': [
+            {
+                'name': 'channel',
+                'samples': [
+                    {
+                        'name': 'ttbar',
+                        'data': [1],
+                        'modifiers': [
+                            {'name': 'a_name', 'type': 'this_should_not_exist', 'data': [1]}
+                        ]
+                    },
+                ]
+            }
+        ]
+    }
+    with pytest.raises(pyhf.exceptions.InvalidSpecification):
+        pyhf.hfpdf(spec)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,18 @@
+import pyhf
+import pytest
+import os
+
+def test_get_default_schema():
+    assert os.path.isfile(pyhf.utils.get_default_schema())
+
+def test_load_default_schema():
+    assert pyhf.utils.load_schema(pyhf.utils.get_default_schema())
+
+def test_load_missing_schema():
+    with pytest.raises(IOError):
+        pyhf.utils.load_schema('a/fake/path/that/should/not/work.json')
+
+def test_load_custom_schema(tmpdir):
+    temp = tmpdir.join("custom_schema.json")
+    temp.write('{"foo": "bar"}')
+    assert pyhf.utils.load_schema(temp.strpath)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,8 +1,6 @@
 import pyhf
-
 import json
 import pytest
-import pkg_resources
 
 @pytest.fixture(scope='module')
 def source_1bin_example1():
@@ -692,7 +690,4 @@ def test_validation(setup):
         setup['expected']['config']['par_bounds']
 
     validate_runOnePoint(pdf, data, setup['mu'], setup['expected']['result'])
-
-def test_schema_access():
-    json.load(open(pkg_resources.resource_filename('pyhf','data/spec.json')))
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,7 +1,6 @@
 import pyhf
 
 import json
-import jsonschema
 import pytest
 import pkg_resources
 
@@ -11,11 +10,7 @@ def source_1bin_example1():
 
 
 @pytest.fixture(scope='module')
-def schema():
-    return json.load(open(pkg_resources.resource_filename('pyhf','data/spec.json')))
-
-@pytest.fixture(scope='module')
-def spec_1bin_shapesys(schema, source=source_1bin_example1()):
+def spec_1bin_shapesys(source=source_1bin_example1()):
     spec = {
         'channels': [
             {
@@ -47,7 +42,6 @@ def spec_1bin_shapesys(schema, source=source_1bin_example1()):
             }
         ]
     }
-    jsonschema.validate(spec, schema)
     return spec
 
 
@@ -98,7 +92,7 @@ def source_1bin_normsys():
 
 
 @pytest.fixture(scope='module')
-def spec_1bin_normsys(schema, source=source_1bin_normsys()):
+def spec_1bin_normsys(source=source_1bin_normsys()):
     spec = {
         'channels': [
             {
@@ -130,7 +124,6 @@ def spec_1bin_normsys(schema, source=source_1bin_normsys()):
             }
         ]
     }
-    jsonschema.validate(spec, schema)
     return spec
 
 
@@ -173,7 +166,7 @@ def source_2bin_histosys_example2():
 
 
 @pytest.fixture(scope='module')
-def spec_2bin_histosys(schema, source=source_2bin_histosys_example2()):
+def spec_2bin_histosys(source=source_2bin_histosys_example2()):
     spec = {
         'channels': [
             {
@@ -208,7 +201,6 @@ def spec_2bin_histosys(schema, source=source_2bin_histosys_example2()):
             }
         ]
     }
-    jsonschema.validate(spec, schema)
     return spec
 
 
@@ -252,7 +244,7 @@ def source_2bin_2channel_example1():
 
 
 @pytest.fixture(scope='module')
-def spec_2bin_2channel(schema, source=source_2bin_2channel_example1()):
+def spec_2bin_2channel(source=source_2bin_2channel_example1()):
     spec = {
         'channels': [
             {
@@ -300,7 +292,6 @@ def spec_2bin_2channel(schema, source=source_2bin_2channel_example1()):
             }
         ]
     }
-    jsonschema.validate(spec, schema)
     return spec
 
 
@@ -345,7 +336,7 @@ def source_2bin_2channel_couplednorm():
 
 
 @pytest.fixture(scope='module')
-def spec_2bin_2channel_couplednorm(schema, source=source_2bin_2channel_couplednorm()):
+def spec_2bin_2channel_couplednorm(source=source_2bin_2channel_couplednorm()):
     spec = {
         'channels': [
             {
@@ -404,7 +395,6 @@ def spec_2bin_2channel_couplednorm(schema, source=source_2bin_2channel_coupledno
             }
         ]
     }
-    jsonschema.validate(spec, schema)
     return spec
 
 
@@ -450,7 +440,7 @@ def source_2bin_2channel_coupledhisto():
 
 
 @pytest.fixture(scope='module')
-def spec_2bin_2channel_coupledhistosys(schema, source=source_2bin_2channel_coupledhisto()):
+def spec_2bin_2channel_coupledhistosys(source=source_2bin_2channel_coupledhisto()):
     spec = {
         'channels': [
             {
@@ -518,7 +508,6 @@ def spec_2bin_2channel_coupledhistosys(schema, source=source_2bin_2channel_coupl
             }
         ]
     }
-    jsonschema.validate(spec, schema)
     return spec
 
 
@@ -564,7 +553,7 @@ def source_2bin_2channel_coupledshapefactor():
 
 
 @pytest.fixture(scope='module')
-def spec_2bin_2channel_coupledshapefactor(schema, source=source_2bin_2channel_coupledshapefactor()):
+def spec_2bin_2channel_coupledshapefactor(source=source_2bin_2channel_coupledshapefactor()):
     spec = {
         'channels': [
             {
@@ -612,7 +601,6 @@ def spec_2bin_2channel_coupledshapefactor(schema, source=source_2bin_2channel_co
             }
         ]
     }
-    jsonschema.validate(spec, schema)
     return spec
 
 

--- a/validation/spec.json
+++ b/validation/spec.json
@@ -1,1 +1,0 @@
-pyhf/data/spec.json


### PR DESCRIPTION
# Description

This resolves #118. This adds specification validation to `hfpdf.__init__()` calls. This will simplify the tests used throughout, and all testing relevant to making sure the schema validation catches common pitfalls is being separated into `tests/test_schema.py` (for want of a better name).

This also sets up class-specific logging functionality to help filter out the logging a bit better as well in the future.

Also adds `staterror` to schema -- somehow missed this.

# Checklist Before Requesting Approver

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
