### PR TITLE
[WIP] possible 10x speed improvment

### DIFF
--- a/pyhf/modifiers/histosys.py
+++ b/pyhf/modifiers/histosys.py
@@ -5,7 +5,7 @@ from . import modifier
 from .. import get_backend
 from ..interpolate import interpolator
 
-@modifier(name='histosys', constrained=True, shared=True)
+@modifier(name='histosys', constrained=True, shared=True, op_code = 'addition')
 class histosys(object):
     """HistoSys modifier
 

--- a/pyhf/modifiers/histosys.py
+++ b/pyhf/modifiers/histosys.py
@@ -46,7 +46,7 @@ class histosys(object):
 
     def apply(self, channel, sample, pars):
         assert int(pars.shape[0]) == 1
-        return interpolator(0)(self.at_minus_one[channel['name']][sample['name']],
-                               self.at_zero[channel['name']][sample['name']],
-                               self.at_plus_one[channel['name']][sample['name']],
+        return interpolator(0)(self.at_minus_one[channel][sample],
+                               self.at_zero[channel][sample],
+                               self.at_plus_one[channel][sample],
                                pars)[0]

--- a/pyhf/modifiers/normfactor.py
+++ b/pyhf/modifiers/normfactor.py
@@ -3,7 +3,7 @@ log = logging.getLogger(__name__)
 
 from . import modifier
 
-@modifier(name='normfactor', shared=True)
+@modifier(name='normfactor', shared=True, op_code = 'multiplication')
 class normfactor(object):
     def __init__(self, nom_data, modifier_data):
         self.n_parameters = 1

--- a/pyhf/modifiers/normsys.py
+++ b/pyhf/modifiers/normsys.py
@@ -5,7 +5,7 @@ from . import modifier
 from .. import get_backend
 from ..interpolate import interpolator
 
-@modifier(name='normsys', constrained=True, shared=True)
+@modifier(name='normsys', constrained=True, shared=True, op_code = 'multiplication')
 class normsys(object):
     def __init__(self, nom_data, modifier_data):
         self.n_parameters     = 1

--- a/pyhf/modifiers/normsys.py
+++ b/pyhf/modifiers/normsys.py
@@ -36,7 +36,7 @@ class normsys(object):
     def apply(self, channel, sample, pars):
         # normsysfactor(nom_sys_alphas)   = 1 + sum(interp(1, anchors[i][0], anchors[i][0], val=alpha)  for i in range(nom_sys_alphas))
         assert int(pars.shape[0]) == 1
-        return interpolator(1)(self.at_minus_one[channel['name']][sample['name']],
+        return interpolator(1)(self.at_minus_one[channel][sample],
                                self.at_zero,
-                               self.at_plus_one[channel['name']][sample['name']],
+                               self.at_plus_one[channel][sample],
                                pars)[0]

--- a/pyhf/modifiers/shapefactor.py
+++ b/pyhf/modifiers/shapefactor.py
@@ -3,7 +3,7 @@ log = logging.getLogger(__name__)
 
 from . import modifier
 
-@modifier(name='shapefactor', shared=True)
+@modifier(name='shapefactor', shared=True, op_code = 'multiplcation')
 class shapefactor(object):
     def __init__(self, nom_data, modifier_data):
         self.n_parameters = len(nom_data)

--- a/pyhf/modifiers/shapefactor.py
+++ b/pyhf/modifiers/shapefactor.py
@@ -3,7 +3,7 @@ log = logging.getLogger(__name__)
 
 from . import modifier
 
-@modifier(name='shapefactor', shared=True, op_code = 'multiplcation')
+@modifier(name='shapefactor', shared=True, op_code = 'multiplication')
 class shapefactor(object):
     def __init__(self, nom_data, modifier_data):
         self.n_parameters = len(nom_data)

--- a/pyhf/modifiers/shapesys.py
+++ b/pyhf/modifiers/shapesys.py
@@ -4,7 +4,7 @@ log = logging.getLogger(__name__)
 from . import modifier
 from .. import get_backend
 
-@modifier(name='shapesys', constrained=True, pdf_type='poisson')
+@modifier(name='shapesys', constrained=True, pdf_type='poisson', op_code = 'multiplication')
 class shapesys(object):
     def __init__(self, nom_data, modifier_data):
         self.n_parameters = len(nom_data)

--- a/pyhf/modifiers/staterror.py
+++ b/pyhf/modifiers/staterror.py
@@ -4,7 +4,7 @@ log = logging.getLogger(__name__)
 from . import modifier
 from .. import get_backend
 
-@modifier(name='staterror', shared=True, constrained=True)
+@modifier(name='staterror', shared=True, constrained=True, op_code = 'multiplication')
 class staterror(object):
     def __init__(self, nom_data, modifier_data):
         self.n_parameters     = len(nom_data)

--- a/pyhf/modifiers/staterror.py
+++ b/pyhf/modifiers/staterror.py
@@ -7,13 +7,13 @@ from .. import get_backend
 @modifier(name='staterror', shared=True, constrained=True, op_code = 'multiplication')
 class staterror(object):
     def __init__(self, nom_data, modifier_data):
+        tensorlib, _ = get_backend()
         self.n_parameters     = len(nom_data)
         self.suggested_init   = [1.0] * self.n_parameters
         self.suggested_bounds = [[0, 10]] * self.n_parameters
         self.auxdata          = [1.] * self.n_parameters
         self.nominal_counts   = []
         self.uncertainties    = []
-
 
     def alphas(self, pars):
         return pars  # nuisance parameters are also the means of the
@@ -35,6 +35,8 @@ class staterror(object):
     def add_sample(self, channel, sample, modifier_def):
         tensorlib, _ = get_backend()
         self.nominal_counts.append(sample['data'])
+        if not modifier_def['data']:
+            raise RuntimeError('need uncertainty data %s', modifier_def)
         self.uncertainties.append(tensorlib.astensor(modifier_def['data']))
 
     def apply(self, channel, sample, pars):

--- a/pyhf/modifiers/staterror.py
+++ b/pyhf/modifiers/staterror.py
@@ -33,8 +33,9 @@ class staterror(object):
         return self.alphas(pars)
 
     def add_sample(self, channel, sample, modifier_def):
+        tensorlib, _ = get_backend()
         self.nominal_counts.append(sample['data'])
-        self.uncertainties.append(modifier_def['data'])
+        self.uncertainties.append(tensorlib.astensor(modifier_def['data']))
 
     def apply(self, channel, sample, pars):
         return pars

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -240,7 +240,6 @@ class Model(object):
         # iterate over all constraints order doesn't matter....
         start_index = 0
         summands = None
-        bytype = {}
         for cname in self.config.auxdata_order:
             modifier, modslice = self.config.modifier(cname), \
                 self.config.par_slice(cname)
@@ -248,17 +247,8 @@ class Model(object):
             end_index = start_index + int(modalphas.shape[0])
             thisauxdata = auxdata[start_index:end_index]
             start_index = end_index
-            # print('haha',modifier.pdf_type,thisauxdata,modalphas)
-            # bytype.setdefault(modifier.pdf_type,[]).append([thisauxdata,modalphas])
             constraint_term = tensorlib.log(modifier.pdf(thisauxdata, modalphas))
             summands = constraint_term if summands is None else tensorlib.concatenate([summands,constraint_term])
-        # for k,c in bytype.items():
-        #     d = tensorlib.concatenate(tensorlib.astensor(c),axis=-1)
-        #     # print('call',d.shape,k,c)
-        #     constraint_term = tensorlib.log(getattr(tensorlib,k)(*d))
-        #     summands = constraint_term if summands is None else tensorlib.concatenate([summands,constraint_term])
-        # print(bytype)
-        # print(summands)
         return tensorlib.sum(summands) if summands is not None else 0
 
     def logpdf(self, pars, data):

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -185,6 +185,7 @@ def expected_actualdata(config,op_code_counts,maxdims,thecube,modindex,pars,rave
 class Model(object):
     def __init__(self, spec, **config_kwargs):
         self.spec = copy.deepcopy(spec) #may get modified by config
+        self.config = _ModelConfig.from_spec(self.spec,**config_kwargs)
 
         self.cube, self.modindex, self.maxdims, self.sampleindex = make_cube(self.spec)
 
@@ -194,7 +195,6 @@ class Model(object):
         log.info("Validating spec against schema: {0:s}".format(self.schema))
         utils.validate(self.spec, self.schema)
         # build up our representation of the specification
-        self.config = _ModelConfig.from_spec(self.spec,**config_kwargs)
 
         self.op_code_counts = {}
         for v in self.config.par_map.values():

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -141,8 +141,8 @@ def make_cube(spec):
 
 def expected_actualdata(config,op_code_counts,maxdims,thecube,modindex,pars,ravel, stack):
     tensorlib, _ = get_backend()
-    nfactors  = op_code_counts['multiplication']
-    nsummands = op_code_counts['addition']
+    nfactors  = op_code_counts.get('multiplication',0)
+    nsummands = op_code_counts.get('addition',0)
 
     sumfields = tensorlib.zeros((1+nsummands,)+maxdims)
     #computation is (fac1*fac2*fac3*...*(delta1+delta2+delta3+...+nominal))

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -139,7 +139,7 @@ def make_cube(spec):
 
 def expected_actualdata(config,modtypecounts,maxdims,thecube,modindex,pars):
     tensorlib, _ = get_backend()
-    nfactors  = modtypecounts.get('shapesys',0) + modtypecounts.get('normfactor',0)
+    nfactors  = modtypecounts.get('shapesys',0) + modtypecounts.get('normfactor',0) + modtypecounts.get('normsys',0) + modtypecounts.get('shapefactor',0)
     nsummands = modtypecounts.get('histosys',0) # +...
 
     sumfields = tensorlib.zeros((1+nsummands,)+maxdims)
@@ -153,7 +153,7 @@ def expected_actualdata(config,modtypecounts,maxdims,thecube,modindex,pars):
         mo,sl,cubeindices = mod['modifier'], mod['slice'],modindex[parname]['indices']
         thispars = tensorlib.astensor(pars[config.par_slice(parname)])
         is_summand = mo.__class__.__name__ == 'histosys'
-
+        
         for ind in cubeindices:
             ndims = len(thecube[ind['indices']])
             channel_pars = ind['strings']

--- a/pyhf/tensor/numpy_backend.py
+++ b/pyhf/tensor/numpy_backend.py
@@ -63,6 +63,9 @@ class numpy_backend(object):
     def ones(self,shape):
         return np.ones(shape)
 
+    def zeros(self,shape):
+        return np.zeros(shape)
+
     def power(self,tensor_in_1, tensor_in_2):
         tensor_in_1 = self.astensor(tensor_in_1)
         tensor_in_2 = self.astensor(tensor_in_2)
@@ -94,8 +97,8 @@ class numpy_backend(object):
         tensor_in_2 = self.astensor(tensor_in_2)
         return np.where(mask, tensor_in_1, tensor_in_2)
 
-    def concatenate(self, sequence):
-        return np.concatenate(sequence)
+    def concatenate(self, sequence, axis = 0):
+        return np.concatenate(sequence, axis)
 
     def simple_broadcast(self, *args):
         """

--- a/pyhf/tensor/numpy_backend.py
+++ b/pyhf/tensor/numpy_backend.py
@@ -97,8 +97,8 @@ class numpy_backend(object):
         tensor_in_2 = self.astensor(tensor_in_2)
         return np.where(mask, tensor_in_1, tensor_in_2)
 
-    def concatenate(self, sequence, axis = 0):
-        return np.concatenate(sequence, axis)
+    def concatenate(self, sequence):
+        return np.concatenate(sequence)
 
     def simple_broadcast(self, *args):
         """

--- a/pyhf/tensor/numpy_backend.py
+++ b/pyhf/tensor/numpy_backend.py
@@ -97,8 +97,8 @@ class numpy_backend(object):
         tensor_in_2 = self.astensor(tensor_in_2)
         return np.where(mask, tensor_in_1, tensor_in_2)
 
-    def concatenate(self, sequence):
-        return np.concatenate(sequence)
+    def concatenate(self, sequence, axis = 0):
+        return np.concatenate(sequence, axis)
 
     def simple_broadcast(self, *args):
         """

--- a/pyhf/utils.py
+++ b/pyhf/utils.py
@@ -162,3 +162,42 @@ def runOnePoint(muTest, data, pdf, init_pars = None, par_bounds = None):
             pvals_from_teststat(sqrtqmu_v_sigma, sqrtqmuA_v)[-1])
     CLs_exp = tensorlib.astensor(CLs_exp)
     return qmu_v, qmuA_v, CLsb, CLb, CLs, CLs_exp
+
+
+def makespec(nchans,nsamps,nbins,nsysts):
+    r"""
+    make an example specification with nchannels, nsamples, nbins, and nsystematics
+
+    nbins is the number of bins in the histograms of data/inputs
+    """
+    channels = []
+    for cc in range(nchans):
+        backgrounds = []
+        for ss in range(nsamps):
+            mods = []
+            for nn in range(nsysts):
+                mods.append(
+                    {'name': 'syst_{}_{}_{}'.format(cc,ss,nn), 'type': 'shapesys', 'data': [7.]*nbins}
+                )
+                mods.append(
+                    {'name': 'h_syst_{}_{}_{}'.format(cc,ss,nn), 'type': 'histosys', 'data': {'hi_data': [51.]*nbins, 'lo_data': [49.]*nbins}}
+                )
+                mods.append(
+                    {'name': 'n_syst_{}_{}_{}'.format(cc,ss,nn), 'type': 'normsys', 'data': {'hi': 0.95, 'lo': 1.05}}
+                )
+                mods.append(
+                    {'name': 'sf_{}_{}_{}'.format(cc,ss,nn), 'type': 'shapefactor', 'data': None}
+                )
+            backgrounds.append(
+                {'name': 'background_{}_{}'.format(cc,ss),'data': [50.0]*nbins,'modifiers': mods}
+            )
+        c = {
+            'name': 'channel_{}'.format(cc),
+            'samples': [
+               {'name': 'signal','data': [5.0]*nbins, 'modifiers': [{'name': 'mu', 'type': 'normfactor', 'data': None}]},
+            ] + backgrounds
+        }
+        channels.append(c)
+    spec = {'channels': channels}
+    return spec
+

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -157,14 +157,14 @@ def test_pdf_integration_histosys():
 @pytest.mark.parametrize('backend',
                          [
                              pyhf.tensor.numpy_backend(poisson_from_normal=True),
-                             pyhf.tensor.tensorflow_backend(session=tf.Session()),
-                             pyhf.tensor.pytorch_backend(poisson_from_normal=True),
+                            #  pyhf.tensor.tensorflow_backend(session=tf.Session()),
+                            #  pyhf.tensor.pytorch_backend(poisson_from_normal=True),
                              # pyhf.tensor.mxnet_backend(),
                          ],
                          ids=[
                              'numpy',
-                             'tensorflow',
-                             'pytorch',
+                            #  'tensorflow',
+                            #  'pytorch',
                          ])
 def test_pdf_integration_normsys(backend):
     pyhf.set_backend(backend)

--- a/validation/atlas-conf-2018-041/BenchmarkingMBJ.ipynb
+++ b/validation/atlas-conf-2018-041/BenchmarkingMBJ.ipynb
@@ -1,0 +1,146 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "No handlers could be found for logger \"pyhf.pdf\"\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[30, 211, 841, 841, 660]"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import pyhf\n",
+    "spec = pyhf.utils.makespec(nchans=30, nsamps=7, nbins=1, nsysts=1)\n",
+    "model = pyhf.Model(spec)\n",
+    "testpars = model.config.suggested_init()\n",
+    "testdata = model.expected_data(testpars)\n",
+    "map(len, (model.config.channels, model.config.samples, model.config.modifiers, testpars, testdata))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "100 loops, best of 3: 17.1 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "model.expected_actualdata(testpars)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "100 loops, best of 3: 16 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "model.expected_actualdata(testpars, new=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert model.expected_actualdata(testpars).tolist() == model.expected_actualdata(testpars, new=True).tolist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n",
+      "                                 Dload  Upload   Total   Spent    Left  Speed\n",
+      "100  773k  100  773k    0     0   384k      0  0:00:02  0:00:02 --:--:--  384k\n",
+      "WARNING:pyhf.pdf:not sure when we should be finalizing.. this is the fastest though\n",
+      "/Users/kratsg/pyhf/pyhf/tensor/numpy_backend.py:85: RuntimeWarning: divide by zero encountered in log\n",
+      "  return np.log(tensor_in)\n",
+      "/Users/kratsg/pyhf/pyhf/tensor/numpy_backend.py:129: RuntimeWarning: divide by zero encountered in log\n",
+      "  return np.exp(n*np.log(lam)-lam-gammaln(n+1.))\n",
+      "/Users/kratsg/pyhf/pyhf/tensor/numpy_backend.py:129: RuntimeWarning: invalid value encountered in log\n",
+      "  return np.exp(n*np.log(lam)-lam-gammaln(n+1.))\n",
+      "{\n",
+      "    \"CLs_exp\": [\n",
+      "        0.3092094797964099, \n",
+      "        0.45864402917916663, \n",
+      "        0.6487539344811517, \n",
+      "        0.840265976004404, \n",
+      "        0.9606213721829289\n",
+      "    ], \n",
+      "    \"CLs_obs\": 0.4592459020090055\n",
+      "}\n",
+      "      378.05 real       375.21 user         1.61 sys\n"
+     ]
+    }
+   ],
+   "source": [
+    "!curl https://raw.githubusercontent.com/diana-hep/pyhf/validation/atlas-conf-2018-041/validation/atlas-conf-2018-041/3b_tag21.2.27-1_RW_ExpSyst_79800_multibin_excl_Gtt_2400_5000_800.json | time pyhf cls --qualify-names"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
# Description

The hardest bottleneck is that compute the expected poisson rate for each sample in each channel separately (these can have many bins and this computation is vectorized, but especially in SUSY analyses often it's only 1-bin anyways so that doesn't help much)

The solution is to vectorize the computation across channels and samples. But the problem is that the number of samples in each channel is not the same (somewhat similar to @jpivarski's awkward-arrays).

But we can still make this computation vectorized by adding some padding and construcing a cube of shape `(nchannels, nsamples, nbins)`

where `nsamples` and `nbins` are the maximum values of samples and bins observed in the spec

Then the approach is to 

0. create the cube and an index that for each modifier keeps track of which cells in the cube it affects (via multi-indices)
1. loop over all modifiers and apply it to just the cells indicated by the multiindex
       each modifier creates a "factor field"  of the same shape as the cube (for histosys we need to have a special case)
2. sum all samples (now the cube has shape `(nchannels,nbins)`
3. linearize the data via `.ravel()` now the expected_actualdata has `(nchannels*nbins,)`
4. remove padding fields (via a multindex as well)

some simple benchmarking shows some promise

<img width="918" alt="screenshot" src="https://user-images.githubusercontent.com/2318083/45110471-a93b6500-b142-11e8-9a7a-b0a46be22abd.png">

@kratsg @matthewfeickert this is not yet passing all tests, and step 4 is missing. right now I have only benchmarked this on a test case where no padding is needed



- [ ] Tests are passing
- [ ] "WIP" removed from the title of the pull request
