### PR TITLE
fixes manifest to correct path

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-validation/data/spec.json
+pyhf/data/spec.json
 


### PR DESCRIPTION
# Description

if installing in non-editable mode, the data we want to distribute via MANIFEST.in needs to be copied and the path was wrong

# Checklist Before Requesting Approver

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
