### PR TITLE
stub for XML writing

### DIFF
--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -7,6 +7,7 @@ import json
 import os
 
 from . import readxml
+from . import writexml
 from .utils import runOnePoint
 from .pdf import Model
 
@@ -27,6 +28,16 @@ def xml2json(entrypoint_xml, basedir, output_file, track_progress):
     else:
         json.dump(spec, open(output_file, 'w+'), indent=4, sort_keys=True)
         log.info("Written to {0:s}".format(output_file))
+
+@pyhf.command()
+@click.argument('workspace', default = '-')
+@click.argument('xmlfile', default = '-')
+def json2xml(workspace,xmlfile):
+    specstream = click.open_file(workspace)
+    outstream = click.open_file(xmlfile,'w')
+    d = json.load(specstream)
+
+    outstream.write(writexml.writexml(d,'','','').decode('utf-8'))
 
 @pyhf.command()
 @click.argument('workspace', default = '-')

--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -32,12 +32,14 @@ def xml2json(entrypoint_xml, basedir, output_file, track_progress):
 @pyhf.command()
 @click.argument('workspace', default = '-')
 @click.argument('xmlfile', default = '-')
-def json2xml(workspace,xmlfile):
+@click.option('--specroot', default = click.Path(exists = True))
+@click.option('--dataroot', default = click.Path(exists = True))
+def json2xml(workspace,xmlfile,specroot,dataroot):
     specstream = click.open_file(workspace)
     outstream = click.open_file(xmlfile,'w')
     d = json.load(specstream)
 
-    outstream.write(writexml.writexml(d,'','','').decode('utf-8'))
+    outstream.write(writexml.writexml(d,specroot,dataroot,'').decode('utf-8'))
 
 @pyhf.command()
 @click.argument('workspace', default = '-')

--- a/pyhf/readxml.py
+++ b/pyhf/readxml.py
@@ -129,7 +129,11 @@ def process_channel(channelxml, rootdir, track_progress=False):
 
     samples = tqdm.tqdm(channel.findall('Sample'), unit='sample', disable=not(track_progress))
 
-    data = channel.findall('Data')[0]
+    data = channel.findall('Data')
+    if data:
+        parsed_data = process_data(data[0], rootdir, inputfile, histopath)
+    else:
+        parsed_data = None
     channelname = channel.attrib['Name']
 
     results = []
@@ -138,7 +142,7 @@ def process_channel(channelxml, rootdir, track_progress=False):
       result = process_sample(sample, rootdir, inputfile, histopath, channelname, track_progress)
       results.append(result)
 
-    return channelname, process_data(data, rootdir, inputfile, histopath), results
+    return channelname, parsed_data, results
 
 def parse(configfile, rootdir, track_progress=False):
     toplvl = ET.parse(configfile)

--- a/pyhf/writexml.py
+++ b/pyhf/writexml.py
@@ -1,0 +1,22 @@
+import xml.etree.cElementTree as ET
+
+def measurement(lumi, lumierr, poi, param_settings = None, name = 'Meas1'):
+    param_settings = param_settings or []
+
+    meas = ET.Element("Measurement", Name = name, Lumi = str(lumi), LumiRelErr = str(lumierr))
+    poiel  = ET.Element('POI')
+    poiel.text = poi
+    meas.append(poiel)
+    for s in param_settings:
+        se  = ET.Element('ParamSetting', **s['attrs'])
+        se.text = ' '.join(s['params'])
+        meas.append(se)
+    return meas
+
+def writexml(spec, specdir, data_rootdir , result_outputprefix):
+    combination = ET.Element("Combination", OutputFilePrefix = result_outputprefix)
+
+    m = measurement(1,0.1,'SigXsecOverSM',[{'attrs': {'Const': 'True'}, 'params': ['Lumi' 'alpha_syst1']}])
+    combination.append(m)
+    return ET.tostring(combination, encoding = 'utf-8')
+

--- a/pyhf/writexml.py
+++ b/pyhf/writexml.py
@@ -16,6 +16,10 @@ def measurement(lumi, lumierr, poi, param_settings = None, name = 'Meas1'):
 
 def write_channel(channelspec, filename, data_rootdir):
     #need to write channelfile here
+    with open(filename,'w') as f:
+        channel = ET.Element('Channel', Name = channelspec['name'])
+        channel = ET.Element('Channel', Name = channelspec['name'])
+        f.write(ET.tostring(channel, encoding = 'utf-8').decode('utf-8'))
     pass
 
 

--- a/pyhf/writexml.py
+++ b/pyhf/writexml.py
@@ -1,3 +1,4 @@
+import os
 import xml.etree.cElementTree as ET
 
 def measurement(lumi, lumierr, poi, param_settings = None, name = 'Meas1'):
@@ -13,8 +14,21 @@ def measurement(lumi, lumierr, poi, param_settings = None, name = 'Meas1'):
         meas.append(se)
     return meas
 
+def write_channel(channelspec, filename, data_rootdir):
+    #need to write channelfile here
+    pass
+
+
 def writexml(spec, specdir, data_rootdir , result_outputprefix):
     combination = ET.Element("Combination", OutputFilePrefix = result_outputprefix)
+
+    for c in spec['channels']:
+        channelfilename = os.path.join(specdir,'channel_{}.xml'.format(c['name']))
+        write_channel(c,channelfilename,data_rootdir)
+        inp = ET.Element("Input")        
+        inp.text = channelfilename
+        combination.append(inp)
+
 
     m = measurement(1,0.1,'SigXsecOverSM',[{'attrs': {'Const': 'True'}, 'params': ['Lumi' 'alpha_syst1']}])
     combination.append(m)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -49,3 +49,12 @@ def test_import_prepHistFactory_and_cls(tmpdir, script_runner):
     assert d
     assert 'CLs_obs' in d
     assert 'CLs_exp' in d
+
+
+def test_import_and_export(tmpdir, script_runner):
+    temp = tmpdir.join("parsed_output.json")
+    command = 'pyhf xml2json validation/xmlimport_input/config/example.xml --basedir validation/xmlimport_input/ --output-file {0:s}'.format(temp.strpath)
+    ret = script_runner.run(*shlex.split(command))
+
+    command = 'pyhf json2xml {0:s} --specroot {1:s} --dataroot {1:s}'.format(temp.strpath,str(tmpdir))
+    ret = script_runner.run(*shlex.split(command))


### PR DESCRIPTION
# Description

Partially adresses #29  https://github.com/diana-hep/pyhf/issues/170

This is an incomplete stub to seed code for XML writing.

* `pyhf.writexml` module with XML generation code
* adds `pyhf json2xml command such that`

```
pyhf xml2json config/example.xml|pyhf json2xml > new.xml
pyhf xml2json new.xml
```

goes through without error by producing valid JSON and XML. (though it does not produce the right XML just yet)



# Checklist Before Requesting Approver

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
