### PR TITLE
qualify modifier names by modifier type

### DIFF
--- a/pyhf/exceptions/__init__.py
+++ b/pyhf/exceptions/__init__.py
@@ -1,5 +1,8 @@
 import sys
 
+class InvalidNameReuse(Exception):
+    pass 
+       
 class InvalidSpecification(Exception):
     """
     InvalidSpecification is raised when a specification does not validate against the given schema.

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -9,18 +9,19 @@ from . import utils
 
 class _ModelConfig(object):
     @classmethod
-    def from_spec(cls,spec,poiname = 'mu'):
+    def from_spec(cls,spec,poiname = 'mu', qualify_names = False):
         # hacky, need to keep track in which order we added the constraints
         # so that we can generate correctly-ordered data
         instance = cls()
         for channel in spec['channels']:
             for sample in channel['samples']:
                 for modifier_def in sample['modifiers']:
-                    modifier_def = copy.deepcopy(modifier_def)
-                    fullname = '{}/{}'.format(modifier_def['type'],modifier_def['name'])
-                    if modifier_def['name'] == poiname:
-                        poiname = fullname
-                    modifier_def['name'] = fullname
+                    if qualify_names:
+                        modifier_def = copy.deepcopy(modifier_def)
+                        fullname = '{}/{}'.format(modifier_def['type'],modifier_def['name'])
+                        if modifier_def['name'] == poiname:
+                            poiname = fullname
+                        modifier_def['name'] = fullname
                     modifier = instance.add_or_get_modifier(channel, sample, modifier_def)
                     modifier.add_sample(channel, sample, modifier_def)
         instance.set_poi(poiname)

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -83,7 +83,10 @@ class _ModelConfig(object):
         # if modifier is shared, check if it already exists and use it
         if modifier_cls.is_shared and modifier_def['name'] in self.par_map:
             log.info('using existing shared, {0:s}constrained modifier (name={1:s}, type={2:s})'.format('' if modifier_cls.is_constrained else 'un', modifier_def['name'], modifier_cls.__name__))
-            return self.par_map[modifier_def['name']]['modifier']
+            modifier = self.par_map[modifier_def['name']]['modifier']
+            if not type(modifier).__name__ == modifier_def['type']:
+                raise RuntimeError('existing modifier is found, but it is of wrong type {} (instead of {}). Use unique modifier names or use qualify_names=True when constructing the pdf.'.format(type(modifier).__name__, modifier_def['type']))
+            return modifier
 
         # did not return, so create new modifier and return it
         modifier = modifier_cls(sample['data'], modifier_def['data'])

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -17,7 +17,6 @@ class _ModelConfig(object):
             for sample in channel['samples']:
                 for modifier_def in sample['modifiers']:
                     if qualify_names:
-                        modifier_def = copy.deepcopy(modifier_def)
                         fullname = '{}/{}'.format(modifier_def['type'],modifier_def['name'])
                         if modifier_def['name'] == poiname:
                             poiname = fullname
@@ -107,13 +106,13 @@ class _ModelConfig(object):
 
 class Model(object):
     def __init__(self, spec, **config_kwargs):
-        self.spec = spec
+        self.spec = copy.deepcopy(spec) #may get modified by config
         self.schema = config_kwargs.get('schema', utils.get_default_schema())
         # run jsonschema validation of input specification against the (provided) schema
         log.info("Validating spec against schema: {0:s}".format(self.schema))
         utils.validate(self.spec, self.schema)
         # build up our representation of the specification
-        self.config = _ModelConfig.from_spec(spec,**config_kwargs)
+        self.config = _ModelConfig.from_spec(self.spec,**config_kwargs)
 
     def expected_sample(self, channel, sample, pars):
         """

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 log = logging.getLogger(__name__)
 
@@ -15,6 +16,11 @@ class _ModelConfig(object):
         for channel in spec['channels']:
             for sample in channel['samples']:
                 for modifier_def in sample['modifiers']:
+                    modifier_def = copy.deepcopy(modifier_def)
+                    fullname = '{}/{}'.format(modifier_def['type'],modifier_def['name'])
+                    if modifier_def['name'] == poiname:
+                        poiname = fullname
+                    modifier_def['name'] = fullname
                     modifier = instance.add_or_get_modifier(channel, sample, modifier_def)
                     modifier.add_sample(channel, sample, modifier_def)
         instance.set_poi(poiname)

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -7,6 +7,7 @@ from . import exceptions
 from . import modifiers
 from . import utils
 
+
 class _ModelConfig(object):
     @classmethod
     def from_spec(cls,spec,poiname = 'mu', qualify_names = False):
@@ -84,7 +85,7 @@ class _ModelConfig(object):
             log.info('using existing shared, {0:s}constrained modifier (name={1:s}, type={2:s})'.format('' if modifier_cls.is_constrained else 'un', modifier_def['name'], modifier_cls.__name__))
             modifier = self.par_map[modifier_def['name']]['modifier']
             if not type(modifier).__name__ == modifier_def['type']:
-                raise RuntimeError('existing modifier is found, but it is of wrong type {} (instead of {}). Use unique modifier names or use qualify_names=True when constructing the pdf.'.format(type(modifier).__name__, modifier_def['type']))
+                raise exceptions.InvalidNameReuse('existing modifier is found, but it is of wrong type {} (instead of {}). Use unique modifier names or use qualify_names=True when constructing the pdf.'.format(type(modifier).__name__, modifier_def['type']))
             return modifier
 
         # did not return, so create new modifier and return it

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -1,6 +1,7 @@
 import pyhf
 import pytest
 import pyhf.simplemodels
+import pyhf.exceptions
 import numpy as np
 import json
 import tensorflow as tf
@@ -272,3 +273,33 @@ def test_invalid_modifier():
     }
     with pytest.raises(pyhf.exceptions.InvalidModifier):
         pyhf.pdf._ModelConfig.from_spec(spec)
+
+def test_invalid_modifier_name_resuse():
+    spec = {
+        'channels': [
+            {
+                'name': 'singlechannel',
+                'samples': [
+                    {
+                        'name': 'signal',
+                        'data': [5.],
+                        'modifiers': [
+                            {'name': 'reused_name', 'type': 'normfactor', 'data': None}
+                        ]
+                    },
+                    {
+                        'name': 'background',
+                        'data': [50.],
+                        'modifiers': [
+                            {'name': 'reused_name', 'type': 'normsys','data': {'lo': 0.9, 'hi': 1.1}}
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+    with pytest.raises(pyhf.exceptions.InvalidNameReuse):
+        pdf  = pyhf.Model(spec, poiname = 'reused_name')
+
+    pdf  = pyhf.Model(spec, poiname = 'reused_name', qualify_names = True)
+    


### PR DESCRIPTION
# Description

Apparently ROOT allows modifiers to reuse names (without sharing) across modifiers. I would suggest that in  `pyhf` we qualify the modifier names as `type/name` which need to be unique

addresses #208 

# Checklist Before Requesting Approver

- [ ] Tests are passing
- [ ] "WIP" removed from the title of the pull request
