### PR TITLE
Remove Docker Hub build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1169739.svg)](https://doi.org/10.5281/zenodo.1169739)
 
 [![Build Status](https://travis-ci.org/diana-hep/pyhf.svg?branch=master)](https://travis-ci.org/diana-hep/pyhf)
-[![Docker Automated](https://img.shields.io/docker/automated/pyhf/pyhf.svg)](https://hub.docker.com/r/pyhf/pyhf/) [![Docker Build](https://img.shields.io/docker/build/pyhf/pyhf.svg)](https://hub.docker.com/r/pyhf/pyhf/)
+[![Docker Automated](https://img.shields.io/docker/automated/pyhf/pyhf.svg)](https://hub.docker.com/r/pyhf/pyhf/)
 [![Coverage Status](https://coveralls.io/repos/github/diana-hep/pyhf/badge.svg?branch=master)](https://coveralls.io/github/diana-hep/pyhf?branch=master) [![Code Health](https://landscape.io/github/diana-hep/pyhf/master/landscape.svg?style=flat)](https://landscape.io/github/diana-hep/pyhf/master)
 
 [![Docs](https://img.shields.io/badge/docs-master-blue.svg)](https://diana-hep.github.io/pyhf)
@@ -39,7 +39,7 @@ Implemented variations:
 - [x] ShapeSys
 - [x] NormFactor
 - [x] Multiple Channels
-- [x] Import from XML + ROOT via [`uproot`](https://github.com/scikit-hep/uproot)
+- [x] Import from XML + ROOT via [uproot](https://github.com/scikit-hep/uproot)
 - [x] ShapeFactor
 - [x] StatError
 


### PR DESCRIPTION
Resolves #244 

Given how the repo's Dockerfile is made it will build correctly on Docker Cloud, but fails on Docker Hub. If the build status badge is left in the `README` it will give the false impression that the Docker image is broken. c.f. Issue #239 for more details on this.

Additionally fix the broken rendering of the uproot link in the RST version of the `README` (the website index page)

# Checklist Before Requesting Approver

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
