### PR TITLE
Feature: make schema stricter (require minItems for some arrays)

### DIFF
--- a/pyhf/data/spec.json
+++ b/pyhf/data/spec.json
@@ -12,7 +12,7 @@
             "type": "object",
             "properties": {
                 "name": { "type": "string" },
-                "samples": { "type": "array", "items": {"$ref": "#/definitions/sample"} }
+                "samples": { "type": "array", "items": {"$ref": "#/definitions/sample"}, "minItems": 1 }
             },
             "required": ["name", "samples"],
             "additionalProperties": false
@@ -21,7 +21,7 @@
             "type": "object",
             "properties": {
                 "name": { "type": "string" },
-                "data": { "type": "array", "items": {"type": "number"} },
+                "data": { "type": "array", "items": {"type": "number"}, "minItems": 1 },
                 "modifiers": {
                     "type": "array",
                     "items": {
@@ -85,7 +85,7 @@
                 "properties": {
                     "name": { "type": "string" },
                     "type": { "const": "shapesys" },
-                    "data": { "type": "array", "items": {"type": "number"} }
+                    "data": { "type": "array", "items": {"type": "number"}, "minItems": 1 }
                 },
                 "required": ["name", "type", "data"],
                 "additionalProperties": false
@@ -95,7 +95,7 @@
                 "properties": {
                     "name": { "type": "string" },
                     "type": { "const": "staterror" },
-                    "data": { "type": "array", "items": {"type": "number"} }
+                    "data": { "type": "array", "items": {"type": "number"}, "minItems": 1 }
                 },
                 "required": ["name", "type", "data"],
                 "additionalProperties": false

--- a/pyhf/data/spec.json
+++ b/pyhf/data/spec.json
@@ -45,7 +45,14 @@
                 "properties": {
                     "name": { "type": "string" },
                     "type": { "const": "histosys" },
-                    "data": { "type": "object", "required": ["lo_data", "hi_data"] }
+                    "data": {
+                        "type": "object",
+                        "properties": {
+                            "lo_data": { "type": "array", "items": {"type": "number"}, "minItems": 1 },
+                            "hi_data": { "type": "array", "items": {"type": "number"}, "minItems": 1 }
+                        },
+                        "required": ["lo_data", "hi_data"]
+                    }
                 },
                 "required": ["name", "type", "data"],
                 "additionalProperties": false
@@ -65,7 +72,14 @@
                 "properties": {
                     "name": { "type": "string" },
                     "type": { "const": "normsys" },
-                    "data": { "type": "object", "required": ["lo", "hi"] }
+                    "data": {
+                        "type": "object",
+                        "properties": {
+                            "lo": { "type": "array", "items": {"type": "number"}, "minItems": 1 },
+                            "hi": { "type": "array", "items": {"type": "number"}, "minItems": 1 }
+                        },
+                        "required": ["lo", "hi"]
+                    }
                 },
                 "required": ["name", "type", "data"],
                 "additionalProperties": false

--- a/pyhf/data/spec.json
+++ b/pyhf/data/spec.json
@@ -75,8 +75,8 @@
                     "data": {
                         "type": "object",
                         "properties": {
-                            "lo": { "type": "array", "items": {"type": "number"}, "minItems": 1 },
-                            "hi": { "type": "array", "items": {"type": "number"}, "minItems": 1 }
+                            "lo": { "type": "number" },
+                            "hi": { "type": "number"}
                         },
                         "required": ["lo", "hi"]
                     }

--- a/pyhf/exceptions/__init__.py
+++ b/pyhf/exceptions/__init__.py
@@ -1,8 +1,8 @@
 import sys
 
 class InvalidNameReuse(Exception):
-    pass 
-       
+    pass
+
 class InvalidSpecification(Exception):
     """
     InvalidSpecification is raised when a specification does not validate against the given schema.
@@ -22,6 +22,13 @@ class InvalidSpecification(Exception):
         # Call the base class constructor with the parameters it needs
         super(InvalidSpecification, self).__init__(message)
 
+class InvalidModel(Exception):
+    """
+    InvalidModel is raised when a given model does not have the right configuration, even though it validates correctly against the schema.
+
+    This can occur, for example, when the provided parameter of interest to fit against does not get declared in the specification provided.
+    """
+    pass
 
 class InvalidModifier(Exception):
     """

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -30,6 +30,8 @@ class _ModelConfig(object):
                     modifier = instance.add_or_get_modifier(channel, sample, modifier_def)
                     modifier.add_sample(channel, sample, modifier_def)
                     modifiers.append(modifier_def['name'])
+        if poiname not in modifiers:
+            raise exceptions.InvalidModel("The paramter of interest '{0:s}' cannot be fit as it is not declared in the model specification.".format(poiname))
         instance.set_poi(poiname)
         return (instance, (list(set(channels)), list(set(samples)), list(set(modifiers))))
 

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -30,10 +30,11 @@ class _ModelConfig(object):
                     modifier = instance.add_or_get_modifier(channel, sample, modifier_def)
                     modifier.add_sample(channel, sample, modifier_def)
                     modifiers.append(modifier_def['name'])
-        if poiname not in modifiers:
-            raise exceptions.InvalidModel("The paramter of interest '{0:s}' cannot be fit as it is not declared in the model specification.".format(poiname))
+        instance.channels = list(set(channels))
+        instance.samples = list(set(samples))
+        instance.modifiers = list(set(modifiers))
         instance.set_poi(poiname)
-        return (instance, (list(set(channels)), list(set(samples)), list(set(modifiers))))
+        return instance
 
     def __init__(self):
         # set up all other bookkeeping variables
@@ -63,6 +64,8 @@ class _ModelConfig(object):
         return self.par_map[name]['modifier']
 
     def set_poi(self,name):
+        if name not in self.modifiers:
+            raise exceptions.InvalidModel("The paramter of interest '{0:s}' cannot be fit as it is not declared in the model specification.".format(name))
         s = self.par_slice(name)
         assert s.stop-s.start == 1
         self.poi_index = s.start
@@ -121,7 +124,7 @@ class Model(object):
         log.info("Validating spec against schema: {0:s}".format(self.schema))
         utils.validate(self.spec, self.schema)
         # build up our representation of the specification
-        self.config, (self.channels, self.samples, self.modifiers) = _ModelConfig.from_spec(self.spec,**config_kwargs)
+        self.config = _ModelConfig.from_spec(self.spec,**config_kwargs)
 
     def expected_sample(self, channel, sample, pars):
         """

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -168,24 +168,3 @@ def test_empty_histosys():
     }
     with pytest.raises(pyhf.exceptions.InvalidSpecification):
         pyhf.Model(spec)
-
-def test_empty_normsys():
-    spec = {
-        'channels': [
-            {
-                'name': 'channel',
-                'samples': [
-                    {
-                        'name': 'sample',
-                        'data': [10.],
-                        'modifiers': [
-                            {'name': 'modifier', 'type': 'normsys', 'data': {'lo': [], 'hi': []}}
-                        ]
-                    }
-                ]
-            },
-        ]
-    }
-    with pytest.raises(pyhf.exceptions.InvalidSpecification):
-        pyhf.Model(spec)
-

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -85,7 +85,6 @@ def test_add_unknown_modifier():
     with pytest.raises(pyhf.exceptions.InvalidSpecification):
         pyhf.Model(spec)
 
-
 def test_empty_staterror():
     spec = {
         'channels': [
@@ -125,3 +124,44 @@ def test_empty_shapesys():
     }
     with pytest.raises(pyhf.exceptions.InvalidSpecification):
         pyhf.Model(spec)
+
+def test_empty_histosys():
+    spec = {
+        'channels': [
+            {
+                'name': 'channel',
+                'samples': [
+                    {
+                        'name': 'sample',
+                        'data': [10.],
+                        'modifiers': [
+                            {'name': 'modifier', 'type': 'histosys', 'data': {'lo_data': [], 'hi_data': []}}
+                        ]
+                    }
+                ]
+            },
+        ]
+    }
+    with pytest.raises(pyhf.exceptions.InvalidSpecification):
+        pyhf.Model(spec)
+
+def test_empty_normsys():
+    spec = {
+        'channels': [
+            {
+                'name': 'channel',
+                'samples': [
+                    {
+                        'name': 'sample',
+                        'data': [10.],
+                        'modifiers': [
+                            {'name': 'modifier', 'type': 'normsys', 'data': {'lo': [], 'hi': []}}
+                        ]
+                    }
+                ]
+            },
+        ]
+    }
+    with pytest.raises(pyhf.exceptions.InvalidSpecification):
+        pyhf.Model(spec)
+

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -48,7 +48,7 @@ def test_sample_missing_name():
     with pytest.raises(pyhf.exceptions.InvalidSpecification):
         pyhf.Model(spec)
 
-def test_sample_missing_modifiers():
+def test_sample_missing_all_modifiers():
     spec = {
         'channels': [
             {
@@ -63,7 +63,31 @@ def test_sample_missing_modifiers():
             },
         ]
     }
-    pyhf.Model(spec)
+    with pytest.raises(pyhf.exceptions.InvalidModel):
+        pyhf.Model(spec)
+
+def test_one_sample_missing_modifiers():
+    spec = {
+        'channels': [
+            {
+                'name': 'channel',
+                'samples': [
+                    {
+                        'name': 'sample',
+                        'data': [10.],
+                        'modifiers': []
+                    },
+                    {
+                        'name': 'another_sample',
+                        'data': [5.],
+                        'modifiers': [{'name': 'mypoi', 'type': 'normfactor', 'data': None}]
+                    }
+                ]
+            },
+        ]
+    }
+    pyhf.Model(spec, poiname='mypoi')
+
 
 def test_add_unknown_modifier():
     spec = {

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,7 +1,37 @@
 import pyhf
 import pytest
 
-def test_missing_sample_name():
+def test_no_samples():
+    spec = {
+        'channels': [
+            {
+                'name': 'channel',
+                'samples': []
+            },
+        ]
+    }
+    with pytest.raises(pyhf.exceptions.InvalidSpecification):
+        pyhf.Model(spec)
+
+def test_sample_missing_data():
+    spec = {
+        'channels': [
+            {
+                'name': 'channel',
+                'samples': [
+                    {
+                        'name': 'sample',
+                        'data': [],
+                        'modifiers': []
+                    }
+                ]
+            },
+        ]
+    }
+    with pytest.raises(pyhf.exceptions.InvalidSpecification):
+        pyhf.Model(spec)
+
+def test_sample_missing_name():
     spec = {
         'channels': [
             {
@@ -18,6 +48,23 @@ def test_missing_sample_name():
     with pytest.raises(pyhf.exceptions.InvalidSpecification):
         pyhf.Model(spec)
 
+def test_sample_missing_modifiers():
+    spec = {
+        'channels': [
+            {
+                'name': 'channel',
+                'samples': [
+                    {
+                        'name': 'sample',
+                        'data': [10.],
+                        'modifiers': []
+                    }
+                ]
+            },
+        ]
+    }
+    pyhf.Model(spec)
+
 def test_add_unknown_modifier():
     spec = {
         'channels': [
@@ -33,6 +80,47 @@ def test_add_unknown_modifier():
                     },
                 ]
             }
+        ]
+    }
+    with pytest.raises(pyhf.exceptions.InvalidSpecification):
+        pyhf.Model(spec)
+
+
+def test_empty_staterror():
+    spec = {
+        'channels': [
+            {
+                'name': 'channel',
+                'samples': [
+                    {
+                        'name': 'sample',
+                        'data': [10.],
+                        'modifiers': [
+                            {'name': 'staterror_channel', 'type': 'staterror', 'data': []}
+                        ]
+                    }
+                ]
+            },
+        ]
+    }
+    with pytest.raises(pyhf.exceptions.InvalidSpecification):
+        pyhf.Model(spec)
+
+def test_empty_shapesys():
+    spec = {
+        'channels': [
+            {
+                'name': 'channel',
+                'samples': [
+                    {
+                        'name': 'sample',
+                        'data': [10.],
+                        'modifiers': [
+                            {'name': 'sample_norm', 'type': 'shapesys','data': []}
+                        ]
+                    }
+                ]
+            },
         ]
     }
     with pytest.raises(pyhf.exceptions.InvalidSpecification):


### PR DESCRIPTION
# Description

StatError and ShapeSys require at least one item in their `data` arrays. Samples require at least one item in their `data` arrays. Channels require at least one sample.

This revealed a bug with `poiname` where a sample with no modifiers (a valid spec) is still not being built by the `_ModelConfig` into a pdf.

This resolves #240 .

# Checklist Before Requesting Approver

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
