### PR TITLE
support stat errors from external histogram (and fix those from internal ones if sumw2 structure is empty)

### DIFF
--- a/pyhf/readxml.py
+++ b/pyhf/readxml.py
@@ -6,19 +6,26 @@ import xml.etree.ElementTree as ET
 import numpy as np
 import tqdm
 
+
 def extract_error(h):
-    if h.fSumw2:
-        return np.sqrt(h.fSumw2[1:-1]).tolist()
-    else:
-        #if fSumw2 is not filled, it must have
-        #been filled with no weights and .Sumw2() never
-        #got called. therefore error is sqrt(entries)
-        return np.sqrt(h.numpy[0]).tolist()
+    """
+    Determine the bin uncertainties for a histogram.
+
+    If `fSumw2` is not filled, then the histogram must have been
+    filled with no weights and `.Sumw2()` was never called. The
+    bin uncertainties are then Poisson, and so the `sqrt(entries)`.
+
+    Args:
+        h: The histogram
+
+    Returns:
+        list: The uncertainty for each bin in the histogram
+    """
+    err = h.fSumw2[1:-1] if h.fSumw2 else h.numpy[0]
+    return np.sqrt(err).tolist()
 
 def import_root_histogram(rootdir, filename, path, name):
     import uproot
-    #import pdb; pdb.set_trace()
-    #assert path == ''
     # strip leading slashes as uproot doesn't use "/" for top-level
     path = path or ''
     path = path.strip('/')

--- a/pyhf/readxml.py
+++ b/pyhf/readxml.py
@@ -25,14 +25,11 @@ def import_root_histogram(rootdir, filename, path, name):
     f = uproot.open(os.path.join(rootdir, filename))
     try:
         h = f[name]
-        return h.numpy[0].tolist(), extract_error(h)
     except KeyError:
         try:
             h = f[os.path.join(path, name)]
         except KeyError:
             raise KeyError('Both {0:s} and {1:s} were tried and not found in {2:s}'.format(name, os.path.join(path, name), os.path.join(rootdir, filename)))
-
-    h = f[os.path.join(path, name)]
     return h.numpy[0].tolist(), extract_error(h)
 
 def process_sample(sample,rootdir,inputfile, histopath, channelname, track_progress=False):

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -17,7 +17,7 @@ def test_import_prepHistFactory():
     channels = {channel['name'] for channel in pdf.spec['channels']}
     samples = {channel['name']: [sample['name'] for sample in channel['samples']] for channel in pdf.spec['channels']}
 
-    assert data == [122.0, 112.0, 0, 0, 1.0, 1.0, 0.0]
+
     ###
     ### signal overallsys
     ### bkg1 overallsys (stat ignored)
@@ -28,12 +28,19 @@ def test_import_prepHistFactory():
     assert 'signal' in samples['channel1']
     assert 'background1' in samples['channel1']
     assert 'background2' in samples['channel1']
-    assert samples['channels'][0]['samples'][1]['modifiers'][0]['data']
-    assert samples['channels'][0]['samples'][2]['modifiers'][0]['data']
 
+    assert pdf.spec['channels'][0]['samples'][2]['modifiers'][0]['type'] == 'staterror'
+    assert pdf.spec['channels'][0]['samples'][2]['modifiers'][0]['data'] == [0,10.]
+
+    assert pdf.spec['channels'][0]['samples'][1]['modifiers'][0]['type'] == 'staterror'
+    assert pdf.spec['channels'][0]['samples'][1]['modifiers'][0]['data'] == [5.000000074505806, 0.0]
 
     assert pdf.expected_actualdata(
         pdf.config.suggested_init()).tolist() == [120.0, 110.0]
+
+    assert pdf.config.auxdata_order ==  ['syst1', 'staterror_channel1', 'syst2', 'syst3']
+
+    assert data == [122.0, 112.0, 0.0, 1.0, 1.0, 0.0, 0.0]
 
     pars = pdf.config.suggested_init()
     pars[pdf.config.par_slice('SigXsecOverSM')] = [2.0]

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -2,6 +2,7 @@ import pyhf
 import pyhf.readxml
 import json
 import pytest
+import numpy as np
 
 def test_import_prepHistFactory():
     parsed_xml = pyhf.readxml.parse('validation/xmlimport_input/config/example.xml',
@@ -33,7 +34,7 @@ def test_import_prepHistFactory():
     assert pdf.spec['channels'][0]['samples'][2]['modifiers'][0]['data'] == [0,10.]
 
     assert pdf.spec['channels'][0]['samples'][1]['modifiers'][0]['type'] == 'staterror'
-    assert pdf.spec['channels'][0]['samples'][1]['modifiers'][0]['data'] == [5.000000074505806, 0.0]
+    assert all(np.isclose(pdf.spec['channels'][0]['samples'][1]['modifiers'][0]['data'],[5.0, 0.0]))
 
     assert pdf.expected_actualdata(
         pdf.config.suggested_init()).tolist() == [120.0, 110.0]

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -29,6 +29,7 @@ def test_import_prepHistFactory():
     assert 'background1' in samples['channel1']
     assert 'background2' in samples['channel1']
     assert samples['channels'][0]['samples'][1]['modifiers'][0]['data']
+    assert samples['channels'][0]['samples'][2]['modifiers'][0]['data']
 
 
     assert pdf.expected_actualdata(

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -28,6 +28,8 @@ def test_import_prepHistFactory():
     assert 'signal' in samples['channel1']
     assert 'background1' in samples['channel1']
     assert 'background2' in samples['channel1']
+    assert samples['channels'][0]['samples'][1]['modifiers'][0]['data']
+
 
     assert pdf.expected_actualdata(
         pdf.config.suggested_init()).tolist() == [120.0, 110.0]


### PR DESCRIPTION
# Description

This adds support for cases where `StatError` is activated, but the uncertainties are provided by an external `Histo`

Example:
https://github.com/diana-hep/pyhf/blob/master/validation/xmlimport_input/config/example_channel.xml#L29

# Checklist Before Requesting Approver

- [x] Tests are passing
- [ ] "WIP" removed from the title of the pull request
