### PR TITLE
Feature: command line parse xml

### DIFF
--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -1,13 +1,16 @@
 import logging
 logging.basicConfig()
+log = logging.getLogger(__name__)
 
 import click
 import json
 from . import readxml
 
 @click.command()
-@click.option('--entrypoint-xml', required=True, prompt='Top-level XML', help='The top-level XML file for the workspace definition.')
-@click.option('--workspace', required=True, prompt='Workspace directory', help='The location of workspace.')
-def xml2json(entrypoint_xml, workspace):
-    spec = readxml(entrypoint_xml, workspace)
-    import pdb; pdb.set_trace()
+@click.option('--entrypoint-xml', required=True, prompt='Top-level XML', help='The top-level XML file for the workspace definition.', type=click.Path(exists=True))
+@click.option('--workspace', required=True, prompt='Workspace directory', help='The location of workspace.', type=click.Path(exists=True))
+@click.option('--output-file', required=True, prompt='Output file', help='The location of the output json file. If not specified, prints to screen.', type=click.Path(exists=False))
+def xml2json(entrypoint_xml, workspace, output_file=None):
+    spec = readxml.parse(entrypoint_xml, workspace, enable_tqdm=True)
+    json.dump(spec, open(output_file, 'w+'), indent=4, sort_keys=True)
+    log.info("Written to {0:s}".format(output_file))

--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -6,7 +6,11 @@ import click
 import json
 from . import readxml
 
-@click.command()
+@click.group(context_settings=dict(help_option_names=['-h', '--help']))
+def pyhf():
+    pass
+
+@pyhf.command()
 @click.option('--entrypoint-xml', required=True, prompt='Top-level XML', help='The top-level XML file for the workspace definition.', type=click.Path(exists=True))
 @click.option('--workspace', required=True, prompt='Workspace directory', help='The location of workspace.', type=click.Path(exists=True))
 @click.option('--output-file', required=True, prompt='Output file', help='The location of the output json file. If not specified, prints to screen.')

--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -10,7 +10,8 @@ from . import readxml
 @click.option('--entrypoint-xml', required=True, prompt='Top-level XML', help='The top-level XML file for the workspace definition.', type=click.Path(exists=True))
 @click.option('--workspace', required=True, prompt='Workspace directory', help='The location of workspace.', type=click.Path(exists=True))
 @click.option('--output-file', required=True, prompt='Output file', help='The location of the output json file. If not specified, prints to screen.')
-def xml2json(entrypoint_xml, workspace, output_file=None):
-    spec = readxml.parse(entrypoint_xml, workspace, enable_tqdm=True)
+@click.option('--tqdm/--no-tqdm', default=True)
+def xml2json(entrypoint_xml, workspace, output_file, tqdm):
+    spec = readxml.parse(entrypoint_xml, workspace, enable_tqdm=tqdm)
     json.dump(spec, open(output_file, 'w+'), indent=4, sort_keys=True)
     log.info("Written to {0:s}".format(output_file))

--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -9,7 +9,7 @@ from . import readxml
 @click.command()
 @click.option('--entrypoint-xml', required=True, prompt='Top-level XML', help='The top-level XML file for the workspace definition.', type=click.Path(exists=True))
 @click.option('--workspace', required=True, prompt='Workspace directory', help='The location of workspace.', type=click.Path(exists=True))
-@click.option('--output-file', required=True, prompt='Output file', help='The location of the output json file. If not specified, prints to screen.', type=click.Path(exists=False))
+@click.option('--output-file', required=True, prompt='Output file', help='The location of the output json file. If not specified, prints to screen.')
 def xml2json(entrypoint_xml, workspace, output_file=None):
     spec = readxml.parse(entrypoint_xml, workspace, enable_tqdm=True)
     json.dump(spec, open(output_file, 'w+'), indent=4, sort_keys=True)

--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -14,8 +14,8 @@ def pyhf():
 @click.option('--entrypoint-xml', required=True, prompt='Top-level XML', help='The top-level XML file for the PDF definition.', type=click.Path(exists=True))
 @click.option('--basedir', required=True, prompt='Base directory', help='The base directory for the XML files to point relative to.', type=click.Path(exists=True))
 @click.option('--output-file', required=True, prompt='Output file', help='The location of the output json file. If not specified, prints to screen.')
-@click.option('--tqdm/--no-tqdm', default=True)
-def xml2json(entrypoint_xml, basedir, output_file, tqdm):
-    spec = readxml.parse(entrypoint_xml, basedir, enable_tqdm=tqdm)
+@click.option('--track-progress/--hide-progress', default=True)
+def xml2json(entrypoint_xml, basedir, output_file, track_progress):
+    spec = readxml.parse(entrypoint_xml, basedir, track_progress=track_progress)
     json.dump(spec, open(output_file, 'w+'), indent=4, sort_keys=True)
     log.info("Written to {0:s}".format(output_file))

--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -1,0 +1,13 @@
+import logging
+logging.basicConfig()
+
+import click
+import json
+from . import readxml
+
+@click.command()
+@click.option('--entrypoint-xml', required=True, prompt='Top-level XML', help='The top-level XML file for the workspace definition.')
+@click.option('--workspace', required=True, prompt='Workspace directory', help='The location of workspace.')
+def xml2json(entrypoint_xml, workspace):
+    spec = readxml(entrypoint_xml, workspace)
+    import pdb; pdb.set_trace()

--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -11,11 +11,11 @@ def pyhf():
     pass
 
 @pyhf.command()
-@click.option('--entrypoint-xml', required=True, prompt='Top-level XML', help='The top-level XML file for the workspace definition.', type=click.Path(exists=True))
-@click.option('--workspace', required=True, prompt='Workspace directory', help='The location of workspace.', type=click.Path(exists=True))
+@click.option('--entrypoint-xml', required=True, prompt='Top-level XML', help='The top-level XML file for the PDF definition.', type=click.Path(exists=True))
+@click.option('--basedir', required=True, prompt='Base directory', help='The base directory for the XML files to point relative to.', type=click.Path(exists=True))
 @click.option('--output-file', required=True, prompt='Output file', help='The location of the output json file. If not specified, prints to screen.')
 @click.option('--tqdm/--no-tqdm', default=True)
-def xml2json(entrypoint_xml, workspace, output_file, tqdm):
-    spec = readxml.parse(entrypoint_xml, workspace, enable_tqdm=tqdm)
+def xml2json(entrypoint_xml, basedir, output_file, tqdm):
+    spec = readxml.parse(entrypoint_xml, basedir, enable_tqdm=tqdm)
     json.dump(spec, open(output_file, 'w+'), indent=4, sort_keys=True)
     log.info("Written to {0:s}".format(output_file))

--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -13,11 +13,12 @@ def pyhf():
     pass
 
 @pyhf.command()
-@click.argument('entrypoint-xml', help='The top-level XML file for the PDF definition.', type=click.Path(exists=True))
+@click.argument('entrypoint-xml', type=click.Path(exists=True))
 @click.option('--basedir', help='The base directory for the XML files to point relative to.', type=click.Path(exists=True), default=os.getcwd())
 @click.option('--output-file', help='The location of the output json file. If not specified, prints to screen.', default=None)
 @click.option('--track-progress/--hide-progress', default=True)
 def xml2json(entrypoint_xml, basedir, output_file, track_progress):
+    """ Entrypoint XML: The top-level XML file for the PDF definition. """
     spec = readxml.parse(entrypoint_xml, basedir, track_progress=track_progress)
     if output_file is None:
         json.dumps(spec, indent=4, sort_keys=True)

--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -4,6 +4,8 @@ log = logging.getLogger(__name__)
 
 import click
 import json
+import os
+
 from . import readxml
 
 @click.group(context_settings=dict(help_option_names=['-h', '--help']))
@@ -11,11 +13,14 @@ def pyhf():
     pass
 
 @pyhf.command()
-@click.option('--entrypoint-xml', required=True, prompt='Top-level XML', help='The top-level XML file for the PDF definition.', type=click.Path(exists=True))
-@click.option('--basedir', required=True, prompt='Base directory', help='The base directory for the XML files to point relative to.', type=click.Path(exists=True))
-@click.option('--output-file', required=True, prompt='Output file', help='The location of the output json file. If not specified, prints to screen.')
+@click.argument('entrypoint-xml', help='The top-level XML file for the PDF definition.', type=click.Path(exists=True))
+@click.option('--basedir', help='The base directory for the XML files to point relative to.', type=click.Path(exists=True), default=os.getcwd())
+@click.option('--output-file', help='The location of the output json file. If not specified, prints to screen.', default=None)
 @click.option('--track-progress/--hide-progress', default=True)
 def xml2json(entrypoint_xml, basedir, output_file, track_progress):
     spec = readxml.parse(entrypoint_xml, basedir, track_progress=track_progress)
-    json.dump(spec, open(output_file, 'w+'), indent=4, sort_keys=True)
-    log.info("Written to {0:s}".format(output_file))
+    if output_file is None:
+        json.dumps(spec, indent=4, sort_keys=True)
+    else:
+        json.dump(spec, open(output_file, 'w+'), indent=4, sort_keys=True)
+        log.info("Written to {0:s}".format(output_file))

--- a/pyhf/readxml.py
+++ b/pyhf/readxml.py
@@ -118,8 +118,8 @@ def parse(configfile, rootdir, enable_tqdm=False):
     channels = {}
     for inp in inputs:
         inputs.set_description('Processing {}'.format(inp))
-        k, d, v = process_channel(ET.parse(os.path.join(rootdir,inp)), rootdir)
-        channels[k] = {'data': d, 'samples': v}
+        channel, data, samples = process_channel(ET.parse(os.path.join(rootdir,inp)), rootdir)
+        channels[channel] = {'data': data, 'samples': samples}
 
     return {
         'toplvl':{

--- a/pyhf/readxml.py
+++ b/pyhf/readxml.py
@@ -11,7 +11,7 @@ def import_root_histogram(rootdir, filename, path, name):
     #import pdb; pdb.set_trace()
     #assert path == ''
     # strip leading slashes as uproot doesn't use "/" for top-level
-    if path is None: path = ''
+    path = path or ''
     path = path.strip('/')
     f = uproot.open(os.path.join(rootdir, filename))
     try:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ setup(
   include_package_data = True,
   install_requires = [
     'numpy<=1.14.5,>=1.14.3',  # required by tensorflow, mxnet, and us
-    'scipy'
+    'scipy',
+    'click>=6.0',  # for console scripts
   ],
   extras_require = {
     'xmlimport': [
@@ -52,6 +53,7 @@ setup(
     ]
   },
   entry_points = {
+      'console_scripts': ['pyhf_xml2json=pyhf.commandline:xml2json']
   },
   dependency_links = [
   ]

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ setup(
   install_requires = [
     'numpy<=1.14.5,>=1.14.3',  # required by tensorflow, mxnet, and us
     'scipy',
-    'click>=6.0',  # for console scripts
+    'click>=6.0',  # for console scripts,
+    'tqdm',  # for readxml
   ],
   extras_require = {
     'xmlimport': [

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
        'pytest>=3.5.1',
        'pytest-cov>=2.5.1',
        'pytest-benchmark[histogram]',
+       'pytest-console-scripts',
        'python-coveralls',
        'coverage==4.0.3',  # coveralls
        'matplotlib',

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     ]
   },
   entry_points = {
-      'console_scripts': ['pyhf_xml2json=pyhf.commandline:xml2json']
+      'console_scripts': ['pyhf=pyhf.commandline:pyhf']
   },
   dependency_links = [
   ]

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -7,7 +7,7 @@ import pyhf
 # see test_import.py for the same (detailed) test
 def test_import_prepHistFactory(tmpdir, script_runner):
     temp = tmpdir.join("parsed_output.json")
-    command = 'pyhf xml2json --entrypoint-xml validation/xmlimport_input/config/example.xml --basedir validation/xmlimport_input/ --output-file {0:s} --hide-progress'.format(temp.strpath)
+    command = 'pyhf xml2json validation/xmlimport_input/config/example.xml --basedir validation/xmlimport_input/ --output-file {0:s} --hide-progress'.format(temp.strpath)
     ret = script_runner.run(*shlex.split(command))
     assert ret.success
     assert ret.stdout == ''
@@ -17,11 +17,10 @@ def test_import_prepHistFactory(tmpdir, script_runner):
     spec = {'channels': parsed_xml['channels']}
     pyhf.utils.validate(spec, pyhf.utils.get_default_schema())
 
-def test_import_prepHistFactory_TQDM(tmpdir, script_runner):
+def test_import_prepHistFactory_withProgress(tmpdir, script_runner):
     temp = tmpdir.join("parsed_output.json")
-    command = 'pyhf xml2json --entrypoint-xml validation/xmlimport_input/config/example.xml --basedir validation/xmlimport_input/ --output-file {0:s}'.format(temp.strpath)
+    command = 'pyhf xml2json validation/xmlimport_input/config/example.xml --basedir validation/xmlimport_input/ --output-file {0:s}'.format(temp.strpath)
     ret = script_runner.run(*shlex.split(command))
     assert ret.success
     assert ret.stdout == ''
     assert ret.stderr != ''
-

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -7,7 +7,7 @@ import pyhf
 # see test_import.py for the same (detailed) test
 def test_import_prepHistFactory(tmpdir, script_runner):
     temp = tmpdir.join("parsed_output.json")
-    command = 'pyhf xml2json --entrypoint-xml validation/xmlimport_input/config/example.xml --basedir validation/xmlimport_input/ --output-file {0:s} --no-tqdm'.format(temp.strpath)
+    command = 'pyhf xml2json --entrypoint-xml validation/xmlimport_input/config/example.xml --basedir validation/xmlimport_input/ --output-file {0:s} --hide-progress'.format(temp.strpath)
     ret = script_runner.run(*shlex.split(command))
     assert ret.success
     assert ret.stdout == ''

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -7,7 +7,7 @@ import pyhf
 # see test_import.py for the same (detailed) test
 def test_import_prepHistFactory(tmpdir, script_runner):
     temp = tmpdir.join("parsed_output.json")
-    command = 'pyhf_xml2json --entrypoint-xml validation/xmlimport_input/config/example.xml --workspace validation/xmlimport_input/ --output-file {0:s} --no-tqdm'.format(temp.strpath)
+    command = 'pyhf_xml2json --entrypoint-xml validation/xmlimport_input/config/example.xml --basedir validation/xmlimport_input/ --output-file {0:s} --no-tqdm'.format(temp.strpath)
     ret = script_runner.run(*shlex.split(command))
     assert ret.success
     assert ret.stdout == ''
@@ -19,7 +19,7 @@ def test_import_prepHistFactory(tmpdir, script_runner):
 
 def test_import_prepHistFactory_TQDM(tmpdir, script_runner):
     temp = tmpdir.join("parsed_output.json")
-    command = 'pyhf_xml2json --entrypoint-xml validation/xmlimport_input/config/example.xml --workspace validation/xmlimport_input/ --output-file {0:s}'.format(temp.strpath)
+    command = 'pyhf_xml2json --entrypoint-xml validation/xmlimport_input/config/example.xml --basedir validation/xmlimport_input/ --output-file {0:s}'.format(temp.strpath)
     ret = script_runner.run(*shlex.split(command))
     assert ret.success
     assert ret.stdout == ''

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -7,7 +7,7 @@ import pyhf
 # see test_import.py for the same (detailed) test
 def test_import_prepHistFactory(tmpdir, script_runner):
     temp = tmpdir.join("parsed_output.json")
-    command = 'pyhf_xml2json --entrypoint-xml validation/xmlimport_input/config/example.xml --basedir validation/xmlimport_input/ --output-file {0:s} --no-tqdm'.format(temp.strpath)
+    command = 'pyhf xml2json --entrypoint-xml validation/xmlimport_input/config/example.xml --basedir validation/xmlimport_input/ --output-file {0:s} --no-tqdm'.format(temp.strpath)
     ret = script_runner.run(*shlex.split(command))
     assert ret.success
     assert ret.stdout == ''
@@ -19,7 +19,7 @@ def test_import_prepHistFactory(tmpdir, script_runner):
 
 def test_import_prepHistFactory_TQDM(tmpdir, script_runner):
     temp = tmpdir.join("parsed_output.json")
-    command = 'pyhf_xml2json --entrypoint-xml validation/xmlimport_input/config/example.xml --basedir validation/xmlimport_input/ --output-file {0:s}'.format(temp.strpath)
+    command = 'pyhf xml2json --entrypoint-xml validation/xmlimport_input/config/example.xml --basedir validation/xmlimport_input/ --output-file {0:s}'.format(temp.strpath)
     ret = script_runner.run(*shlex.split(command))
     assert ret.success
     assert ret.stdout == ''

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,0 +1,27 @@
+import pytest
+import json
+import shlex
+
+import pyhf
+
+# see test_import.py for the same (detailed) test
+def test_import_prepHistFactory(tmpdir, script_runner):
+    temp = tmpdir.join("parsed_output.json")
+    command = 'pyhf_xml2json --entrypoint-xml validation/xmlimport_input/config/example.xml --workspace validation/xmlimport_input/ --output-file {0:s} --no-tqdm'.format(temp.strpath)
+    ret = script_runner.run(*shlex.split(command))
+    assert ret.success
+    assert ret.stdout == ''
+    assert ret.stderr == ''
+
+    parsed_xml = json.loads(temp.read())
+    spec = {'channels': parsed_xml['channels']}
+    pyhf.utils.validate(spec, pyhf.utils.get_default_schema())
+
+def test_import_prepHistFactory_TQDM(tmpdir, script_runner):
+    temp = tmpdir.join("parsed_output.json")
+    command = 'pyhf_xml2json --entrypoint-xml validation/xmlimport_input/config/example.xml --workspace validation/xmlimport_input/ --output-file {0:s}'.format(temp.strpath)
+    ret = script_runner.run(*shlex.split(command))
+    assert ret.success
+    assert ret.stdout == ''
+    assert ret.stderr != ''
+


### PR DESCRIPTION
# Description

This allows someone to use `pyhf` from command-line to parse the XML workspaces using the `readxml.parse` functionality. This uses `click` to set up options/arguments.

This also updates `readxml` with some slight reorganization to allow for a `tqdm` progress bar that can be enabled (default: disabled) for reading in the channels in various XML files.

```
pyhf_xml2json --entrypoint-xml validation/multibin_multibjets/config/NormalMeasurement.xml --workspace validation/multibin_multibjets/ --output_file test.json
```

![screenshot 2018-08-23 10 45 23](https://user-images.githubusercontent.com/761483/44542454-b1ff5600-a6c1-11e8-8c72-78bf0d36d95e.png)

NB: both `click` and `tqdm` are already installed via our dependencies, but I've explicitly listed them in `setup.py` now.

# Checklist Before Requesting Approver

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
