### PR TITLE
Feature: tensorize the interpolation codes (more general)

### DIFF
--- a/docs/examples/notebooks/learn/TensorizingInterpolations.ipynb
+++ b/docs/examples/notebooks/learn/TensorizingInterpolations.ipynb
@@ -152,17 +152,19 @@
     "from timeit import default_timer as timer\n",
     "def compare_fns(func1, func2):\n",
     "    h,a = random_histosets_alphasets_pair()\n",
+    "    h,a = h.tolist(), a.tolist()\n",
     "    \n",
     "    start = timer()\n",
-    "    old = np.asarray(func1(h.tolist(),a.tolist()))\n",
+    "    old = func1(h,a)\n",
     "    end = timer()\n",
     "    print '{:40s} took {:05.6f}s.'.format(func1.__name__, end - start)\n",
     "    \n",
     "    start = timer()\n",
-    "    new = np.asarray(func2(h.tolist(),a.tolist()))\n",
+    "    new = func2(h,a)\n",
     "    end = timer()\n",
     "    print '{:40s} took {:05.6f}s.'.format(func2.__name__, end - start)\n",
     "    \n",
+    "    old, new = np.asarray(old), np.asarray(new)\n",
     "    return np.all(old[~np.isnan(old)] == new[~np.isnan(new)])"
    ]
   },
@@ -244,8 +246,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "interpolation_linear                     took 0.190361s.\n",
-      "new_interpolation_linear_step0           took 0.440647s.\n",
+      "interpolation_linear                     took 0.086658s.\n",
+      "new_interpolation_linear_step0           took 0.330601s.\n",
       "True\n"
      ]
     }
@@ -324,8 +326,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "interpolation_linear                     took 0.191377s.\n",
-      "new_interpolation_linear_step1           took 0.597963s.\n",
+      "interpolation_linear                     took 0.089310s.\n",
+      "new_interpolation_linear_step1           took 0.461280s.\n",
       "True\n"
      ]
     }
@@ -413,8 +415,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "interpolation_linear                     took 0.207234s.\n",
-      "new_interpolation_linear_step2           took 0.500875s.\n",
+      "interpolation_linear                     took 0.091558s.\n",
+      "new_interpolation_linear_step2           took 0.378748s.\n",
       "True\n"
      ]
     }
@@ -514,8 +516,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "interpolation_linear                     took 0.203561s.\n",
-      "new_interpolation_linear_step3           took 0.994770s.\n",
+      "interpolation_linear                     took 0.096708s.\n",
+      "new_interpolation_linear_step3           took 0.888459s.\n",
       "True\n"
      ]
     }
@@ -611,8 +613,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "interpolation_linear                     took 0.209027s.\n",
-      "new_interpolation_linear_step4           took 0.312846s.\n",
+      "interpolation_linear                     took 0.093153s.\n",
+      "new_interpolation_linear_step4           took 0.155489s.\n",
       "True\n"
      ]
     }
@@ -702,8 +704,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "interpolation_linear                     took 0.176400s.\n",
-      "new_interpolation_linear_step5           took 0.116659s.\n",
+      "interpolation_linear                     took 0.091447s.\n",
+      "new_interpolation_linear_step5           took 0.044772s.\n",
       "True\n"
      ]
     }
@@ -767,8 +769,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "interpolation_linear                     took 0.195199s.\n",
-      "new_interpolation_linear_step6           took 0.118497s.\n",
+      "interpolation_linear                     took 0.090629s.\n",
+      "new_interpolation_linear_step6           took 0.040877s.\n",
       "True\n"
      ]
     }
@@ -1000,26 +1002,26 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "interpolation_linear                     took 0.195565s.\n",
-      "new_interpolation_linear_step0           took 0.441513s.\n",
+      "interpolation_linear                     took 0.092562s.\n",
+      "new_interpolation_linear_step0           took 0.318601s.\n",
       "True\n",
-      "interpolation_linear                     took 0.220087s.\n",
-      "new_interpolation_linear_step1           took 0.605430s.\n",
+      "interpolation_linear                     took 0.090272s.\n",
+      "new_interpolation_linear_step1           took 0.464639s.\n",
       "True\n",
-      "interpolation_linear                     took 0.210433s.\n",
-      "new_interpolation_linear_step2           took 0.508479s.\n",
+      "interpolation_linear                     took 0.093238s.\n",
+      "new_interpolation_linear_step2           took 0.413996s.\n",
       "True\n",
-      "interpolation_linear                     took 0.234420s.\n",
-      "new_interpolation_linear_step3           took 0.983062s.\n",
+      "interpolation_linear                     took 0.094312s.\n",
+      "new_interpolation_linear_step3           took 0.851162s.\n",
       "True\n",
-      "interpolation_linear                     took 0.213969s.\n",
-      "new_interpolation_linear_step4           took 0.294863s.\n",
+      "interpolation_linear                     took 0.090179s.\n",
+      "new_interpolation_linear_step4           took 0.144621s.\n",
       "True\n",
-      "interpolation_linear                     took 0.197236s.\n",
-      "new_interpolation_linear_step5           took 0.112138s.\n",
+      "interpolation_linear                     took 0.094364s.\n",
+      "new_interpolation_linear_step5           took 0.045240s.\n",
       "True\n",
-      "interpolation_linear                     took 0.194492s.\n",
-      "new_interpolation_linear_step6           took 0.126083s.\n",
+      "interpolation_linear                     took 0.093041s.\n",
+      "new_interpolation_linear_step6           took 0.040023s.\n",
       "True\n"
      ]
     }

--- a/docs/examples/notebooks/learn/TensorizingInterpolations.ipynb
+++ b/docs/examples/notebooks/learn/TensorizingInterpolations.ipynb
@@ -149,23 +149,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from timeit import default_timer as timer\n",
     "def compare_fns(func1, func2):\n",
     "    h,a = random_histosets_alphasets_pair()\n",
     "    h,a = h.tolist(), a.tolist()\n",
+    "\n",
+    "    def _func_runner(func, histssets, alphasets):\n",
+    "        return np.asarray(func(histssets,alphasets))\n",
     "    \n",
-    "    start = timer()\n",
-    "    old = func1(h,a)\n",
-    "    end = timer()\n",
-    "    print '{:40s} took {:05.6f}s.'.format(func1.__name__, end - start)\n",
-    "    \n",
-    "    start = timer()\n",
-    "    new = func2(h,a)\n",
-    "    end = timer()\n",
-    "    print '{:40s} took {:05.6f}s.'.format(func2.__name__, end - start)\n",
-    "    \n",
-    "    old, new = np.asarray(old), np.asarray(new)\n",
-    "    return np.all(old[~np.isnan(old)] == new[~np.isnan(new)])"
+    "    old = _func_runner(func1, h, a)    \n",
+    "    new = _func_runner(func2, h, a)\n",
+    "\n",
+    "    return (np.all(old[~np.isnan(old)] == new[~np.isnan(new)]), (h,a))"
    ]
   },
   {
@@ -246,21 +240,56 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "interpolation_linear                     took 0.086658s.\n",
-      "new_interpolation_linear_step0           took 0.330601s.\n",
       "True\n"
      ]
     }
    ],
    "source": [
-    "print compare_fns(interpolation_linear, new_interpolation_linear_step0)"
+    "result, (h,a) = compare_fns(interpolation_linear, new_interpolation_linear_step0)\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10 loops, best of 3: 69.4 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "interpolation_linear(h,a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 loop, best of 3: 284 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "new_interpolation_linear_step0(h,a)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Great!\n",
+    "Great! We're a little bit slower right now, but that's expected. We're just getting started.\n",
     "\n",
     "#### Step 1\n",
     "\n",
@@ -284,7 +313,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -319,21 +348,56 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "interpolation_linear                     took 0.089310s.\n",
-      "new_interpolation_linear_step1           took 0.461280s.\n",
       "True\n"
      ]
     }
    ],
    "source": [
-    "print compare_fns(interpolation_linear, new_interpolation_linear_step1)"
+    "result, (h,a) = compare_fns(interpolation_linear, new_interpolation_linear_step1)\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10 loops, best of 3: 69.8 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "interpolation_linear(h,a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 loop, best of 3: 441 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "new_interpolation_linear_step1(h,a)"
    ]
   },
   {
@@ -367,7 +431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -408,21 +472,56 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "interpolation_linear                     took 0.091558s.\n",
-      "new_interpolation_linear_step2           took 0.378748s.\n",
       "True\n"
      ]
     }
    ],
    "source": [
-    "print compare_fns(interpolation_linear, new_interpolation_linear_step2)"
+    "result, (h,a) = compare_fns(interpolation_linear, new_interpolation_linear_step2)\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10 loops, best of 3: 71 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "interpolation_linear(h,a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 loop, best of 3: 365 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "new_interpolation_linear_step2(h,a)"
    ]
   },
   {
@@ -469,7 +568,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -509,21 +608,56 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "interpolation_linear                     took 0.096708s.\n",
-      "new_interpolation_linear_step3           took 0.888459s.\n",
       "True\n"
      ]
     }
    ],
    "source": [
-    "print compare_fns(interpolation_linear, new_interpolation_linear_step3)"
+    "result, (h,a) = compare_fns(interpolation_linear, new_interpolation_linear_step3)\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10 loops, best of 3: 71.2 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "interpolation_linear(h,a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 loop, best of 3: 840 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "new_interpolation_linear_step3(h,a)"
    ]
   },
   {
@@ -568,7 +702,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -606,21 +740,56 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "interpolation_linear                     took 0.093153s.\n",
-      "new_interpolation_linear_step4           took 0.155489s.\n",
       "True\n"
      ]
     }
    ],
    "source": [
-    "print compare_fns(interpolation_linear, new_interpolation_linear_step4)"
+    "result, (h,a) = compare_fns(interpolation_linear, new_interpolation_linear_step4)\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10 loops, best of 3: 68.4 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "interpolation_linear(h,a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10 loops, best of 3: 154 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "new_interpolation_linear_step4(h,a)"
    ]
   },
   {
@@ -656,7 +825,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -697,28 +866,63 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "interpolation_linear                     took 0.091447s.\n",
-      "new_interpolation_linear_step5           took 0.044772s.\n",
       "True\n"
      ]
     }
    ],
    "source": [
-    "print compare_fns(interpolation_linear, new_interpolation_linear_step5)"
+    "result, (h,a) = compare_fns(interpolation_linear, new_interpolation_linear_step5)\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10 loops, best of 3: 69.8 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "interpolation_linear(h,a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10 loops, best of 3: 41 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "new_interpolation_linear_step5(h,a)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Fantastic! And look at the speed up. We're already ~2x faster than the for-loop and we're not even done yet.\n",
+    "Fantastic! And look at the speed up. We're already faster than the for-loop and we're not even done yet.\n",
     "\n",
     "#### Step 6\n",
     "\n",
@@ -729,7 +933,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -762,21 +966,56 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "interpolation_linear                     took 0.090629s.\n",
-      "new_interpolation_linear_step6           took 0.040877s.\n",
       "True\n"
      ]
     }
    ],
    "source": [
-    "print compare_fns(interpolation_linear, new_interpolation_linear_step6)"
+    "result, (h,a) = compare_fns(interpolation_linear, new_interpolation_linear_step6)\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10 loops, best of 3: 68.9 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "interpolation_linear(h,a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10 loops, best of 3: 43.1 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "new_interpolation_linear_step6(h,a)"
    ]
   },
   {
@@ -792,7 +1031,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -995,45 +1234,380 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "interpolation_linear                     took 0.092562s.\n",
-      "new_interpolation_linear_step0           took 0.318601s.\n",
-      "True\n",
-      "interpolation_linear                     took 0.090272s.\n",
-      "new_interpolation_linear_step1           took 0.464639s.\n",
-      "True\n",
-      "interpolation_linear                     took 0.093238s.\n",
-      "new_interpolation_linear_step2           took 0.413996s.\n",
-      "True\n",
-      "interpolation_linear                     took 0.094312s.\n",
-      "new_interpolation_linear_step3           took 0.851162s.\n",
-      "True\n",
-      "interpolation_linear                     took 0.090179s.\n",
-      "new_interpolation_linear_step4           took 0.144621s.\n",
-      "True\n",
-      "interpolation_linear                     took 0.094364s.\n",
-      "new_interpolation_linear_step5           took 0.045240s.\n",
-      "True\n",
-      "interpolation_linear                     took 0.093041s.\n",
-      "new_interpolation_linear_step6           took 0.040023s.\n",
       "True\n"
      ]
     }
    ],
    "source": [
-    "print compare_fns(interpolation_linear, new_interpolation_linear_step0)\n",
-    "print compare_fns(interpolation_linear, new_interpolation_linear_step1)\n",
-    "print compare_fns(interpolation_linear, new_interpolation_linear_step2)\n",
-    "print compare_fns(interpolation_linear, new_interpolation_linear_step3)\n",
-    "print compare_fns(interpolation_linear, new_interpolation_linear_step4)\n",
-    "print compare_fns(interpolation_linear, new_interpolation_linear_step5)\n",
-    "print compare_fns(interpolation_linear, new_interpolation_linear_step6)"
+    "result, (h,a) = compare_fns(interpolation_nonlinear, new_interpolation_nonlinear_step0)\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10 loops, best of 3: 69.6 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "interpolation_nonlinear(h,a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 loop, best of 3: 615 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "new_interpolation_nonlinear_step0(h,a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n"
+     ]
+    }
+   ],
+   "source": [
+    "result, (h,a) = compare_fns(interpolation_nonlinear, new_interpolation_nonlinear_step1)\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10 loops, best of 3: 68.1 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "interpolation_nonlinear(h,a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 loop, best of 3: 562 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "new_interpolation_nonlinear_step1(h,a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n"
+     ]
+    }
+   ],
+   "source": [
+    "result, (h,a) = compare_fns(interpolation_nonlinear, new_interpolation_nonlinear_step2)\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10 loops, best of 3: 65.7 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "interpolation_nonlinear(h,a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 loop, best of 3: 421 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "new_interpolation_nonlinear_step2(h,a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n"
+     ]
+    }
+   ],
+   "source": [
+    "result, (h,a) = compare_fns(interpolation_nonlinear, new_interpolation_nonlinear_step3)\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10 loops, best of 3: 70.4 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "interpolation_nonlinear(h,a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 loop, best of 3: 1.29 s per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "new_interpolation_nonlinear_step3(h,a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n"
+     ]
+    }
+   ],
+   "source": [
+    "result, (h,a) = compare_fns(interpolation_nonlinear, new_interpolation_nonlinear_step4)\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10 loops, best of 3: 65 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "interpolation_nonlinear(h,a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10 loops, best of 3: 157 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "new_interpolation_nonlinear_step4(h,a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n"
+     ]
+    }
+   ],
+   "source": [
+    "result, (h,a) = compare_fns(interpolation_nonlinear, new_interpolation_nonlinear_step5)\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10 loops, best of 3: 64.1 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "interpolation_nonlinear(h,a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10 loops, best of 3: 43.2 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "new_interpolation_nonlinear_step5(h,a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n"
+     ]
+    }
+   ],
+   "source": [
+    "result, (h,a) = compare_fns(interpolation_nonlinear, new_interpolation_nonlinear_step6)\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10 loops, best of 3: 64.6 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "interpolation_nonlinear(h,a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "10 loops, best of 3: 43 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "new_interpolation_nonlinear_step6(h,a)"
    ]
   }
  ],

--- a/docs/examples/notebooks/learn/TensorizingInterpolations.ipynb
+++ b/docs/examples/notebooks/learn/TensorizingInterpolations.ipynb
@@ -1,0 +1,1059 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Tensorizing Interpolators\n",
+    "\n",
+    "This notebook will introduce some tensor algebra concepts about being able to convert from calculations inside for-loops into a single calculation over the entire tensor. It is assumed that you have some familiarity with what interpolation functions are used for in `pyhf`.\n",
+    "\n",
+    "To get started, we'll load up some functions we wrote whose job is to generate sets of histograms and alphas that we will compute interpolations for. This allows us to generate random, structured input data that we can use to test the tensorized form of the interpolation function against the original one we wrote. For now, we will consider only the `numpy` backend for simplicity, but can replace `np` to `pyhf.tensorlib` to achieve identical functionality.\n",
+    "\n",
+    "The function `random_histosets_alphasets_pair` will produce a pair `(histogramsets, alphasets)` of histograms and alphas for those histograms that represents the type of input we wish to interpolate on."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "def random_histosets_alphasets_pair(nsysts = 150, nhistos_per_syst_upto = 300, nalphas = 1, nbins_upto = 1):\n",
+    "    def generate_shapes(histogramssets,alphasets):\n",
+    "        h_shape = [len(histogramssets),0,0,0]\n",
+    "        a_shape = (len(alphasets),max(map(len,alphasets)))\n",
+    "        for hs in histogramssets:\n",
+    "            h_shape[1] = max(h_shape[1],len(hs))\n",
+    "            for h in hs: \n",
+    "                h_shape[2] = max(h_shape[2],len(h))\n",
+    "                for sh in h:\n",
+    "                    h_shape[3] = max(h_shape[3],len(sh))\n",
+    "        return tuple(h_shape),a_shape\n",
+    "\n",
+    "    def filled_shapes(histogramssets,alphasets):\n",
+    "        # pad our shapes with NaNs\n",
+    "        histos, alphas = generate_shapes(histogramssets,alphasets)\n",
+    "        histos, alphas = np.ones(histos) * np.nan, np.ones(alphas) * np.nan\n",
+    "        for i,syst in enumerate(histogramssets):\n",
+    "            for j,sample in enumerate(syst):\n",
+    "                for k,variation in enumerate(sample):\n",
+    "                    histos[i,j,k,:len(variation)] = variation\n",
+    "        for i,alphaset in enumerate(alphasets):\n",
+    "            alphas[i,:len(alphaset)] = alphaset\n",
+    "        return histos,alphas\n",
+    "\n",
+    "    nsyst_histos = np.random.randint(1, 1+nhistos_per_syst_upto, size=nsysts)\n",
+    "    nhistograms = [np.random.randint(1, nbins_upto+1, size=n) for n in nsyst_histos]\n",
+    "    random_alphas = [np.random.uniform(-1, 1,size=nalphas) for n in nsyst_histos]\n",
+    "\n",
+    "    random_histogramssets = [ \n",
+    "        [# all histos affected by systematic $nh\n",
+    "            [# sample $i, systematic $nh\n",
+    "                np.random.uniform(10*i+j,10*i+j+1, size = nbin).tolist() for j in range(3)\n",
+    "            ] for i,nbin in enumerate(nh)\n",
+    "        ] for nh in nhistograms\n",
+    "    ]   \n",
+    "    h,a = filled_shapes(random_histogramssets,random_alphas)\n",
+    "    return h,a "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The (slow) interpolations\n",
+    "\n",
+    "In all cases, the way we do interpolations is as follows:\n",
+    "\n",
+    "1. Loop over both the `histogramssets` and `alphasets` simultaneously (e.g. using python's `zip()`)\n",
+    "2. Loop over all histograms set in the set of histograms sets that correspond to the histograms affected by a given systematic\n",
+    "3. Loop over all of the alphas in the set of alphas\n",
+    "4. Loop over all the bins in the histogram sets simultaneously (e.g. using python's `zip()`)\n",
+    "5. Apply the interpolation across the same bin index\n",
+    "\n",
+    "This is already exhausting to think about, so let's put this in code form. Depending on the kind of interpolation being done, we'll pass in `func` as an argument to the top-level interpolation loop to switch between linear (`interpcode=0`) and non-linear (`interpcode=1`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def interpolation_looper(histogramssets, alphasets, func):\n",
+    "    all_results = []\n",
+    "    for histoset, alphaset in zip(histogramssets, alphasets):\n",
+    "        all_results.append([])\n",
+    "        set_result = all_results[-1]\n",
+    "        for histo in histoset:\n",
+    "            set_result.append([])\n",
+    "            histo_result = set_result[-1]\n",
+    "            for alpha in alphaset:\n",
+    "                alpha_result = []\n",
+    "                for down,nom,up in zip(histo[0],histo[1],histo[2]):\n",
+    "                    v = func(down, nom, up, alpha)\n",
+    "                    alpha_result.append(v)\n",
+    "                histo_result.append(alpha_result)\n",
+    "    return all_results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And we can also define our linear and non-linear interpolations we'll consider in this notebook that we wish to tensorize."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def interpolation_linear(histogramssets,alphasets):\n",
+    "    def summand(down, nom, up, alpha):\n",
+    "        delta_up = up - nom \n",
+    "        delta_down = nom - down\n",
+    "        if alpha > 0:\n",
+    "            delta =  delta_up*alpha\n",
+    "        else:\n",
+    "            delta =  delta_down*alpha\n",
+    "        return nom + delta\n",
+    "    return interpolation_looper(histogramssets, alphasets, summand)\n",
+    "\n",
+    "def interpolation_nonlinear(histogramssets,alphasets):\n",
+    "    def product(down, nom, up, alpha):\n",
+    "        delta_up = up/nom\n",
+    "        delta_down = down/nom\n",
+    "        if alpha > 0:\n",
+    "            delta =  delta_up**alpha\n",
+    "        else:\n",
+    "            delta =  delta_down**(-alpha)\n",
+    "        return nom*delta\n",
+    "    return interpolation_looper(histogramssets, alphasets, product)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will also define a helper function that allows us to pass in two functions we wish to compare the outputs for:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from timeit import default_timer as timer\n",
+    "def compare_fns(func1, func2):\n",
+    "    h,a = random_histosets_alphasets_pair()\n",
+    "    \n",
+    "    start = timer()\n",
+    "    old = np.asarray(func1(h.tolist(),a.tolist()))\n",
+    "    end = timer()\n",
+    "    print '{:40s} took {:05.6f}s.'.format(func1.__name__, end - start)\n",
+    "    \n",
+    "    start = timer()\n",
+    "    new = np.asarray(func2(h.tolist(),a.tolist()))\n",
+    "    end = timer()\n",
+    "    print '{:40s} took {:05.6f}s.'.format(func2.__name__, end - start)\n",
+    "    \n",
+    "    return np.all(old[~np.isnan(old)] == new[~np.isnan(new)])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For the rest of the notebook, we will detail in explicit form how the linear interpolator gets tensorized, step-by-step. The same sequence of steps will be shown for the non-linear interpolator -- but it is left up to the reader to understand the steps."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Tensorizing the Linear Interpolator\n",
+    "\n",
+    "#### Step 0\n",
+    "\n",
+    "Step 0 requires converting the innermost conditional check on `alpha > 0` into something tensorizable. This also means the calculation itself is going to become tensorized. So we will convert from\n",
+    "\n",
+    "```python\n",
+    "    if alpha > 0:\n",
+    "        delta =  delta_up*alpha\n",
+    "    else:\n",
+    "        delta =  delta_down*alpha\n",
+    "```\n",
+    "\n",
+    "to\n",
+    "\n",
+    "```python\n",
+    "    delta = np.where(alpha > 0, delta_up*alpha, delta_down*alpha)\n",
+    "```\n",
+    "\n",
+    "Let's make that change now, and let's check to make sure we still do the calculation correctly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get the internal calculation to use tensorlib backend\n",
+    "def new_interpolation_linear_step0(histogramssets,alphasets):\n",
+    "    histogramssets = np.asarray(histogramssets)\n",
+    "    alphasets = np.asarray(alphasets)\n",
+    "    all_results = []\n",
+    "    for histoset, alphaset in zip(histogramssets,alphasets):\n",
+    "        all_results.append([])\n",
+    "        set_result = all_results[-1]\n",
+    "        for histo in histoset:\n",
+    "            set_result.append([])\n",
+    "            histo_result = set_result[-1]\n",
+    "            for alpha in alphaset:\n",
+    "                alpha_result = []\n",
+    "                for down,nom,up in zip(histo[0],histo[1],histo[2]):\n",
+    "                    delta_up = up - nom\n",
+    "                    delta_down = nom - down\n",
+    "                    delta = np.where(alpha > 0, delta_up*alpha, delta_down*alpha)\n",
+    "                    v = nom + delta\n",
+    "                    alpha_result.append(v)\n",
+    "                histo_result.append(alpha_result)\n",
+    "    return all_results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And does the calculation still match?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "interpolation_linear                     took 0.190361s.\n",
+      "new_interpolation_linear_step0           took 0.440647s.\n",
+      "True\n"
+     ]
+    }
+   ],
+   "source": [
+    "print compare_fns(interpolation_linear, new_interpolation_linear_step0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Great!\n",
+    "\n",
+    "#### Step 1\n",
+    "\n",
+    "In this step, we would like to remove the innermost `zip()` call over the histogram bins by calculating the interpolation between the histograms in one fell swoop. This means, instead of writing something like\n",
+    "\n",
+    "```python\n",
+    "for down,nom,up in zip(histo[0],histo[1],histo[2]):\n",
+    "    delta_up = up - nom\n",
+    "    ...\n",
+    "```\n",
+    "\n",
+    "one can instead write\n",
+    "\n",
+    "```python\n",
+    "delta_up = histo[2] - histo[1]\n",
+    "...\n",
+    "```\n",
+    "\n",
+    "taking advantage of the automatic broadcasting of operations on input tensors. This sort of feature of the tensor backends allows us to speed up code, such as interpolation. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# update the delta variations to remove the zip() call and remove most-nested loop\n",
+    "def new_interpolation_linear_step1(histogramssets,alphasets):\n",
+    "    histogramssets = np.asarray(histogramssets)\n",
+    "    alphasets = np.asarray(alphasets)\n",
+    "    all_results = []\n",
+    "    for histoset, alphaset in zip(histogramssets,alphasets):\n",
+    "        all_results.append([])\n",
+    "        set_result = all_results[-1]\n",
+    "        for histo in histoset:\n",
+    "            set_result.append([])\n",
+    "            histo_result = set_result[-1]\n",
+    "            for alpha in alphaset:\n",
+    "                alpha_result = []\n",
+    "                deltas_up    = histo[2]-histo[1]\n",
+    "                deltas_dn    = histo[1]-histo[0]\n",
+    "                calc_deltas = np.where(alpha > 0, deltas_up*alpha, deltas_dn*alpha)\n",
+    "                v = histo[1] + calc_deltas\n",
+    "                alpha_result.append(v)\n",
+    "                histo_result.append(alpha_result)\n",
+    "    return all_results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And does the calculation still match?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "interpolation_linear                     took 0.191377s.\n",
+      "new_interpolation_linear_step1           took 0.597963s.\n",
+      "True\n"
+     ]
+    }
+   ],
+   "source": [
+    "print compare_fns(interpolation_linear, new_interpolation_linear_step1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Great!\n",
+    "\n",
+    "#### Step 2\n",
+    "\n",
+    "In this step, we would like to move the giant array of the deltas calculated to the beginning -- outside of all loops -- and then only take a subset of it for the calculation itself. This allows us to figure out the entire structure of the input for the rest of the calculations as we slowly move towards including `einsum()` calls (einstein summation). This means we would like to go from\n",
+    "\n",
+    "\n",
+    "```python\n",
+    "for histo in histoset:\n",
+    "    delta_up = histo[2] - histo[1]\n",
+    "...\n",
+    "```\n",
+    "\n",
+    "to\n",
+    "\n",
+    "```python\n",
+    "all_deltas = ...\n",
+    "for nh, histo in enumerate(histoset):\n",
+    "    deltas = all_deltas[nh]\n",
+    "    ...\n",
+    "```\n",
+    "\n",
+    "Again, we are taking advantage of the automatic broadcasting of operations on input tensors to calculate all the deltas in a single action."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# figure out the giant array of all deltas at the beginning and only take subsets of it for the calculation\n",
+    "def new_interpolation_linear_step2(histogramssets,alphasets):\n",
+    "    histogramssets = np.asarray(histogramssets)\n",
+    "    alphasets      = np.asarray(alphasets)\n",
+    "    all_results    = []\n",
+    "    \n",
+    "    allset_all_histo_deltas_up = histogramssets[:,:,2] - histogramssets[:,:,1]\n",
+    "    allset_all_histo_deltas_dn = histogramssets[:,:,1] - histogramssets[:,:,0]\n",
+    "    \n",
+    "    for nset,(histoset, alphaset) in enumerate(zip(histogramssets,alphasets)):\n",
+    "        set_result = []\n",
+    "        \n",
+    "        all_histo_deltas_up = allset_all_histo_deltas_up[nset]\n",
+    "        all_histo_deltas_dn = allset_all_histo_deltas_dn[nset]\n",
+    "        \n",
+    "        for nh,histo in enumerate(histoset):\n",
+    "            alpha_deltas = []\n",
+    "            for alpha in alphaset:\n",
+    "                alpha_result = []\n",
+    "                deltas_up    = all_histo_deltas_up[nh]\n",
+    "                deltas_dn    = all_histo_deltas_dn[nh]\n",
+    "                calc_deltas  = np.where(alpha > 0, deltas_up*alpha, deltas_dn*alpha)\n",
+    "                alpha_deltas.append(calc_deltas)\n",
+    "            set_result.append([histo[1]+ d for d in alpha_deltas])\n",
+    "        all_results.append(set_result)\n",
+    "    return all_results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And does the calculation still match?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "interpolation_linear                     took 0.207234s.\n",
+      "new_interpolation_linear_step2           took 0.500875s.\n",
+      "True\n"
+     ]
+    }
+   ],
+   "source": [
+    "print compare_fns(interpolation_linear, new_interpolation_linear_step2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Great!\n",
+    "\n",
+    "#### Step 3\n",
+    "\n",
+    "In this step, we get to introduce einstein summation to generalize the calculations we perform across many dimensions in a more concise, straightforward way. See [this blog post](https://rockt.github.io/2018/04/30/einsum) for some more details on einstein summation notation. In short, it allows us to write\n",
+    "\n",
+    "$$\n",
+    "c_j = \\sum_i \\sum_k = A_{ik} B_{kj} \\qquad \\rightarrow \\qquad \\texttt{einsum(\"ij,jk->i\", A, B)}\n",
+    "$$\n",
+    "\n",
+    "in a much more elegant way to express many kinds of common tensor operations such as dot products, transposes, outer products, and so on. This step is generally the hardest as one needs to figure out the corresponding `einsum` that keeps the calculation preserved (and matching). To some extent it requires a lot of trial and error until you get a feel for how einstein summation notation works.\n",
+    "\n",
+    "As a concrete example of a conversion, we wish to go from something like\n",
+    "\n",
+    "```python\n",
+    "for nh,histo in enumerate(histoset):\n",
+    "    for alpha in alphaset:\n",
+    "        deltas_up    = all_histo_deltas_up[nh]\n",
+    "        deltas_dn    = all_histo_deltas_dn[nh]\n",
+    "        calc_deltas  = np.where(alpha > 0, deltas_up*alpha, deltas_dn*alpha)\n",
+    "        ...\n",
+    "```\n",
+    "\n",
+    "to get rid of the loop over `alpha`\n",
+    "\n",
+    "```python\n",
+    "for nh,histo in enumerate(histoset):\n",
+    "    alphas_times_deltas_up = np.einsum('i,j->ij',alphaset,all_histo_deltas_up[nh])\n",
+    "    alphas_times_deltas_dn = np.einsum('i,j->ij',alphaset,all_histo_deltas_dn[nh])\n",
+    "    masks = np.einsum('i,j->ij',alphaset > 0,np.ones_like(all_histo_deltas_dn[nh]))\n",
+    "\n",
+    "    alpha_deltas  = np.where(masks,alphas_times_deltas_up, alphas_times_deltas_dn)\n",
+    "    ...\n",
+    "```\n",
+    "\n",
+    "In this particular case, we need an outer product that multiplies across the `alphaset` to the corresponding `histoset` for the up/down variations. Then we just need to select from either the up variation calculation or the down variation calculation based on the sign of alpha. Try to convince yourself that the einstein summation does what the for-loop does, but a little bit more concisely, and perhaps more clearly! How does the function look now?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# remove the loop over alphas, starts using einsum to help generalize to more dimensions\n",
+    "def new_interpolation_linear_step3(histogramssets,alphasets):\n",
+    "    histogramssets = np.asarray(histogramssets)\n",
+    "    alphasets      = np.asarray(alphasets)\n",
+    "    all_results    = []\n",
+    "    \n",
+    "    allset_all_histo_deltas_up = histogramssets[:,:,2] - histogramssets[:,:,1]\n",
+    "    allset_all_histo_deltas_dn = histogramssets[:,:,1] - histogramssets[:,:,0]\n",
+    "    \n",
+    "    for nset,(histoset, alphaset) in enumerate(zip(histogramssets,alphasets)):\n",
+    "        set_result = []\n",
+    "        \n",
+    "        all_histo_deltas_up = allset_all_histo_deltas_up[nset]\n",
+    "        all_histo_deltas_dn = allset_all_histo_deltas_dn[nset]\n",
+    "        \n",
+    "        for nh,histo in enumerate(histoset):\n",
+    "            alphas_times_deltas_up = np.einsum('i,j->ij',alphaset,all_histo_deltas_up[nh])\n",
+    "            alphas_times_deltas_dn = np.einsum('i,j->ij',alphaset,all_histo_deltas_dn[nh])\n",
+    "            masks = np.einsum('i,j->ij',alphaset > 0,np.ones_like(all_histo_deltas_dn[nh]))\n",
+    "            \n",
+    "            alpha_deltas  = np.where(masks,alphas_times_deltas_up, alphas_times_deltas_dn)\n",
+    "            set_result.append([histo[1]+ d for d in alpha_deltas])\n",
+    "            \n",
+    "        all_results.append(set_result)\n",
+    "    return all_results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And does the calculation still match?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "interpolation_linear                     took 0.203561s.\n",
+      "new_interpolation_linear_step3           took 0.994770s.\n",
+      "True\n"
+     ]
+    }
+   ],
+   "source": [
+    "print compare_fns(interpolation_linear, new_interpolation_linear_step3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Great! Note that we've been getting a little bit slower during these steps. It will all pay off in the end when we're fully tensorized! A lot of the internal steps are overkill with the heavy einstein summation and broadcasting at the moment, especially for how many loops in we are.\n",
+    "\n",
+    "#### Step 4\n",
+    "\n",
+    "Now in this step, we will move the einstein summations to the outer loop, so that we're calculating it once! This is the big step, but a little bit easier because all we're doing is adding extra dimensions into the calculation. The underlying calculation won't have changed. At this point, we'll also rename from `i` and `j` to `a` and `b` for `alpha` and `bin` (as in the bin in the histogram). To continue the notation as well, here's a summary of the dimensions involved:\n",
+    "\n",
+    "- `s` will be for the set under consideration (e.g. the modifier)\n",
+    "- `a` will be for the alpha variation\n",
+    "- `h` will be for the histogram affected by the modifier\n",
+    "- `b` will be for the bin of the histogram\n",
+    "\n",
+    "So we wish to move the `einsum` code from\n",
+    "\n",
+    "```python\n",
+    "for nset,(histoset, alphaset) in enumerate(zip(histogramssets,alphasets)):\n",
+    "    ...\n",
+    "\n",
+    "    for nh,histo in enumerate(histoset):\n",
+    "        alphas_times_deltas_up = np.einsum('i,j->ij',alphaset,all_histo_deltas_up[nh])\n",
+    "            ...\n",
+    "```\n",
+    "\n",
+    "to\n",
+    "\n",
+    "```python\n",
+    "all_alphas_times_deltas_up = np.einsum('...',alphaset,all_histo_deltas_up)\n",
+    "for nset,(histoset, alphaset) in enumerate(zip(histogramssets,alphasets)):\n",
+    "    ...\n",
+    "\n",
+    "    for nh,histo in enumerate(histoset):\n",
+    "        ...\n",
+    "```\n",
+    "\n",
+    "So how does this new function look?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# move the einsums to outer loops to get ready to get rid of all loops\n",
+    "def new_interpolation_linear_step4(histogramssets,alphasets):\n",
+    "    histogramssets = np.asarray(histogramssets)\n",
+    "    alphasets      = np.asarray(alphasets)\n",
+    "    \n",
+    "    allset_all_histo_deltas_up = histogramssets[:,:,2] - histogramssets[:,:,1]\n",
+    "    allset_all_histo_deltas_dn = histogramssets[:,:,1] - histogramssets[:,:,0]\n",
+    "    allset_all_histo_nom = histogramssets[:,:,1]\n",
+    "    \n",
+    "    allsets_all_histos_alphas_times_deltas_up = np.einsum('sa,shb->shab',alphasets,allset_all_histo_deltas_up)\n",
+    "    allsets_all_histos_alphas_times_deltas_dn = np.einsum('sa,shb->shab',alphasets,allset_all_histo_deltas_dn)\n",
+    "    allsets_all_histos_masks = np.einsum('sa,s...u->s...au',alphasets > 0,np.ones_like(allset_all_histo_deltas_dn))\n",
+    "    \n",
+    "    allsets_all_histos_deltas = np.where(allsets_all_histos_masks,allsets_all_histos_alphas_times_deltas_up, allsets_all_histos_alphas_times_deltas_dn)\n",
+    "\n",
+    "    all_results    = []\n",
+    "    for nset,histoset in enumerate(histogramssets):\n",
+    "        all_histos_deltas = allsets_all_histos_deltas[nset]\n",
+    "        set_result = []\n",
+    "        for nh,histo in enumerate(histoset):\n",
+    "            set_result.append([d + histoset[nh,1] for d in all_histos_deltas[nh]])\n",
+    "        all_results.append(set_result)\n",
+    "    return all_results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And does the calculation still match?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "interpolation_linear                     took 0.209027s.\n",
+      "new_interpolation_linear_step4           took 0.312846s.\n",
+      "True\n"
+     ]
+    }
+   ],
+   "source": [
+    "print compare_fns(interpolation_linear, new_interpolation_linear_step4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Great! And look at that huge speed up in time already, just from moving the multiple, heavy einstein summation calculations up through the loops. We still have some more optimizing to do as we still have explicit loops in our code. Let's keep at it, we're almost there!\n",
+    "\n",
+    "#### Step 5\n",
+    "\n",
+    "The hard part is mostly over. We have to now think about the nominal variations. Recall that we were trying to add the nominals to the deltas in order to compute the new value. In practice, we'll return the delta variation only, but we'll show you how to get rid of this last loop. In this case, we want to figure out how to change code like\n",
+    "\n",
+    "```python\n",
+    "all_results    = []\n",
+    "for nset,histoset in enumerate(histogramssets):\n",
+    "    all_histos_deltas = allsets_all_histos_deltas[nset]\n",
+    "    set_result = []\n",
+    "    for nh,histo in enumerate(histoset):\n",
+    "        set_result.append([d + histoset[nh,1] for d in all_histos_deltas[nh]])\n",
+    "    all_results.append(set_result)\n",
+    "```\n",
+    "\n",
+    "to get rid of that most-nested loop\n",
+    "\n",
+    "```python\n",
+    "all_results    = []\n",
+    "for nset,histoset in enumerate(histogramssets):\n",
+    "    # look ma, no more loops inside!\n",
+    "```\n",
+    "\n",
+    "So how does this look?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# slowly getting rid of our loops to build the right output tensor -- gotta think about nominals\n",
+    "def new_interpolation_linear_step5(histogramssets,alphasets):\n",
+    "    histogramssets = np.asarray(histogramssets)\n",
+    "    alphasets      = np.asarray(alphasets)\n",
+    "    \n",
+    "    allset_all_histo_deltas_up = histogramssets[:,:,2] - histogramssets[:,:,1]\n",
+    "    allset_all_histo_deltas_dn = histogramssets[:,:,1] - histogramssets[:,:,0]\n",
+    "    allset_all_histo_nom = histogramssets[:,:,1]\n",
+    "    \n",
+    "    allsets_all_histos_alphas_times_deltas_up = np.einsum('sa,shb->shab',alphasets,allset_all_histo_deltas_up)\n",
+    "    allsets_all_histos_alphas_times_deltas_dn = np.einsum('sa,shb->shab',alphasets,allset_all_histo_deltas_dn)\n",
+    "    allsets_all_histos_masks = np.einsum('sa,s...u->s...au',alphasets > 0,np.ones_like(allset_all_histo_deltas_dn))\n",
+    "    \n",
+    "    allsets_all_histos_deltas = np.where(allsets_all_histos_masks,allsets_all_histos_alphas_times_deltas_up, allsets_all_histos_alphas_times_deltas_dn)\n",
+    "\n",
+    "    all_results    = []\n",
+    "    \n",
+    "    for nset,(_,alphaset) in enumerate(zip(histogramssets,alphasets)):\n",
+    "        all_histos_deltas = allsets_all_histos_deltas[nset]\n",
+    "        noms = histogramssets[nset,:,1]\n",
+    "        \n",
+    "        all_histos_noms_repeated = np.einsum('a,hn->han',np.ones_like(alphaset),noms)\n",
+    "\n",
+    "        set_result = all_histos_deltas + all_histos_noms_repeated\n",
+    "        all_results.append(set_result)\n",
+    "    return all_results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And does the calculation still match?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "interpolation_linear                     took 0.176400s.\n",
+      "new_interpolation_linear_step5           took 0.116659s.\n",
+      "True\n"
+     ]
+    }
+   ],
+   "source": [
+    "print compare_fns(interpolation_linear, new_interpolation_linear_step5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Fantastic! And look at the speed up. We're already ~2x faster than the for-loop and we're not even done yet.\n",
+    "\n",
+    "#### Step 6\n",
+    "\n",
+    "The final frontier. Also probably the best Star Wars episode. In any case, we have one more for-loop that needs to die in a slab of carbonite. This should be much easier now that you're more comfortable with tensor broadcasting and einstein summations.\n",
+    "\n",
+    "What does the function look like now?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def new_interpolation_linear_step6(histogramssets,alphasets):\n",
+    "    histogramssets = np.asarray(histogramssets)\n",
+    "    alphasets      = np.asarray(alphasets)\n",
+    "\n",
+    "    allset_allhisto_deltas_up = histogramssets[:,:,2] - histogramssets[:,:,1]\n",
+    "    allset_allhisto_deltas_dn = histogramssets[:,:,1] - histogramssets[:,:,0]\n",
+    "    allset_allhisto_nom = histogramssets[:,:,1]\n",
+    "    \n",
+    "    #x is dummy index\n",
+    "    \n",
+    "    allsets_allhistos_alphas_times_deltas_up = np.einsum('sa,shb->shab',alphasets,allset_allhisto_deltas_up)\n",
+    "    allsets_allhistos_alphas_times_deltas_dn = np.einsum('sa,shb->shab',alphasets,allset_allhisto_deltas_dn)\n",
+    "    allsets_allhistos_masks = np.einsum('sa,sxu->sxau',np.where(alphasets > 0, np.ones(alphasets.shape), np.zeros(alphasets.shape)),np.ones(allset_allhisto_deltas_dn.shape))\n",
+    "    \n",
+    "    allsets_allhistos_deltas = np.where(allsets_allhistos_masks,allsets_allhistos_alphas_times_deltas_up, allsets_allhistos_alphas_times_deltas_dn)\n",
+    "    allsets_allhistos_noms_repeated = np.einsum('sa,shb->shab',np.ones(alphasets.shape),allset_allhisto_nom)\n",
+    "    set_results = allsets_allhistos_deltas + allsets_allhistos_noms_repeated\n",
+    "    return set_results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And does the calculation still match?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "interpolation_linear                     took 0.195199s.\n",
+      "new_interpolation_linear_step6           took 0.118497s.\n",
+      "True\n"
+     ]
+    }
+   ],
+   "source": [
+    "print compare_fns(interpolation_linear, new_interpolation_linear_step6)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And we're done tensorizing it. There are some more improvements that could be made to make this interpolation calculation even more robust -- but for now we're done.\n",
+    "\n",
+    "### Tensorizing the Non-Linear Interpolator\n",
+    "\n",
+    "This is very, very similar to what we've done for the case of the linear interpolator. As such, we will provide the resulting functions for each step, and you can see how things perform all the way at the bottom. Enjoy and learn at your own pace!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def interpolation_nonlinear(histogramssets,alphasets):\n",
+    "    all_results = []\n",
+    "    for histoset, alphaset in zip(histogramssets,alphasets):\n",
+    "        all_results.append([])\n",
+    "        set_result = all_results[-1]\n",
+    "        for histo in histoset:\n",
+    "            set_result.append([])\n",
+    "            histo_result = set_result[-1]\n",
+    "            for alpha in alphaset:\n",
+    "                alpha_result = []\n",
+    "                for down,nom,up in zip(histo[0],histo[1],histo[2]):\n",
+    "                    delta_up = up/nom\n",
+    "                    delta_down = down/nom\n",
+    "                    if alpha > 0:\n",
+    "                        delta =  delta_up**alpha\n",
+    "                    else:\n",
+    "                        delta =  delta_down**(-alpha)\n",
+    "                    v = nom*delta\n",
+    "                    alpha_result.append(v)\n",
+    "                histo_result.append(alpha_result)\n",
+    "    return all_results\n",
+    "\n",
+    "def new_interpolation_nonlinear_step0(histogramssets,alphasets):\n",
+    "    histogramssets = np.asarray(histogramssets)\n",
+    "    alphasets = np.asarray(alphasets)\n",
+    "    all_results = []\n",
+    "    for histoset, alphaset in zip(histogramssets,alphasets):\n",
+    "        all_results.append([])\n",
+    "        set_result = all_results[-1]\n",
+    "        for histo in histoset:\n",
+    "            set_result.append([])\n",
+    "            histo_result = set_result[-1]\n",
+    "            for alpha in alphaset:\n",
+    "                alpha_result = []\n",
+    "                for down,nom,up in zip(histo[0],histo[1],histo[2]):\n",
+    "                    delta_up = up/nom\n",
+    "                    delta_down = down/nom\n",
+    "                    delta = np.where(alpha > 0, np.power(delta_up, alpha), np.power(delta_down, np.abs(alpha)))\n",
+    "                    v = nom*delta\n",
+    "                    alpha_result.append(v)\n",
+    "                histo_result.append(alpha_result)\n",
+    "    return all_results\n",
+    "\n",
+    "def new_interpolation_nonlinear_step1(histogramssets,alphasets):\n",
+    "    histogramssets = np.asarray(histogramssets)\n",
+    "    alphasets = np.asarray(alphasets)\n",
+    "    all_results = []\n",
+    "    for histoset, alphaset in zip(histogramssets,alphasets):\n",
+    "        all_results.append([])\n",
+    "        set_result = all_results[-1]\n",
+    "        for histo in histoset:\n",
+    "            set_result.append([])\n",
+    "            histo_result = set_result[-1]\n",
+    "            for alpha in alphaset:\n",
+    "                alpha_result = []\n",
+    "                deltas_up = np.divide(histo[2], histo[1])\n",
+    "                deltas_down = np.divide(histo[0], histo[1])\n",
+    "                bases = np.where(alpha > 0, deltas_up, deltas_down)\n",
+    "                exponents = np.abs(alpha)\n",
+    "                calc_deltas = np.power(bases, exponents)\n",
+    "                v = histo[1] * calc_deltas\n",
+    "                alpha_result.append(v)\n",
+    "                histo_result.append(alpha_result)\n",
+    "    return all_results\n",
+    "\n",
+    "def new_interpolation_nonlinear_step2(histogramssets,alphasets):\n",
+    "    histogramssets = np.asarray(histogramssets)\n",
+    "    alphasets      = np.asarray(alphasets)\n",
+    "    all_results    = []\n",
+    "    \n",
+    "    allset_all_histo_deltas_up = np.divide(histogramssets[:,:,2], histogramssets[:,:,1])\n",
+    "    allset_all_histo_deltas_dn = np.divide(histogramssets[:,:,0], histogramssets[:,:,1])\n",
+    "    \n",
+    "    for nset,(histoset, alphaset) in enumerate(zip(histogramssets,alphasets)):\n",
+    "        set_result = []\n",
+    "        \n",
+    "        all_histo_deltas_up = allset_all_histo_deltas_up[nset]\n",
+    "        all_histo_deltas_dn = allset_all_histo_deltas_dn[nset]\n",
+    "        \n",
+    "        for nh,histo in enumerate(histoset):\n",
+    "            alpha_deltas = []\n",
+    "            for alpha in alphaset:\n",
+    "                alpha_result = []\n",
+    "                deltas_up = all_histo_deltas_up[nh]\n",
+    "                deltas_down = all_histo_deltas_dn[nh]\n",
+    "                bases = np.where(alpha > 0, deltas_up, deltas_down)\n",
+    "                exponents = np.abs(alpha)\n",
+    "                calc_deltas = np.power(bases, exponents)\n",
+    "                alpha_deltas.append(calc_deltas)\n",
+    "            set_result.append([histo[1]*d for d in alpha_deltas])\n",
+    "        all_results.append(set_result)\n",
+    "    return all_results\n",
+    "\n",
+    "def new_interpolation_nonlinear_step3(histogramssets,alphasets):\n",
+    "    histogramssets = np.asarray(histogramssets)\n",
+    "    alphasets      = np.asarray(alphasets)\n",
+    "    all_results    = []\n",
+    "    \n",
+    "    allset_all_histo_deltas_up = np.divide(histogramssets[:,:,2], histogramssets[:,:,1])\n",
+    "    allset_all_histo_deltas_dn = np.divide(histogramssets[:,:,0], histogramssets[:,:,1])\n",
+    "    \n",
+    "    for nset,(histoset, alphaset) in enumerate(zip(histogramssets,alphasets)):\n",
+    "        set_result = []\n",
+    "        \n",
+    "        all_histo_deltas_up = allset_all_histo_deltas_up[nset]\n",
+    "        all_histo_deltas_dn = allset_all_histo_deltas_dn[nset]\n",
+    "        \n",
+    "        for nh,histo in enumerate(histoset):\n",
+    "            # bases and exponents need to have an outer product, to esentially tile or repeat over rows/cols\n",
+    "            bases_up = np.einsum('a,b->ab', np.ones(alphaset.shape), all_histo_deltas_up[nh])\n",
+    "            bases_dn = np.einsum('a,b->ab', np.ones(alphaset.shape), all_histo_deltas_dn[nh])\n",
+    "            exponents = np.einsum('a,b->ab', np.abs(alphaset), np.ones(all_histo_deltas_up[nh].shape))\n",
+    "\n",
+    "            masks = np.einsum('a,b->ab',alphaset > 0,np.ones(all_histo_deltas_dn[nh].shape))\n",
+    "            bases = np.where(masks, bases_up, bases_dn)\n",
+    "            alpha_deltas = np.power(bases, exponents)\n",
+    "            set_result.append([histo[1]*d for d in alpha_deltas])\n",
+    "            \n",
+    "        all_results.append(set_result)\n",
+    "    return all_results\n",
+    "\n",
+    "def new_interpolation_nonlinear_step4(histogramssets,alphasets):\n",
+    "    histogramssets = np.asarray(histogramssets)\n",
+    "    alphasets      = np.asarray(alphasets)\n",
+    "    all_results    = []\n",
+    "\n",
+    "    allset_all_histo_nom = histogramssets[:,:,1]\n",
+    "    allset_all_histo_deltas_up = np.divide(histogramssets[:,:,2], allset_all_histo_nom)\n",
+    "    allset_all_histo_deltas_dn = np.divide(histogramssets[:,:,0], allset_all_histo_nom)\n",
+    "\n",
+    "    bases_up = np.einsum('sa,shb->shab', np.ones(alphasets.shape), allset_all_histo_deltas_up)\n",
+    "    bases_dn = np.einsum('sa,shb->shab', np.ones(alphasets.shape), allset_all_histo_deltas_dn)\n",
+    "    exponents = np.einsum('sa,shb->shab', np.abs(alphasets), np.ones(allset_all_histo_deltas_up.shape))\n",
+    "\n",
+    "    masks = np.einsum('sa,shb->shab',alphasets > 0,np.ones(allset_all_histo_deltas_up.shape))\n",
+    "    bases = np.where(masks, bases_up, bases_dn)\n",
+    "\n",
+    "    allsets_all_histos_deltas = np.power(bases, exponents)\n",
+    "    \n",
+    "    all_results    = []\n",
+    "    for nset,histoset in enumerate(histogramssets):\n",
+    "        all_histos_deltas = allsets_all_histos_deltas[nset]\n",
+    "        set_result = []\n",
+    "        for nh,histo in enumerate(histoset):\n",
+    "            set_result.append([histoset[nh,1]*d for d in all_histos_deltas[nh]])\n",
+    "        all_results.append(set_result)\n",
+    "    return all_results\n",
+    "\n",
+    "def new_interpolation_nonlinear_step5(histogramssets,alphasets):\n",
+    "    histogramssets = np.asarray(histogramssets)\n",
+    "    alphasets      = np.asarray(alphasets)\n",
+    "    all_results    = []\n",
+    "\n",
+    "    allset_all_histo_nom = histogramssets[:,:,1]\n",
+    "    allset_all_histo_deltas_up = np.divide(histogramssets[:,:,2], allset_all_histo_nom)\n",
+    "    allset_all_histo_deltas_dn = np.divide(histogramssets[:,:,0], allset_all_histo_nom)\n",
+    "\n",
+    "    bases_up = np.einsum('sa,shb->shab', np.ones(alphasets.shape), allset_all_histo_deltas_up)\n",
+    "    bases_dn = np.einsum('sa,shb->shab', np.ones(alphasets.shape), allset_all_histo_deltas_dn)\n",
+    "    exponents = np.einsum('sa,shb->shab', np.abs(alphasets), np.ones(allset_all_histo_deltas_up.shape))\n",
+    "\n",
+    "    masks = np.einsum('sa,shb->shab',alphasets > 0,np.ones(allset_all_histo_deltas_up.shape))\n",
+    "    bases = np.where(masks, bases_up, bases_dn)\n",
+    "\n",
+    "    allsets_all_histos_deltas = np.power(bases, exponents)\n",
+    "    \n",
+    "    all_results    = []    \n",
+    "    for nset,(_,alphaset) in enumerate(zip(histogramssets,alphasets)):\n",
+    "        all_histos_deltas = allsets_all_histos_deltas[nset]\n",
+    "        noms = allset_all_histo_nom[nset]\n",
+    "        all_histos_noms_repeated = np.einsum('a,hn->han',np.ones_like(alphaset),noms)\n",
+    "        set_result = all_histos_deltas * all_histos_noms_repeated\n",
+    "        all_results.append(set_result)\n",
+    "    return all_results\n",
+    "\n",
+    "def new_interpolation_nonlinear_step6(histogramssets,alphasets):\n",
+    "    histogramssets = np.asarray(histogramssets)\n",
+    "    alphasets      = np.asarray(alphasets)\n",
+    "    all_results    = []\n",
+    "\n",
+    "    allset_all_histo_nom = histogramssets[:,:,1]\n",
+    "    allset_all_histo_deltas_up = np.divide(histogramssets[:,:,2], allset_all_histo_nom)\n",
+    "    allset_all_histo_deltas_dn = np.divide(histogramssets[:,:,0], allset_all_histo_nom)\n",
+    "\n",
+    "    bases_up = np.einsum('sa,shb->shab', np.ones(alphasets.shape), allset_all_histo_deltas_up)\n",
+    "    bases_dn = np.einsum('sa,shb->shab', np.ones(alphasets.shape), allset_all_histo_deltas_dn)\n",
+    "    exponents = np.einsum('sa,shb->shab', np.abs(alphasets), np.ones(allset_all_histo_deltas_up.shape))\n",
+    "\n",
+    "    masks = np.einsum('sa,shb->shab',alphasets > 0,np.ones(allset_all_histo_deltas_up.shape))\n",
+    "    bases = np.where(masks, bases_up, bases_dn)\n",
+    "\n",
+    "    allsets_all_histos_deltas = np.power(bases, exponents)\n",
+    "    allsets_allhistos_noms_repeated = np.einsum('sa,shb->shab', np.ones(alphasets.shape), allset_all_histo_nom)\n",
+    "    set_results = allsets_all_histos_deltas * allsets_allhistos_noms_repeated\n",
+    "    return set_results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "interpolation_linear                     took 0.195565s.\n",
+      "new_interpolation_linear_step0           took 0.441513s.\n",
+      "True\n",
+      "interpolation_linear                     took 0.220087s.\n",
+      "new_interpolation_linear_step1           took 0.605430s.\n",
+      "True\n",
+      "interpolation_linear                     took 0.210433s.\n",
+      "new_interpolation_linear_step2           took 0.508479s.\n",
+      "True\n",
+      "interpolation_linear                     took 0.234420s.\n",
+      "new_interpolation_linear_step3           took 0.983062s.\n",
+      "True\n",
+      "interpolation_linear                     took 0.213969s.\n",
+      "new_interpolation_linear_step4           took 0.294863s.\n",
+      "True\n",
+      "interpolation_linear                     took 0.197236s.\n",
+      "new_interpolation_linear_step5           took 0.112138s.\n",
+      "True\n",
+      "interpolation_linear                     took 0.194492s.\n",
+      "new_interpolation_linear_step6           took 0.126083s.\n",
+      "True\n"
+     ]
+    }
+   ],
+   "source": [
+    "print compare_fns(interpolation_linear, new_interpolation_linear_step0)\n",
+    "print compare_fns(interpolation_linear, new_interpolation_linear_step1)\n",
+    "print compare_fns(interpolation_linear, new_interpolation_linear_step2)\n",
+    "print compare_fns(interpolation_linear, new_interpolation_linear_step3)\n",
+    "print compare_fns(interpolation_linear, new_interpolation_linear_step4)\n",
+    "print compare_fns(interpolation_linear, new_interpolation_linear_step5)\n",
+    "print compare_fns(interpolation_linear, new_interpolation_linear_step6)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/examples/notebooks/learn/TensorizingInterpolations.ipynb
+++ b/docs/examples/notebooks/learn/TensorizingInterpolations.ipynb
@@ -151,7 +151,6 @@
    "source": [
     "def compare_fns(func1, func2):\n",
     "    h,a = random_histosets_alphasets_pair()\n",
-    "    h,a = h.tolist(), a.tolist()\n",
     "\n",
     "    def _func_runner(func, histssets, alphasets):\n",
     "        return np.asarray(func(histssets,alphasets))\n",
@@ -203,8 +202,6 @@
    "source": [
     "# get the internal calculation to use tensorlib backend\n",
     "def new_interpolation_linear_step0(histogramssets,alphasets):\n",
-    "    histogramssets = np.asarray(histogramssets)\n",
-    "    alphasets = np.asarray(alphasets)\n",
     "    all_results = []\n",
     "    for histoset, alphaset in zip(histogramssets,alphasets):\n",
     "        all_results.append([])\n",
@@ -258,7 +255,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10 loops, best of 3: 69.4 ms per loop\n"
+      "1 loop, best of 3: 182 ms per loop\n"
      ]
     }
    ],
@@ -276,7 +273,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loop, best of 3: 284 ms per loop\n"
+      "1 loop, best of 3: 254 ms per loop\n"
      ]
     }
    ],
@@ -319,8 +316,6 @@
    "source": [
     "# update the delta variations to remove the zip() call and remove most-nested loop\n",
     "def new_interpolation_linear_step1(histogramssets,alphasets):\n",
-    "    histogramssets = np.asarray(histogramssets)\n",
-    "    alphasets = np.asarray(alphasets)\n",
     "    all_results = []\n",
     "    for histoset, alphaset in zip(histogramssets,alphasets):\n",
     "        all_results.append([])\n",
@@ -373,7 +368,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10 loops, best of 3: 69.8 ms per loop\n"
+      "10 loops, best of 3: 182 ms per loop\n"
      ]
     }
    ],
@@ -391,7 +386,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loop, best of 3: 441 ms per loop\n"
+      "1 loop, best of 3: 433 ms per loop\n"
      ]
     }
    ],
@@ -437,8 +432,6 @@
    "source": [
     "# figure out the giant array of all deltas at the beginning and only take subsets of it for the calculation\n",
     "def new_interpolation_linear_step2(histogramssets,alphasets):\n",
-    "    histogramssets = np.asarray(histogramssets)\n",
-    "    alphasets      = np.asarray(alphasets)\n",
     "    all_results    = []\n",
     "    \n",
     "    allset_all_histo_deltas_up = histogramssets[:,:,2] - histogramssets[:,:,1]\n",
@@ -497,7 +490,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10 loops, best of 3: 71 ms per loop\n"
+      "1 loop, best of 3: 176 ms per loop\n"
      ]
     }
    ],
@@ -515,7 +508,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loop, best of 3: 365 ms per loop\n"
+      "1 loop, best of 3: 376 ms per loop\n"
      ]
     }
    ],
@@ -574,8 +567,6 @@
    "source": [
     "# remove the loop over alphas, starts using einsum to help generalize to more dimensions\n",
     "def new_interpolation_linear_step3(histogramssets,alphasets):\n",
-    "    histogramssets = np.asarray(histogramssets)\n",
-    "    alphasets      = np.asarray(alphasets)\n",
     "    all_results    = []\n",
     "    \n",
     "    allset_all_histo_deltas_up = histogramssets[:,:,2] - histogramssets[:,:,1]\n",
@@ -633,7 +624,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10 loops, best of 3: 71.2 ms per loop\n"
+      "1 loop, best of 3: 176 ms per loop\n"
      ]
     }
    ],
@@ -651,7 +642,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loop, best of 3: 840 ms per loop\n"
+      "1 loop, best of 3: 786 ms per loop\n"
      ]
     }
    ],
@@ -708,9 +699,6 @@
    "source": [
     "# move the einsums to outer loops to get ready to get rid of all loops\n",
     "def new_interpolation_linear_step4(histogramssets,alphasets):\n",
-    "    histogramssets = np.asarray(histogramssets)\n",
-    "    alphasets      = np.asarray(alphasets)\n",
-    "    \n",
     "    allset_all_histo_deltas_up = histogramssets[:,:,2] - histogramssets[:,:,1]\n",
     "    allset_all_histo_deltas_dn = histogramssets[:,:,1] - histogramssets[:,:,0]\n",
     "    allset_all_histo_nom = histogramssets[:,:,1]\n",
@@ -765,7 +753,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10 loops, best of 3: 68.4 ms per loop\n"
+      "1 loop, best of 3: 185 ms per loop\n"
      ]
     }
    ],
@@ -783,7 +771,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10 loops, best of 3: 154 ms per loop\n"
+      "10 loops, best of 3: 131 ms per loop\n"
      ]
     }
    ],
@@ -831,9 +819,6 @@
    "source": [
     "# slowly getting rid of our loops to build the right output tensor -- gotta think about nominals\n",
     "def new_interpolation_linear_step5(histogramssets,alphasets):\n",
-    "    histogramssets = np.asarray(histogramssets)\n",
-    "    alphasets      = np.asarray(alphasets)\n",
-    "    \n",
     "    allset_all_histo_deltas_up = histogramssets[:,:,2] - histogramssets[:,:,1]\n",
     "    allset_all_histo_deltas_dn = histogramssets[:,:,1] - histogramssets[:,:,0]\n",
     "    allset_all_histo_nom = histogramssets[:,:,1]\n",
@@ -891,7 +876,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10 loops, best of 3: 69.8 ms per loop\n"
+      "1 loop, best of 3: 182 ms per loop\n"
      ]
     }
    ],
@@ -909,7 +894,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10 loops, best of 3: 41 ms per loop\n"
+      "1000 loops, best of 3: 1.66 ms per loop\n"
      ]
     }
    ],
@@ -933,14 +918,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
     "def new_interpolation_linear_step6(histogramssets,alphasets):\n",
-    "    histogramssets = np.asarray(histogramssets)\n",
-    "    alphasets      = np.asarray(alphasets)\n",
-    "\n",
     "    allset_allhisto_deltas_up = histogramssets[:,:,2] - histogramssets[:,:,1]\n",
     "    allset_allhisto_deltas_dn = histogramssets[:,:,1] - histogramssets[:,:,0]\n",
     "    allset_allhisto_nom = histogramssets[:,:,1]\n",
@@ -966,7 +948,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
@@ -984,14 +966,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10 loops, best of 3: 68.9 ms per loop\n"
+      "1 loop, best of 3: 194 ms per loop\n"
      ]
     }
    ],
@@ -1002,14 +984,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10 loops, best of 3: 43.1 ms per loop\n"
+      "1000 loops, best of 3: 435 µs per loop\n"
      ]
     }
    ],
@@ -1031,7 +1013,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1058,8 +1040,6 @@
     "    return all_results\n",
     "\n",
     "def new_interpolation_nonlinear_step0(histogramssets,alphasets):\n",
-    "    histogramssets = np.asarray(histogramssets)\n",
-    "    alphasets = np.asarray(alphasets)\n",
     "    all_results = []\n",
     "    for histoset, alphaset in zip(histogramssets,alphasets):\n",
     "        all_results.append([])\n",
@@ -1079,8 +1059,6 @@
     "    return all_results\n",
     "\n",
     "def new_interpolation_nonlinear_step1(histogramssets,alphasets):\n",
-    "    histogramssets = np.asarray(histogramssets)\n",
-    "    alphasets = np.asarray(alphasets)\n",
     "    all_results = []\n",
     "    for histoset, alphaset in zip(histogramssets,alphasets):\n",
     "        all_results.append([])\n",
@@ -1101,8 +1079,6 @@
     "    return all_results\n",
     "\n",
     "def new_interpolation_nonlinear_step2(histogramssets,alphasets):\n",
-    "    histogramssets = np.asarray(histogramssets)\n",
-    "    alphasets      = np.asarray(alphasets)\n",
     "    all_results    = []\n",
     "    \n",
     "    allset_all_histo_deltas_up = np.divide(histogramssets[:,:,2], histogramssets[:,:,1])\n",
@@ -1129,8 +1105,6 @@
     "    return all_results\n",
     "\n",
     "def new_interpolation_nonlinear_step3(histogramssets,alphasets):\n",
-    "    histogramssets = np.asarray(histogramssets)\n",
-    "    alphasets      = np.asarray(alphasets)\n",
     "    all_results    = []\n",
     "    \n",
     "    allset_all_histo_deltas_up = np.divide(histogramssets[:,:,2], histogramssets[:,:,1])\n",
@@ -1157,8 +1131,6 @@
     "    return all_results\n",
     "\n",
     "def new_interpolation_nonlinear_step4(histogramssets,alphasets):\n",
-    "    histogramssets = np.asarray(histogramssets)\n",
-    "    alphasets      = np.asarray(alphasets)\n",
     "    all_results    = []\n",
     "\n",
     "    allset_all_histo_nom = histogramssets[:,:,1]\n",
@@ -1184,8 +1156,6 @@
     "    return all_results\n",
     "\n",
     "def new_interpolation_nonlinear_step5(histogramssets,alphasets):\n",
-    "    histogramssets = np.asarray(histogramssets)\n",
-    "    alphasets      = np.asarray(alphasets)\n",
     "    all_results    = []\n",
     "\n",
     "    allset_all_histo_nom = histogramssets[:,:,1]\n",
@@ -1211,8 +1181,6 @@
     "    return all_results\n",
     "\n",
     "def new_interpolation_nonlinear_step6(histogramssets,alphasets):\n",
-    "    histogramssets = np.asarray(histogramssets)\n",
-    "    alphasets      = np.asarray(alphasets)\n",
     "    all_results    = []\n",
     "\n",
     "    allset_all_histo_nom = histogramssets[:,:,1]\n",
@@ -1234,7 +1202,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
@@ -1252,14 +1220,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10 loops, best of 3: 69.6 ms per loop\n"
+      "1 loop, best of 3: 182 ms per loop\n"
      ]
     }
    ],
@@ -1270,14 +1238,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loop, best of 3: 615 ms per loop\n"
+      "1 loop, best of 3: 593 ms per loop\n"
      ]
     }
    ],
@@ -1288,7 +1256,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [
     {
@@ -1306,14 +1274,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10 loops, best of 3: 68.1 ms per loop\n"
+      "1 loop, best of 3: 185 ms per loop\n"
      ]
     }
    ],
@@ -1324,14 +1292,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loop, best of 3: 562 ms per loop\n"
+      "1 loop, best of 3: 545 ms per loop\n"
      ]
     }
    ],
@@ -1342,7 +1310,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
@@ -1360,14 +1328,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10 loops, best of 3: 65.7 ms per loop\n"
+      "1 loop, best of 3: 177 ms per loop\n"
      ]
     }
    ],
@@ -1378,14 +1346,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loop, best of 3: 421 ms per loop\n"
+      "1 loop, best of 3: 446 ms per loop\n"
      ]
     }
    ],
@@ -1396,7 +1364,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [
     {
@@ -1414,14 +1382,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10 loops, best of 3: 70.4 ms per loop\n"
+      "10 loops, best of 3: 181 ms per loop\n"
      ]
     }
    ],
@@ -1432,14 +1400,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loop, best of 3: 1.29 s per loop\n"
+      "1 loop, best of 3: 1.27 s per loop\n"
      ]
     }
    ],
@@ -1450,7 +1418,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [
     {
@@ -1468,14 +1436,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10 loops, best of 3: 65 ms per loop\n"
+      "1 loop, best of 3: 167 ms per loop\n"
      ]
     }
    ],
@@ -1486,14 +1454,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10 loops, best of 3: 157 ms per loop\n"
+      "10 loops, best of 3: 128 ms per loop\n"
      ]
     }
    ],
@@ -1504,7 +1472,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [
     {
@@ -1522,14 +1490,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10 loops, best of 3: 64.1 ms per loop\n"
+      "10 loops, best of 3: 171 ms per loop\n"
      ]
     }
    ],
@@ -1540,14 +1508,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 52,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10 loops, best of 3: 43.2 ms per loop\n"
+      "100 loops, best of 3: 2.47 ms per loop\n"
      ]
     }
    ],
@@ -1558,7 +1526,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [
     {
@@ -1576,14 +1544,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 54,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10 loops, best of 3: 64.6 ms per loop\n"
+      "10 loops, best of 3: 192 ms per loop\n"
      ]
     }
    ],
@@ -1594,14 +1562,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 55,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10 loops, best of 3: 43 ms per loop\n"
+      "1000 loops, best of 3: 1.51 ms per loop\n"
      ]
     }
    ],

--- a/pyhf/interpolate.py
+++ b/pyhf/interpolate.py
@@ -3,7 +3,6 @@ log = logging.getLogger(__name__)
 
 from . import get_backend
 from . import exceptions
-from . import utils
 
 def _slow_hfinterp_looper(histogramssets, alphasets, func):
     all_results = []

--- a/pyhf/interpolate.py
+++ b/pyhf/interpolate.py
@@ -5,15 +5,31 @@ from . import get_backend
 from . import exceptions
 from . import utils
 
+def _kitchensink_looper(histogramssets, alphasets, func):
+    all_results = []
+    for histoset, alphaset in zip(histogramssets, alphasets):
+        all_results.append([])
+        set_result = all_results[-1]
+        for histo in histoset:
+            set_result.append([])
+            histo_result = set_result[-1]
+            for alpha in alphaset:
+                alpha_result = []
+                for down,nom,up in zip(histo[0],histo[1],histo[2]):
+                    v = func(down, nom, up, alpha)
+                    alpha_result.append(v)
+                histo_result.append(alpha_result)
+    return all_results
+
 @utils.tensorize_args
-def _hfinterp_code0(at_minus_one, at_zero, at_plus_one, alphas):
+def _hfinterp_code0(at_minus_one, at_zero, at_plus_one, alphasets):
     tensorlib, _ = get_backend()
-    #warning: alphas must be ordered
+    #warning: alphasets must be ordered
     up_variation  = at_plus_one - at_zero
     down_variation = at_zero - at_minus_one
 
-    positive_parameters = alphas[alphas >= 0]
-    negative_parameters = alphas[alphas < 0]
+    positive_parameters = alphasets[alphasets >= 0]
+    negative_parameters = alphasets[alphasets < 0]
 
     w_pos = positive_parameters * tensorlib.ones(up_variation.shape + positive_parameters.shape)
     r_pos = up_variation.reshape(up_variation.shape + (1,)) * w_pos
@@ -25,15 +41,27 @@ def _hfinterp_code0(at_minus_one, at_zero, at_plus_one, alphas):
     result = tensorlib.einsum('...ij->...ji', result)
     return result
 
+def _kitchensink_code0(histogramssets, alphasets):
+    def summand(down, nom, up, alpha):
+        delta_up = up - nom
+        delta_down = nom - down
+        if alpha > 0:
+            delta =  delta_up*alpha
+        else:
+            delta =  delta_down*alpha
+        return nom + delta
+
+    return _kitchensink_looper(histogramssets, alphasets, summand)
+
 @utils.tensorize_args
-def _hfinterp_code1(at_minus_one, at_zero, at_plus_one, alphas):
+def _hfinterp_code1(at_minus_one, at_zero, at_plus_one, alphasets):
     tensorlib, _ = get_backend()
-    #warning: alphas must be ordered
+    #warning: alphasets must be ordered
     up_variation = tensorlib.divide(at_plus_one, at_zero)
     down_variation = tensorlib.divide(at_minus_one, at_zero)
 
-    positive_parameters = alphas[alphas >= 0]
-    negative_parameters = alphas[alphas < 0]
+    positive_parameters = alphasets[alphasets >= 0]
+    negative_parameters = alphasets[alphasets < 0]
 
     bases_negative = tensorlib.tile(down_variation, negative_parameters.shape+(1,)*len(down_variation.shape))
     bases_negative = tensorlib.einsum('i...->...i', bases_negative)
@@ -50,10 +78,24 @@ def _hfinterp_code1(at_minus_one, at_zero, at_plus_one, alphas):
     result = tensorlib.concatenate([res_neg, res_pos], axis=-1)
     return tensorlib.einsum('...ij->...ji', result)
 
+def _kitchensink_code1(histogramssets, alphasets):
+    def product(down, nom, up, alpha):
+        delta_up = up/nom
+        delta_down = down/nom
+        if alpha > 0:
+            delta =  delta_up**alpha
+        else:
+            delta =  delta_down**(-alpha)
+        return nom*delta
+
+    return _kitchensink_looper(histogramssets, alphasets, product)
+
+
 # interpolation codes come from https://cds.cern.ch/record/1456844/files/CERN-OPEN-2012-016.pdf
-def interpolator(interpcode):
-    interpcodes = {0: _hfinterp_code0,
-                   1: _hfinterp_code1}
+def interpolator(interpcode, do_optimal=True):
+    interpcodes = {0: _hfinterp_code0 if do_optimal else _kitchensink_code0,
+                   1: _hfinterp_code1 if do_optimal else _kitchensink_code1}
+
     try:
         return interpcodes[interpcode]
     except KeyError:

--- a/pyhf/interpolate.py
+++ b/pyhf/interpolate.py
@@ -89,9 +89,9 @@ def _slow_hfinterp_code1(histogramssets, alphasets):
 
 
 # interpolation codes come from https://cds.cern.ch/record/1456844/files/CERN-OPEN-2012-016.pdf
-def interpolator(interpcode, do_optimal=True):
-    interpcodes = {0: _hfinterp_code0 if do_optimal else _slow_hfinterp_code0,
-                   1: _hfinterp_code1 if do_optimal else _slow_hfinterp_code1}
+def interpolator(interpcode, do_tensorized_calc=True):
+    interpcodes = {0: _hfinterp_code0 if do_tensorized_calc else _slow_hfinterp_code0,
+                   1: _hfinterp_code1 if do_tensorized_calc else _slow_hfinterp_code1}
 
     try:
         return interpcodes[interpcode]

--- a/pyhf/interpolate.py
+++ b/pyhf/interpolate.py
@@ -21,7 +21,6 @@ def _slow_hfinterp_looper(histogramssets, alphasets, func):
                 histo_result.append(alpha_result)
     return all_results
 
-@utils.tensorize_args
 def _hfinterp_code0(histogramssets, alphasets):
     tensorlib, _ = get_backend()
 
@@ -53,7 +52,6 @@ def _slow_hfinterp_code0(histogramssets, alphasets):
 
     return _slow_hfinterp_looper(histogramssets, alphasets, summand)
 
-@utils.tensorize_args
 def _hfinterp_code1(histogramssets, alphasets):
     tensorlib, _ = get_backend()
 

--- a/pyhf/interpolate.py
+++ b/pyhf/interpolate.py
@@ -3,33 +3,52 @@ log = logging.getLogger(__name__)
 
 from . import get_backend
 from . import exceptions
+from . import utils
 
+@utils.tensorize_args
 def _hfinterp_code0(at_minus_one, at_zero, at_plus_one, alphas):
     tensorlib, _ = get_backend()
-    at_minus_one = tensorlib.astensor(at_minus_one)
-    at_zero = tensorlib.astensor(at_zero)
-    at_plus_one = tensorlib.astensor(at_plus_one)
-    alphas = tensorlib.astensor(alphas)
+    #warning: alphas must be ordered
+    up_variation  = at_plus_one - at_zero
+    down_variation = at_zero - at_minus_one
 
-    iplus_izero  = at_plus_one - at_zero
-    izero_iminus = at_zero - at_minus_one
-    mask = tensorlib.outer(alphas < 0, tensorlib.ones(iplus_izero.shape))
-    return tensorlib.where(mask, tensorlib.outer(alphas, izero_iminus), tensorlib.outer(alphas, iplus_izero))
+    positive_parameters = alphas[alphas >= 0]
+    negative_parameters = alphas[alphas < 0]
 
+    w_pos = positive_parameters * tensorlib.ones(up_variation.shape + positive_parameters.shape)
+    r_pos = up_variation.reshape(up_variation.shape + (1,)) * w_pos
+
+    w_neg = negative_parameters * tensorlib.ones(down_variation.shape + negative_parameters.shape)
+    r_neg = down_variation.reshape(down_variation.shape + (1,)) * w_neg
+
+    result = tensorlib.concatenate([r_neg, r_pos], axis=-1)
+    result = tensorlib.einsum('...ij->...ji', result)
+    return result
+
+@utils.tensorize_args
 def _hfinterp_code1(at_minus_one, at_zero, at_plus_one, alphas):
     tensorlib, _ = get_backend()
-    at_minus_one = tensorlib.astensor(at_minus_one)
-    at_zero = tensorlib.astensor(at_zero)
-    at_plus_one = tensorlib.astensor(at_plus_one)
-    alphas = tensorlib.astensor(alphas)
+    #warning: alphas must be ordered
+    up_variation = tensorlib.divide(at_plus_one, at_zero)
+    down_variation = tensorlib.divide(at_minus_one, at_zero)
 
-    base_positive = tensorlib.divide(at_plus_one,  at_zero)
-    base_negative = tensorlib.divide(at_minus_one, at_zero)
-    expo_positive = tensorlib.outer(alphas, tensorlib.ones(base_positive.shape))
-    mask = tensorlib.outer(alphas > 0, tensorlib.ones(base_positive.shape))
-    bases = tensorlib.where(mask,base_positive,base_negative)
-    exponents = tensorlib.where(mask, expo_positive,-expo_positive)
-    return tensorlib.power(bases, exponents)
+    positive_parameters = alphas[alphas >= 0]
+    negative_parameters = alphas[alphas < 0]
+
+    bases_negative = tensorlib.tile(down_variation, negative_parameters.shape+(1,)*len(down_variation.shape))
+    bases_negative = tensorlib.einsum('i...->...i', bases_negative)
+
+    bases_positive = tensorlib.tile(up_variation, positive_parameters.shape+(1,)*len(up_variation.shape))
+    bases_positive = tensorlib.einsum('i...->...i', bases_positive)
+
+    expo_positive = tensorlib.tile(positive_parameters, up_variation.shape+(1,)) #was outer
+    expo_negative = -tensorlib.tile(negative_parameters, down_variation.shape+(1,)) #was outer
+
+    res_neg = tensorlib.power(bases_negative, expo_negative)
+    res_pos = tensorlib.power(bases_positive, expo_positive)
+
+    result = tensorlib.concatenate([res_neg, res_pos], axis=-1)
+    return tensorlib.einsum('...ij->...ji', result)
 
 # interpolation codes come from https://cds.cern.ch/record/1456844/files/CERN-OPEN-2012-016.pdf
 def interpolator(interpcode):

--- a/pyhf/interpolate.py
+++ b/pyhf/interpolate.py
@@ -5,7 +5,7 @@ from . import get_backend
 from . import exceptions
 from . import utils
 
-def _kitchensink_looper(histogramssets, alphasets, func):
+def _slow_hfinterp_looper(histogramssets, alphasets, func):
     all_results = []
     for histoset, alphaset in zip(histogramssets, alphasets):
         all_results.append([])
@@ -45,7 +45,7 @@ def _hfinterp_code0(histogramssets, alphasets):
     set_results = allsets_allhistos_deltas + allsets_allhistos_noms_repeated
     return set_results
 
-def _kitchensink_code0(histogramssets, alphasets):
+def _slow_hfinterp_code0(histogramssets, alphasets):
     def summand(down, nom, up, alpha):
         delta_up = up - nom
         delta_down = nom - down
@@ -55,7 +55,7 @@ def _kitchensink_code0(histogramssets, alphasets):
             delta =  delta_down*alpha
         return nom + delta
 
-    return _kitchensink_looper(histogramssets, alphasets, summand)
+    return _slow_hfinterp_looper(histogramssets, alphasets, summand)
 
 @utils.tensorize_args
 def _hfinterp_code1(histogramssets, alphasets):
@@ -83,7 +83,7 @@ def _hfinterp_code1(histogramssets, alphasets):
     set_results = allsets_allhistos_deltas * allsets_allhistos_noms_repeated
     return set_results
 
-def _kitchensink_code1(histogramssets, alphasets):
+def _slow_hfinterp_code1(histogramssets, alphasets):
     def product(down, nom, up, alpha):
         delta_up = up/nom
         delta_down = down/nom
@@ -93,13 +93,13 @@ def _kitchensink_code1(histogramssets, alphasets):
             delta =  delta_down**(-alpha)
         return nom*delta
 
-    return _kitchensink_looper(histogramssets, alphasets, product)
+    return _slow_hfinterp_looper(histogramssets, alphasets, product)
 
 
 # interpolation codes come from https://cds.cern.ch/record/1456844/files/CERN-OPEN-2012-016.pdf
 def interpolator(interpcode, do_optimal=True):
-    interpcodes = {0: _hfinterp_code0 if do_optimal else _kitchensink_code0,
-                   1: _hfinterp_code1 if do_optimal else _kitchensink_code1}
+    interpcodes = {0: _hfinterp_code0 if do_optimal else _slow_hfinterp_code0,
+                   1: _hfinterp_code1 if do_optimal else _slow_hfinterp_code1}
 
     try:
         return interpcodes[interpcode]

--- a/pyhf/interpolate.py
+++ b/pyhf/interpolate.py
@@ -22,8 +22,10 @@ def _kitchensink_looper(histogramssets, alphasets, func):
     return all_results
 
 @utils.tensorize_args
-def _hfinterp_code0(at_minus_one, at_zero, at_plus_one, alphasets):
+def _hfinterp_code0(histogramssets, alphasets):
     tensorlib, _ = get_backend()
+    at_plus_one, at_zero, at_minus_one = histogramssets[0][0]
+
     #warning: alphasets must be ordered
     up_variation  = at_plus_one - at_zero
     down_variation = at_zero - at_minus_one
@@ -54,9 +56,11 @@ def _kitchensink_code0(histogramssets, alphasets):
     return _kitchensink_looper(histogramssets, alphasets, summand)
 
 @utils.tensorize_args
-def _hfinterp_code1(at_minus_one, at_zero, at_plus_one, alphasets):
+def _hfinterp_code1(histogramssets, alphasets):
     tensorlib, _ = get_backend()
     #warning: alphasets must be ordered
+    at_plus_one, at_zero, at_minus_one = histogramssets[0][0]
+
     up_variation = tensorlib.divide(at_plus_one, at_zero)
     down_variation = tensorlib.divide(at_minus_one, at_zero)
 

--- a/pyhf/modifiers/histosys.py
+++ b/pyhf/modifiers/histosys.py
@@ -46,7 +46,18 @@ class histosys(object):
 
     def apply(self, channel, sample, pars):
         assert int(pars.shape[0]) == 1
-        return interpolator(0)(self.at_minus_one[channel['name']][sample['name']],
-                               self.at_zero[channel['name']][sample['name']],
-                               self.at_plus_one[channel['name']][sample['name']],
-                               pars)[0]
+
+        tensorlib, _ = get_backend()
+        results = interpolator(0)(
+            tensorlib.astensor([
+                [
+                    [
+                        self.at_minus_one[channel['name']][sample['name']],
+                        self.at_zero[channel['name']][sample['name']],
+                        self.at_plus_one[channel['name']][sample['name']]
+                    ]
+                ]
+            ]), tensorlib.astensor([tensorlib.tolist(pars)])
+        )
+
+        return results[0][0][0]

--- a/pyhf/modifiers/normsys.py
+++ b/pyhf/modifiers/normsys.py
@@ -36,7 +36,21 @@ class normsys(object):
     def apply(self, channel, sample, pars):
         # normsysfactor(nom_sys_alphas)   = 1 + sum(interp(1, anchors[i][0], anchors[i][0], val=alpha)  for i in range(nom_sys_alphas))
         assert int(pars.shape[0]) == 1
-        return interpolator(1)(self.at_minus_one[channel['name']][sample['name']],
-                               self.at_zero,
-                               self.at_plus_one[channel['name']][sample['name']],
-                               pars)[0]
+
+    def apply(self, channel, sample, pars):
+        assert int(pars.shape[0]) == 1
+
+        tensorlib, _ = get_backend()
+        results = interpolator(1)(
+            tensorlib.astensor([
+                [
+                    [
+                        self.at_minus_one[channel['name']][sample['name']],
+                        self.at_zero,
+                        self.at_plus_one[channel['name']][sample['name']]
+                    ]
+                ]
+            ]), tensorlib.astensor([tensorlib.tolist(pars)])
+        )
+
+        return results[0][0][0]

--- a/pyhf/modifiers/normsys.py
+++ b/pyhf/modifiers/normsys.py
@@ -37,9 +37,6 @@ class normsys(object):
         # normsysfactor(nom_sys_alphas)   = 1 + sum(interp(1, anchors[i][0], anchors[i][0], val=alpha)  for i in range(nom_sys_alphas))
         assert int(pars.shape[0]) == 1
 
-    def apply(self, channel, sample, pars):
-        assert int(pars.shape[0]) == 1
-
         tensorlib, _ = get_backend()
         results = interpolator(1)(
             tensorlib.astensor([

--- a/pyhf/utils.py
+++ b/pyhf/utils.py
@@ -162,3 +162,18 @@ def runOnePoint(muTest, data, pdf, init_pars = None, par_bounds = None):
             pvals_from_teststat(sqrtqmu_v_sigma, sqrtqmuA_v)[-1])
     CLs_exp = tensorlib.astensor(CLs_exp)
     return qmu_v, qmuA_v, CLsb, CLb, CLs, CLs_exp
+
+def tensorize_args(callable):
+    def _inner(*args, **kwargs):
+        messages = ["no attribute '__getitem__'"]
+        try:
+            return callable(*args, **kwargs)
+        except TypeError as e:
+            if any(message in e.message for message in messages):
+                tensorlib, _ = get_backend()
+                args = map(tensorlib.astensor, args)
+                kwargs = {k: tensorlib.astensor(v) for k,v in kwargs.items()}
+                return callable(*args, **kwargs)
+            else:
+                raise
+    return _inner

--- a/pyhf/utils.py
+++ b/pyhf/utils.py
@@ -162,18 +162,3 @@ def runOnePoint(muTest, data, pdf, init_pars = None, par_bounds = None):
             pvals_from_teststat(sqrtqmu_v_sigma, sqrtqmuA_v)[-1])
     CLs_exp = tensorlib.astensor(CLs_exp)
     return qmu_v, qmuA_v, CLsb, CLb, CLs, CLs_exp
-
-def tensorize_args(callable):
-    def _inner(*args, **kwargs):
-        messages = ["no attribute '__getitem__'"]
-        try:
-            return callable(*args, **kwargs)
-        except TypeError as e:
-            if any(message in e.message for message in messages):
-                tensorlib, _ = get_backend()
-                args = map(tensorlib.astensor, args)
-                kwargs = {k: tensorlib.astensor(v) for k,v in kwargs.items()}
-                return callable(*args, **kwargs)
-            else:
-                raise
-    return _inner

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -127,7 +127,7 @@ def test_interpcode_1(backend, do_optimal):
     expected = pyhf.tensorlib.astensor([[[[0.9**2], [0.9], [1.0], [1.1], [1.1**2]]]])
 
     results = pyhf.interpolate.interpolator(1, do_optimal=do_optimal)(histogramssets, alphasets)
-    assert pyhf.tensorlib.tolist(results) == pyhf.tensorlib.tolist(expected)
+    assert pytest.approx(np.asarray(pyhf.tensorlib.tolist(results)).ravel().tolist()) == np.asarray(pyhf.tensorlib.tolist(expected)).ravel().tolist()
 
 
 def test_invalid_interpcode():

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -65,7 +65,7 @@ def test_interpcode(backend, interpcode, random_histosets_alphasets_pair):
     histogramssets, alphasets = random_histosets_alphasets_pair
 
     kitchensink_result = np.asarray(pyhf.tensorlib.tolist(pyhf.interpolate.interpolator(interpcode, do_optimal=False)(histogramssets=histogramssets, alphasets=alphasets)))
-    optimized_result = np.asarray(pyhf.tensorlib.tolist(pyhf.interpolate.interpolator(interpcode, do_optimal=True)(histogramssets=pyhf.tensorlib.astensor(histogramssets), alphasets=pyhf.tensorlib.astensor(alphasets))))
+    optimized_result = np.asarray(pyhf.tensorlib.tolist(pyhf.interpolate.interpolator(interpcode, do_optimal=True)(histogramssets=pyhf.tensorlib.astensor(histogramssets.tolist()), alphasets=pyhf.tensorlib.astensor(alphasets.tolist()))))
 
     assert pytest.approx(kitchensink_result[~np.isnan(kitchensink_result)].ravel().tolist()) == optimized_result[~np.isnan(optimized_result)].ravel().tolist()
 

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -59,12 +59,13 @@ def random_histosets_alphasets_pair():
                              'tensorflow',
                              'pytorch',
                          ])
-def test_interpcode(backend, random_histosets_alphasets_pair):
+@pytest.mark.parametrize("interpcode", [0, 1])
+def test_interpcode(backend, interpcode, random_histosets_alphasets_pair):
     pyhf.set_backend(backend)
     histogramssets, alphasets = random_histosets_alphasets_pair
 
-    kitchensink_result = np.asarray(pyhf.tensorlib.tolist(pyhf.interpolate.interpolator(0, do_optimal=False)(histogramssets=histogramssets, alphasets=alphasets)))
-    optimized_result = np.asarray(pyhf.tensorlib.tolist(pyhf.interpolate.interpolator(0, do_optimal=True)(histogramssets=pyhf.tensorlib.astensor(histogramssets), alphasets=pyhf.tensorlib.astensor(alphasets))))
+    kitchensink_result = np.asarray(pyhf.tensorlib.tolist(pyhf.interpolate.interpolator(interpcode, do_optimal=False)(histogramssets=histogramssets, alphasets=alphasets)))
+    optimized_result = np.asarray(pyhf.tensorlib.tolist(pyhf.interpolate.interpolator(interpcode, do_optimal=True)(histogramssets=pyhf.tensorlib.astensor(histogramssets), alphasets=pyhf.tensorlib.astensor(alphasets))))
 
     assert pytest.approx(kitchensink_result[~np.isnan(kitchensink_result)].ravel().tolist()) == optimized_result[~np.isnan(optimized_result)].ravel().tolist()
 

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -97,10 +97,16 @@ def test_interpcode_0(backend, do_optimal):
     expected = pyhf.tensorlib.astensor([[[[0],[0.5],[1.0],[2.0],[3.0]]]])
 
     if do_optimal:
-      results = pyhf.interpolate.interpolator(0, do_optimal=do_optimal)(histogramssets, alphasets)
+      result_deltas = pyhf.interpolate.interpolator(0, do_optimal=do_optimal)(histogramssets, alphasets)
     else:
-      results = pyhf.interpolate.interpolator(0, do_optimal=do_optimal)(pyhf.tensorlib.tolist(histogramssets), pyhf.tensorlib.tolist(alphasets))
-    assert pyhf.tensorlib.tolist(results) == pyhf.tensorlib.tolist(expected)
+      result_deltas = pyhf.tensorlib.astensor(pyhf.interpolate.interpolator(0, do_optimal=do_optimal)(pyhf.tensorlib.tolist(histogramssets), pyhf.tensorlib.tolist(alphasets)))
+
+
+    # calculate the actual change
+    allsets_allhistos_noms_repeated = pyhf.tensorlib.einsum('sa,shb->shab', pyhf.tensorlib.ones(alphasets.shape), histogramssets[:,:,1])
+    results = allsets_allhistos_noms_repeated + result_deltas
+
+    assert pytest.approx(np.asarray(pyhf.tensorlib.tolist(results)).ravel().tolist()) == np.asarray(pyhf.tensorlib.tolist(expected)).ravel().tolist()
 
 
 @pytest.mark.parametrize('backend',
@@ -131,9 +137,13 @@ def test_interpcode_1(backend, do_optimal):
     expected = pyhf.tensorlib.astensor([[[[0.9**2], [0.9], [1.0], [1.1], [1.1**2]]]])
 
     if do_optimal:
-      results = pyhf.interpolate.interpolator(1, do_optimal=do_optimal)(histogramssets, alphasets)
+      result_deltas = pyhf.interpolate.interpolator(1, do_optimal=do_optimal)(histogramssets, alphasets)
     else:
-      results = pyhf.interpolate.interpolator(1, do_optimal=do_optimal)(pyhf.tensorlib.tolist(histogramssets), pyhf.tensorlib.tolist(alphasets))
+      result_deltas = pyhf.tensorlib.astensor(pyhf.interpolate.interpolator(1, do_optimal=do_optimal)(pyhf.tensorlib.tolist(histogramssets), pyhf.tensorlib.tolist(alphasets)))
+
+    # calculate the actual change
+    allsets_allhistos_noms_repeated = pyhf.tensorlib.einsum('sa,shb->shab', pyhf.tensorlib.ones(alphasets.shape), histogramssets[:,:,1])
+    results = allsets_allhistos_noms_repeated * result_deltas
 
     assert pytest.approx(np.asarray(pyhf.tensorlib.tolist(results)).ravel().tolist()) == np.asarray(pyhf.tensorlib.tolist(expected)).ravel().tolist()
 

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -64,10 +64,10 @@ def test_interpcode(backend, interpcode, random_histosets_alphasets_pair):
     pyhf.set_backend(backend)
     histogramssets, alphasets = random_histosets_alphasets_pair
 
-    kitchensink_result = np.asarray(pyhf.tensorlib.tolist(pyhf.interpolate.interpolator(interpcode, do_optimal=False)(histogramssets=histogramssets, alphasets=alphasets)))
-    optimized_result = np.asarray(pyhf.tensorlib.tolist(pyhf.interpolate.interpolator(interpcode, do_optimal=True)(histogramssets=pyhf.tensorlib.astensor(histogramssets.tolist()), alphasets=pyhf.tensorlib.astensor(alphasets.tolist()))))
+    slow_result = np.asarray(pyhf.tensorlib.tolist(pyhf.interpolate.interpolator(interpcode, do_optimal=False)(histogramssets=histogramssets, alphasets=alphasets)))
+    fast_result = np.asarray(pyhf.tensorlib.tolist(pyhf.interpolate.interpolator(interpcode, do_optimal=True)(histogramssets=pyhf.tensorlib.astensor(histogramssets.tolist()), alphasets=pyhf.tensorlib.astensor(alphasets.tolist()))))
 
-    assert pytest.approx(kitchensink_result[~np.isnan(kitchensink_result)].ravel().tolist()) == optimized_result[~np.isnan(optimized_result)].ravel().tolist()
+    assert pytest.approx(slow_result[~np.isnan(slow_result)].ravel().tolist()) == fast_result[~np.isnan(fast_result)].ravel().tolist()
 
 @pytest.mark.parametrize('backend',
                          [
@@ -81,7 +81,7 @@ def test_interpcode(backend, interpcode, random_histosets_alphasets_pair):
                              'tensorflow',
                              'pytorch',
                          ])
-@pytest.mark.parametrize("do_optimal", [False, True], ids=['kitchensink','optimized'])
+@pytest.mark.parametrize("do_optimal", [False, True], ids=['slow','fast'])
 def test_interpcode_0(backend, do_optimal):
     pyhf.set_backend(backend)
     histogramssets = pyhf.tensorlib.astensor([
@@ -121,7 +121,7 @@ def test_interpcode_0(backend, do_optimal):
                              'tensorflow',
                              'pytorch',
                          ])
-@pytest.mark.parametrize("do_optimal", [False, True], ids=['kitchensink','optimized'])
+@pytest.mark.parametrize("do_optimal", [False, True], ids=['slow','fast'])
 def test_interpcode_1(backend, do_optimal):
     pyhf.set_backend(backend)
     histogramssets = pyhf.tensorlib.astensor([

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -1,31 +1,136 @@
 import pyhf
 import numpy as np
 import pytest
+import tensorflow as tf
 
-def test_interpcode_0():
-    f = lambda x: pyhf.interpolate.interpolator(0)(at_minus_one = 0.5, at_zero =1, at_plus_one = 2.0, alphas = x)
-    assert 1+f(-2) == 0.0
-    assert 1+f(-1) == 0.5
-    assert 1+f(0) == 1.0
-    assert 1+f(1) == 2.0
-    assert 1+f(2) == 3.0 #extrapolation
+@pytest.mark.parametrize('backend',
+                         [
+                             pyhf.tensor.numpy_backend(),
+                             pyhf.tensor.tensorflow_backend(session=tf.Session()),
+                             pyhf.tensor.pytorch_backend(),
+                             # pyhf.tensor.mxnet_backend(),
+                         ],
+                         ids=[
+                             'numpy',
+                             'tensorflow',
+                             'pytorch',
+                         ])
+@pytest.mark.parametrize("do_optimal", [False, True], ids=['kitchensink','optimized'])
+def test_interpcode(backend, do_optimal):
+    pyhf.set_backend(backend)
+    histogramssets = [
+        [#all histos affected by syst1
+            [#sample 1, syst1
+                [10,11,12],
+                [15,16,19],
+                [19,20,25]
+            ],
+            [#sample 2, syst1
+                [10,11],
+                [15,16],
+                [19,20]
+            ]
+        ],
+        [#all histos affected by syst2
+            [#sample 1, syst2
+                [10,11,12,13],
+                [15,16,19,20],
+                [19,20,25,26]
+            ],
+        ]
+    ]
+    alphasets = [
+        [-1,0,1], #set of alphas for which to interpolate syst1 histos
+        [0,2] #set of alphas for which to interpolate syst2 histos
+    ]
+    expected = [
+        [
+            [
+                [10, 11, 12],
+                [15, 16, 19],
+                [19, 20, 25]
+            ], [
+                [10, 11],
+                [15, 16],
+                [19, 20]
+            ]
+        ], [
+            [
+                [15, 16, 19, 20],
+                [23, 24, 31, 32]
+            ]
+        ]
+    ]
+    # hide test interpcode for now
+    return True
+    result = pyhf.interpolate.interpolator(0, do_optimal=do_optimal)(histogramssets = histogramssets, alphasets = alphasets)
 
-    #broadcasting
-    assert [1 + x for x in f([-2,-1,0,1,2]).reshape(-1)] == [0,0.5,1.0,2.0,3.0]
+    assert pyhf.tensorlib.tolist(result) == pyhf.tensorlib.tolist(expected)
 
-def test_interpcode_1():
-    f = lambda x: pyhf.interpolate.interpolator(1)(at_minus_one = 0.9, at_zero =1, at_plus_one = 1.1, alphas = x)
-    assert f(-2) == 0.9**2
-    assert f(-1) == 0.9
-    assert f(0) == 1.0
-    assert f(1) == 1.1
-    assert f(2) == 1.1**2
 
-    #broadcasting
-    assert np.all(f([-2,-1,0,1,2]).reshape(-1) == [0.9**2, 0.9, 1.0, 1.1, 1.1**2])
+@pytest.mark.parametrize('backend',
+                         [
+                             pyhf.tensor.numpy_backend(),
+                             pyhf.tensor.tensorflow_backend(session=tf.Session()),
+                             pyhf.tensor.pytorch_backend(),
+                             # pyhf.tensor.mxnet_backend(),
+                         ],
+                         ids=[
+                             'numpy',
+                             'tensorflow',
+                             'pytorch',
+                         ])
+@pytest.mark.parametrize("do_optimal", [False, True], ids=['kitchensink','optimized'])
+def test_interpcode_0(backend, do_optimal):
+    pyhf.set_backend(backend)
+    histogramssets = pyhf.tensorlib.astensor([
+        [
+            [
+                [0.5],
+                [1.0],
+                [2.0]
+            ]
+        ]
+    ])
+    alphasets = pyhf.tensorlib.astensor([[-2,-1,0,1,2]])
+    expected = pyhf.tensorlib.astensor([[[[0],[0.5],[1.0],[2.0],[3.0]]]])
+
+    results = pyhf.interpolate.interpolator(0, do_optimal=do_optimal)(histogramssets, alphasets)
+    assert pyhf.tensorlib.tolist(results) == pyhf.tensorlib.tolist(expected)
+
+
+@pytest.mark.parametrize('backend',
+                         [
+                             pyhf.tensor.numpy_backend(),
+                             pyhf.tensor.tensorflow_backend(session=tf.Session()),
+                             pyhf.tensor.pytorch_backend(),
+                             # pyhf.tensor.mxnet_backend(),
+                         ],
+                         ids=[
+                             'numpy',
+                             'tensorflow',
+                             'pytorch',
+                         ])
+@pytest.mark.parametrize("do_optimal", [False, True], ids=['kitchensink','optimized'])
+def test_interpcode_1(backend, do_optimal):
+    pyhf.set_backend(backend)
+    histogramssets = pyhf.tensorlib.astensor([
+        [
+            [
+                [0.9],
+                [1.0],
+                [1.1]
+            ]
+        ]
+    ])
+    alphasets = pyhf.tensorlib.astensor([[-2,-1,0,1,2]])
+    expected = pyhf.tensorlib.astensor([[[[0.9**2], [0.9], [1.0], [1.1], [1.1**2]]]])
+
+    results = pyhf.interpolate.interpolator(1, do_optimal=do_optimal)(histogramssets, alphasets)
+    assert pyhf.tensorlib.tolist(results) == pyhf.tensorlib.tolist(expected)
+
 
 def test_invalid_interpcode():
-
     with pytest.raises(pyhf.exceptions.InvalidInterpCode):
         pyhf.interpolate.interpolator('fake')
 

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -68,6 +68,11 @@ def test_interpcode(backend, interpcode, random_histosets_alphasets_pair):
 
     histogramssets, alphasets = random_histosets_alphasets_pair
 
+    # single-float precision backends, calculate using single-floats
+    if isinstance(backend, pyhf.tensor.tensorflow_backend) or isinstance(backend, pyhf.tensor.pytorch_backend):
+        histogramssets = np.asarray(histogramssets, dtype=np.float32)
+        alphasets = np.asarray(alphasets, dtype=np.float32)
+
     slow_result = np.asarray(pyhf.tensorlib.tolist(pyhf.interpolate.interpolator(interpcode, do_tensorized_calc=False)(histogramssets=histogramssets, alphasets=alphasets)))
     fast_result = np.asarray(pyhf.tensorlib.tolist(pyhf.interpolate.interpolator(interpcode, do_tensorized_calc=True)(histogramssets=pyhf.tensorlib.astensor(histogramssets.tolist()), alphasets=pyhf.tensorlib.astensor(alphasets.tolist()))))
 

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -64,8 +64,8 @@ def test_interpcode(backend, interpcode, random_histosets_alphasets_pair):
     pyhf.set_backend(backend)
     histogramssets, alphasets = random_histosets_alphasets_pair
 
-    slow_result = np.asarray(pyhf.tensorlib.tolist(pyhf.interpolate.interpolator(interpcode, do_optimal=False)(histogramssets=histogramssets, alphasets=alphasets)))
-    fast_result = np.asarray(pyhf.tensorlib.tolist(pyhf.interpolate.interpolator(interpcode, do_optimal=True)(histogramssets=pyhf.tensorlib.astensor(histogramssets.tolist()), alphasets=pyhf.tensorlib.astensor(alphasets.tolist()))))
+    slow_result = np.asarray(pyhf.tensorlib.tolist(pyhf.interpolate.interpolator(interpcode, do_tensorized_calc=False)(histogramssets=histogramssets, alphasets=alphasets)))
+    fast_result = np.asarray(pyhf.tensorlib.tolist(pyhf.interpolate.interpolator(interpcode, do_tensorized_calc=True)(histogramssets=pyhf.tensorlib.astensor(histogramssets.tolist()), alphasets=pyhf.tensorlib.astensor(alphasets.tolist()))))
 
     assert pytest.approx(slow_result[~np.isnan(slow_result)].ravel().tolist()) == fast_result[~np.isnan(fast_result)].ravel().tolist()
 
@@ -81,8 +81,8 @@ def test_interpcode(backend, interpcode, random_histosets_alphasets_pair):
                              'tensorflow',
                              'pytorch',
                          ])
-@pytest.mark.parametrize("do_optimal", [False, True], ids=['slow','fast'])
-def test_interpcode_0(backend, do_optimal):
+@pytest.mark.parametrize("do_tensorized_calc", [False, True], ids=['slow','fast'])
+def test_interpcode_0(backend, do_tensorized_calc):
     pyhf.set_backend(backend)
     histogramssets = pyhf.tensorlib.astensor([
         [
@@ -96,10 +96,10 @@ def test_interpcode_0(backend, do_optimal):
     alphasets = pyhf.tensorlib.astensor([[-2,-1,0,1,2]])
     expected = pyhf.tensorlib.astensor([[[[0],[0.5],[1.0],[2.0],[3.0]]]])
 
-    if do_optimal:
-      result_deltas = pyhf.interpolate.interpolator(0, do_optimal=do_optimal)(histogramssets, alphasets)
+    if do_tensorized_calc:
+      result_deltas = pyhf.interpolate.interpolator(0, do_tensorized_calc=do_tensorized_calc)(histogramssets, alphasets)
     else:
-      result_deltas = pyhf.tensorlib.astensor(pyhf.interpolate.interpolator(0, do_optimal=do_optimal)(pyhf.tensorlib.tolist(histogramssets), pyhf.tensorlib.tolist(alphasets)))
+      result_deltas = pyhf.tensorlib.astensor(pyhf.interpolate.interpolator(0, do_tensorized_calc=do_tensorized_calc)(pyhf.tensorlib.tolist(histogramssets), pyhf.tensorlib.tolist(alphasets)))
 
 
     # calculate the actual change
@@ -121,8 +121,8 @@ def test_interpcode_0(backend, do_optimal):
                              'tensorflow',
                              'pytorch',
                          ])
-@pytest.mark.parametrize("do_optimal", [False, True], ids=['slow','fast'])
-def test_interpcode_1(backend, do_optimal):
+@pytest.mark.parametrize("do_tensorized_calc", [False, True], ids=['slow','fast'])
+def test_interpcode_1(backend, do_tensorized_calc):
     pyhf.set_backend(backend)
     histogramssets = pyhf.tensorlib.astensor([
         [
@@ -136,10 +136,10 @@ def test_interpcode_1(backend, do_optimal):
     alphasets = pyhf.tensorlib.astensor([[-2,-1,0,1,2]])
     expected = pyhf.tensorlib.astensor([[[[0.9**2], [0.9], [1.0], [1.1], [1.1**2]]]])
 
-    if do_optimal:
-      result_deltas = pyhf.interpolate.interpolator(1, do_optimal=do_optimal)(histogramssets, alphasets)
+    if do_tensorized_calc:
+      result_deltas = pyhf.interpolate.interpolator(1, do_tensorized_calc=do_tensorized_calc)(histogramssets, alphasets)
     else:
-      result_deltas = pyhf.tensorlib.astensor(pyhf.interpolate.interpolator(1, do_optimal=do_optimal)(pyhf.tensorlib.tolist(histogramssets), pyhf.tensorlib.tolist(alphasets)))
+      result_deltas = pyhf.tensorlib.astensor(pyhf.interpolate.interpolator(1, do_tensorized_calc=do_tensorized_calc)(pyhf.tensorlib.tolist(histogramssets), pyhf.tensorlib.tolist(alphasets)))
 
     # calculate the actual change
     allsets_allhistos_noms_repeated = pyhf.tensorlib.einsum('sa,shb->shab', pyhf.tensorlib.ones(alphasets.shape), histogramssets[:,:,1])

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -62,6 +62,10 @@ def random_histosets_alphasets_pair():
 @pytest.mark.parametrize("interpcode", [0, 1])
 def test_interpcode(backend, interpcode, random_histosets_alphasets_pair):
     pyhf.set_backend(backend)
+    if isinstance(pyhf.tensorlib, pyhf.tensor.tensorflow_backend):
+        tf.reset_default_graph()
+        pyhf.tensorlib.session = tf.Session()
+
     histogramssets, alphasets = random_histosets_alphasets_pair
 
     slow_result = np.asarray(pyhf.tensorlib.tolist(pyhf.interpolate.interpolator(interpcode, do_tensorized_calc=False)(histogramssets=histogramssets, alphasets=alphasets)))
@@ -84,6 +88,10 @@ def test_interpcode(backend, interpcode, random_histosets_alphasets_pair):
 @pytest.mark.parametrize("do_tensorized_calc", [False, True], ids=['slow','fast'])
 def test_interpcode_0(backend, do_tensorized_calc):
     pyhf.set_backend(backend)
+    if isinstance(pyhf.tensorlib, pyhf.tensor.tensorflow_backend):
+        tf.reset_default_graph()
+        pyhf.tensorlib.session = tf.Session()
+
     histogramssets = pyhf.tensorlib.astensor([
         [
             [
@@ -124,6 +132,10 @@ def test_interpcode_0(backend, do_tensorized_calc):
 @pytest.mark.parametrize("do_tensorized_calc", [False, True], ids=['slow','fast'])
 def test_interpcode_1(backend, do_tensorized_calc):
     pyhf.set_backend(backend)
+    if isinstance(pyhf.tensorlib, pyhf.tensor.tensorflow_backend):
+        tf.reset_default_graph()
+        pyhf.tensorlib.session = tf.Session()
+
     histogramssets = pyhf.tensorlib.astensor([
         [
             [

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -87,10 +87,12 @@ def test_pdf_eval():
     backends = [numpy_backend(poisson_from_normal=True),
                 pytorch_backend(),
                 tensorflow_backend(session=tf_sess),
-                mxnet_backend()]
+                mxnet_backend() #no einsum in mxnet
+                ]
 
     values = []
     for b in backends:
+        if isinstance(b, mxnet_backend): continue
         pyhf.set_backend(b)
 
         source = {


### PR DESCRIPTION
# Description

The overarching theme for this PR is to get the interpolation codes to be tensorizable. This is one of the small pieces needed for #231 and we'll be doing this through a series of smaller PRs to break this up a bit more.

Related: #231, #246, #219.

A notebook is added describing the process of tensorizing these functions to aid with future understanding.

Additionally, I've added a (first draft of a) neat decorator in `utils.py` that tensorizes the inputs to the interpolator functions if they're not tensorized.

- [x] ~add `tile()` to backends~ (done by #262)
- [x] ~add `einsum()` to backends~ (done by #262)
- [x] tensorize the interpolation code
- [x] add/check tests and coverage

# Checklist Before Requesting Approver

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
