### PR TITLE
Allow for configurable measurement to be specified from command line

### DIFF
--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -27,7 +27,7 @@ def xml2json(entrypoint_xml, basedir, output_file, track_progress):
         print(json.dumps(spec, indent=4, sort_keys=True))
     else:
         json.dump(spec, open(output_file, 'w+'), indent=4, sort_keys=True)
-        log.info("Written to {0:s}".format(output_file))
+        log.debug("Written to {0:s}".format(output_file))
 
 @pyhf.command()
 @click.argument('workspace', default = '-')
@@ -62,7 +62,7 @@ def cls(workspace, output_file, measurement, qualify_names):
         elif measurement:
             measurement_index = measurement_names.index(measurement)
 
-        log.info('calculating CLs for measurement {0:s}'.format(measurements[measurement_index]['name']))
+        log.debug('calculating CLs for measurement {0:s}'.format(measurements[measurement_index]['name']))
         p = Model({'channels':d['channels']}, poiname=measurements[measurement_index]['config']['poi'], qualify_names=qualify_names)
         result = runOnePoint(1.0, sum((d['data'][c['name']] for c in d['channels']),[]) + p.config.auxdata, p)
         result = {'CLs_obs': result[-2].tolist()[0], 'CLs_exp': result[-1].ravel().tolist()}
@@ -70,4 +70,4 @@ def cls(workspace, output_file, measurement, qualify_names):
             print(json.dumps(result, indent=4, sort_keys=True))
         else:
             json.dump(result, open(output_file, 'w+'), indent=4, sort_keys=True)
-            log.info("Written to {0:s}".format(output_file))
+            log.debug("Written to {0:s}".format(output_file))

--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -52,7 +52,7 @@ def cls(workspace, output_file, measurement, qualify_names):
     measurements = d['toplvl']['measurements']
     measurement_names = [m['name'] for m in measurements]
     measurement_index = 0
-    log.info('measurements defined:\n\t{0:s}'.format('\n\t'.join(measurement_names)))
+    log.debug('measurements defined:\n\t{0:s}'.format('\n\t'.join(measurement_names)))
     if measurement and measurement not in measurement_names:
         log.error('no measurement by name \'{0:s}\' exists, pick from one of the valid ones above'.format(measurement))
     else:

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -50,6 +50,16 @@ def test_import_prepHistFactory_and_cls(tmpdir, script_runner):
     assert 'CLs_obs' in d
     assert 'CLs_exp' in d
 
+    for measurement in ['GaussExample','GammaExample','LogNormExample','ConstExample']:
+        command = 'pyhf cls {0:s} --measurement {1:s}'.format(temp.strpath, measurement)
+        ret = script_runner.run(*shlex.split(command))
+
+        assert ret.success
+        d = json.loads(ret.stdout)
+        assert d
+        assert 'CLs_obs' in d
+        assert 'CLs_exp' in d
+
 
 def test_import_and_export(tmpdir, script_runner):
     temp = tmpdir.join("parsed_output.json")


### PR DESCRIPTION
# Description

This was raised as part of #233 . `pyhf cls foo.json --measurement MyMeasurement` now works.

# Checklist Before Requesting Approver

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
