### PR TITLE
Install with --ignore-installed to ensure proper NumPy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,11 @@ cache: pip
 python:
   - '2.7'
   - '3.6'
+before_install:
+- pip install --upgrade pip setuptools
+- pip uninstall -y numpy  # As numpy 1.13.3 is install by default in Travis it will be used unless removed
 install:
-- pip install --upgrade pip
 - pip install -U -q -e .[tensorflow,torch,mxnet,develop]
-- pip install "numpy<=1.14.5,>=1.14.0"
 script:
   - pyflakes pyhf
   - pytest --ignore tests/benchmarks/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,9 @@ python:
   - '2.7'
   - '3.6'
 before_install:
-- pip install --upgrade pip setuptools
-- pip uninstall -y numpy  # As numpy 1.13.3 is install by default in Travis it will be used unless removed
+  - pip install --upgrade pip setuptools
 install:
-- pip install -U -q -e .[tensorflow,torch,mxnet,develop]
+  - pip install --ignore-installed -U -q -e .[tensorflow,torch,mxnet,develop]  # Ensure right version of NumPy installed
 script:
   - pyflakes pyhf
   - pytest --ignore tests/benchmarks/
@@ -34,16 +33,19 @@ jobs:
   include:
   - stage: benchmark
     python: '3.6'
+    before_install:
+      - pip install --upgrade pip setuptools
     install:
-      - pip install --upgrade pip
-      - pip install -U -q -e .[tensorflow,torch,mxnet,develop]
+      - pip install --ignore-installed -U -q -e .[tensorflow,torch,mxnet,develop]
     script: pytest --benchmark-sort=mean tests/benchmarks/
   - stage: docs
     python: '3.6'
-    install:
+    before_install:
       - sudo apt-get update
       - sudo apt-get -qq install pandoc
-      - pip install -U -q -e .[tensorflow,torch,mxnet,develop]
+      - pip install --upgrade pip setuptools
+    install:
+      - pip install --ignore-installed -U -q -e .[tensorflow,torch,mxnet,develop]
     script:
     - python -m doctest README.md
     - cd docs && make html && cd -

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ If you have found a bug please report it by filling out the [bug report template
 You can install the development environment (which includes a number of extra) libraries via `pip`:
 
 ```
-pip install -e .[tensorflow,torch,mxnet,develop]
+pip install --ignore-installed -U -e .[tensorflow,torch,mxnet,develop]
 ```
 
 ## Running the tests

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -3,4 +3,4 @@ Developing
 
 To develop, we suggest using `virtual environments <https://virtualenvwrapper.readthedocs.io/en/latest/>`__ together with ``pip`` or using `pipenv <https://pipenv.readthedocs.io/en/latest/>`__. To get all necessary packages for development::
 
-    pip install -e .[tensorflow,torch,mxnet,develop]
+    pip install --ignore-installed -U -e .[tensorflow,torch,mxnet,develop]


### PR DESCRIPTION
If this is not done, then the default Travis installation of `numpy==1.13.3` will be used throughout instead of installing a later requested version unless it is explicitly asked for in `setup.py`'s `install_requires` (which is not done for details explained in PR #235). This allows for pyhf to be installed in Travis CI in the same way that a user or developer would, without having to force any version of NumPy.

This resolves the [confusion that I was having in PR #235](https://github.com/diana-hep/pyhf/pull/235#issuecomment-418910900) as well about the difference in NumPy releases being installed in my Docker containers and in Travis CI. In retrospect this difference should have been an obvious indicator that Travis CI already had a version of NumPy installed, so sorry about missing about.

# Checklist Before Requesting Approver

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
