### PR TITLE
Feature: maintain union of specification items as part of the model

### DIFF
--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -18,9 +18,9 @@ class _ModelConfig(object):
         # so that we can generate correctly-ordered data
         instance = cls()
         for channel in spec['channels']:
-            channels.append(channel)
+            channels.append(channel['name'])
             for sample in channel['samples']:
-                samples.append(sample)
+                samples.append(sample['name'])
                 for modifier_def in sample['modifiers']:
                     if qualify_names:
                         fullname = '{}/{}'.format(modifier_def['type'],modifier_def['name'])
@@ -31,7 +31,7 @@ class _ModelConfig(object):
                     modifier.add_sample(channel, sample, modifier_def)
                     modifiers.append(modifier_def['name'])
         instance.set_poi(poiname)
-        return instance, (list(set(channels)), list(set(samples)), list(set(modifiers)))
+        return (instance, (list(set(channels)), list(set(samples)), list(set(modifiers))))
 
     def __init__(self):
         # set up all other bookkeeping variables

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -11,11 +11,16 @@ from . import utils
 class _ModelConfig(object):
     @classmethod
     def from_spec(cls,spec,poiname = 'mu', qualify_names = False):
+        channels = []
+        samples = []
+        modifiers = []
         # hacky, need to keep track in which order we added the constraints
         # so that we can generate correctly-ordered data
         instance = cls()
         for channel in spec['channels']:
+            channels.append(channel)
             for sample in channel['samples']:
+                samples.append(sample)
                 for modifier_def in sample['modifiers']:
                     if qualify_names:
                         fullname = '{}/{}'.format(modifier_def['type'],modifier_def['name'])
@@ -24,8 +29,9 @@ class _ModelConfig(object):
                         modifier_def['name'] = fullname
                     modifier = instance.add_or_get_modifier(channel, sample, modifier_def)
                     modifier.add_sample(channel, sample, modifier_def)
+                    modifiers.append(modifier_def['name'])
         instance.set_poi(poiname)
-        return instance
+        return instance, (list(set(channels)), list(set(samples)), list(set(modifiers)))
 
     def __init__(self):
         # set up all other bookkeeping variables
@@ -113,7 +119,7 @@ class Model(object):
         log.info("Validating spec against schema: {0:s}".format(self.schema))
         utils.validate(self.spec, self.schema)
         # build up our representation of the specification
-        self.config = _ModelConfig.from_spec(self.spec,**config_kwargs)
+        self.config, (self.channels, self.samples, self.modifiers) = _ModelConfig.from_spec(self.spec,**config_kwargs)
 
     def expected_sample(self, channel, sample, pars):
         """


### PR DESCRIPTION
# Description

This is useful for #231 and similar where we can access a union of the names of all the various modifiers, samples, and channels involved in configuration of the model (pdf). This PR allows for the following to be possible:

```python
>>> spec = {  ... }
>>> model = pyhf.Model(spec)
>>> model.channels
['firstchannel']
>>> model.samples
['mu', 'bkg1', 'bkg2', 'bkg3']
>>> model.modifiers
['mu', 'stat_firstchannel']
```

# Checklist Before Requesting Approver

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
