### PR TITLE
add patch CLI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     'tqdm',  # for readxml
     'six',  # for modifiers
     'jsonschema>=v3.0.0a2',  # for utils, alpha-release for draft 6
+    'jsonpatch'
   ],
   extras_require = {
     'xmlimport': [

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -73,9 +73,10 @@ def test_import_and_export(tmpdir, script_runner):
 def test_patch(tmpdir, script_runner):
     patch = tmpdir.join('patch.json')
 
-    patch.write('''
+    patchcontent = u'''
 [{"op": "replace", "path": "/channels/0/samples/0/data", "value": [5,6]}]
-    ''')
+    '''
+    patch.write(patchcontent)
 
     temp = tmpdir.join("parsed_output.json")
     command = 'pyhf xml2json validation/xmlimport_input/config/example.xml --basedir validation/xmlimport_input/ --output-file {0:s}'.format(temp.strpath)
@@ -84,9 +85,12 @@ def test_patch(tmpdir, script_runner):
     command = 'pyhf cls {0:s} --patch {1:s}'.format(temp.strpath,patch.strpath)
     ret = script_runner.run(*shlex.split(command))
     assert ret.success
-
+    import io
     command = 'pyhf cls {0:s} --patch -'.format(temp.strpath,patch.strpath)
-    ret = script_runner.run(*shlex.split(command), stdin = patch)
+
+    pipefile = io.StringIO(patchcontent) #python 2.7 pytest-files are not file-like enough
+    ret = script_runner.run(*shlex.split(command), stdin = pipefile)
+    print(ret.stderr)
     assert ret.success
 
 

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -68,6 +68,7 @@ def test_import_and_export(tmpdir, script_runner):
 
     command = 'pyhf json2xml {0:s} --specroot {1:s} --dataroot {1:s}'.format(temp.strpath,str(tmpdir))
     ret = script_runner.run(*shlex.split(command))
+    assert ret.success
 
 def test_patch(tmpdir, script_runner):
     patch = tmpdir.join('patch.json')


### PR DESCRIPTION
# Description

This adds a `--patch` flag to `pyhf cls`

```
cat newsignal.json|pyhf cls original.json --patch -
```

```
pyhf cls original.json --patch newsignal.json
```

```
pyhf cls original.json --patch newsignal.json
```

```
cat original.json pyhf cls - --patch newsignal.json
```


# Checklist Before Requesting Approver

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
