### PR TITLE
Bug: docs deployment doesn't like symlinks

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -53,7 +53,8 @@ clean:
 .PHONY: html
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
-	mkdir -p $(BUILDDIR)/html/docs && ln -sfn ../_static $(BUILDDIR)/html/docs/_static
+	#mkdir -p $(BUILDDIR)/html/docs && ln -sfn ../_static $(BUILDDIR)/html/docs/_static
+	mkdir -p $(BUILDDIR)/html/docs && rsync -r $(BUILDDIR)/html/_static $(BUILDDIR)/html/docs/
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 


### PR DESCRIPTION
# Description

Got hit by this bug: travis-ci/travis-ci#9996 . Approve and merge asap. Changes the `ln -sfn` command to an `rsync -r` command. Images in `README.md` are not linked properly in the generated sphinx documentation because the symlinks were not transferred over as part of deployment.

# Checklist Before Requesting Approver

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
