### PR TITLE
fix benchmark tests

### DIFF
--- a/tests/benchmarks/test_benchmark.py
+++ b/tests/benchmarks/test_benchmark.py
@@ -69,9 +69,9 @@ def runOnePoint(pdf, data):
         tf.reset_default_graph()
         pyhf.tensorlib.session = tf.Session()
 
-    return pyhf.runOnePoint(1.0, data, pdf,
-                            pdf.config.suggested_init(),
-                            pdf.config.suggested_bounds())
+    return pyhf.utils.runOnePoint(1.0, data, pdf,
+                                  pdf.config.suggested_init(),
+                                  pdf.config.suggested_bounds())
 
 
 # bins = [1, 10, 50, 100, 200, 500, 800, 1000]


### PR DESCRIPTION
# Description

The current master is breaking because of #193 moving `runOnePoint` to `utils.py` and forgetting to update the one line in the test for fixing it.

# Checklist Before Requesting Approver

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
