### PR TITLE
Add complete install option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 before_install:
   - pip install --upgrade pip setuptools wheel
 install:
-  - pip install --ignore-installed -U -q -e .[tensorflow,torch,mxnet,minuit,develop]
+  - pip install --ignore-installed -U -q -e .[complete]
   - pip freeze
 script:
   - pyflakes pyhf
@@ -45,7 +45,7 @@ jobs:
     before_install:
       - pip install --upgrade pip setuptools wheel
     install:
-      - pip install --ignore-installed -U -q -e .[tensorflow,torch,mxnet,minuit,develop]
+      - pip install --ignore-installed -U -q -e .[complete]
       - pip freeze
     script: pytest -r sx --benchmark-sort=mean tests/benchmarks/
   - stage: docs
@@ -55,7 +55,7 @@ jobs:
       - sudo apt-get -qq install pandoc
       - pip install --upgrade pip setuptools wheel
     install:
-      - pip install --ignore-installed -U -q -e .[tensorflow,torch,mxnet,minuit,develop]
+      - pip install --ignore-installed -U -q -e .[complete]
       - pip freeze
     script:
     - python -m doctest README.md

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -3,4 +3,4 @@ Developing
 
 To develop, we suggest using `virtual environments <https://virtualenvwrapper.readthedocs.io/en/latest/>`__ together with ``pip`` or using `pipenv <https://pipenv.readthedocs.io/en/latest/>`__. To get all necessary packages for development::
 
-    pip install --ignore-installed -U -e .[tensorflow,torch,mxnet,develop]
+    pip install --ignore-installed -U -e .[complete]

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,9 @@ extras_require = {
         'numpy<1.15.0,>=1.8.2',
         'requests<2.19.0,>=2.18.4',
     ],
+    'dask': [
+        'dask[array]'
+    ],
     'xmlimport': [
         'uproot',
     ],

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from setuptools import setup, find_packages
 
 extras_require = {
@@ -57,7 +59,7 @@ setup(
     author='Lukas Heinrich',
     author_email='lukas.heinrich@cern.ch',
     license='Apache',
-    keywords='pyhsics fitting numpy scipy tensorflow pytorch mxnet dask',
+    keywords='physics fitting numpy scipy tensorflow pytorch mxnet dask',
     classifiers=[
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,9 @@ extras_require = {
         'numpy<1.15.0,>=1.8.2',
         'requests<2.19.0,>=2.18.4',
     ],
-    'dask': [
-        'dask[array]'
-    ],
+    # 'dask': [
+    #     'dask[array]'
+    # ],
     'xmlimport': [
         'uproot',
     ],

--- a/setup.py
+++ b/setup.py
@@ -1,68 +1,80 @@
 from setuptools import setup, find_packages
-setup(
-  name = 'pyhf',
-  version = '0.0.15',
-  description = '(partial) pure python histfactory implementation',
-  url = '',
-  author = 'Lukas Heinrich',
-  author_email = 'lukas.heinrich@cern.ch',
-  packages = find_packages(),
-  include_package_data = True,
-  install_requires = [
-    'scipy',  # requires numpy, which is required by pyhf, tensorflow, and mxnet
-    'click>=6.0',  # for console scripts,
-    'tqdm',  # for readxml
-    'six',  # for modifiers
-    'jsonschema>=v3.0.0a2',  # for utils, alpha-release for draft 6
-    'jsonpatch'
-  ],
-  extras_require = {
-    'xmlimport': [
-       'uproot',
-     ],
+
+extras_require = {
+    'tensorflow': [
+        'tensorflow>=1.10.0',
+        # 'tensorflow-probability>=0.3.0', # Causing troulbe with Travis CI, but *should* be used
+        'numpy<=1.14.5,>=1.14.0',  # Lower of 1.14.0 instead of 1.13.3 to ensure doctest pass
+        'setuptools<=39.1.0',
+    ],
     'torch': [
-      'torch>=0.4.0'
+        'torch>=0.4.0'
+    ],
+    'mxnet': [
+        'mxnet>=1.0.0',
+        'requests<2.19.0,>=2.18.4',
+        'numpy<1.15.0,>=1.8.2',
+        'requests<2.19.0,>=2.18.4',
+    ],
+    'xmlimport': [
+        'uproot',
     ],
     'minuit': [
-      'iminuit'
-    ],
-    'mxnet':[
-      'mxnet>=1.0.0',
-      'requests<2.19.0,>=2.18.4',
-      'numpy<1.15.0,>=1.8.2',
-      'requests<2.19.0,>=2.18.4',
-    ],
-    'tensorflow':[
-       'tensorflow>=1.10.0',
-       # 'tensorflow-probability>=0.3.0', # Causing troulbe with Travis CI, but *should* be used
-       'numpy<=1.14.5,>=1.14.0',  # Lower of 1.14.0 instead of 1.13.3 to ensure doctest pass
-       'setuptools<=39.1.0',
+        'iminuit'
     ],
     'develop': [
-       'pyflakes',
-       'pytest>=3.5.1',
-       'pytest-cov>=2.5.1',
-       'pytest-benchmark[histogram]',
-       'pytest-console-scripts',
-       'python-coveralls',
-       'coverage>=4.0',  # coveralls
-       'matplotlib',
-       'jupyter',
-       'uproot>=3.0.0',
-       'papermill',
-       'graphviz',
-       'sphinx',
-       'sphinxcontrib-bibtex',
-       'sphinxcontrib-napoleon',
-       'sphinx_rtd_theme',
-       'nbsphinx',
-       'm2r',
-       'jsonpatch'
+        'pyflakes',
+        'pytest>=3.5.1',
+        'pytest-cov>=2.5.1',
+        'pytest-benchmark[histogram]',
+        'pytest-console-scripts',
+        'python-coveralls',
+        'coverage>=4.0',  # coveralls
+        'matplotlib',
+        'jupyter',
+        'uproot>=3.0.0',
+        'papermill',
+        'graphviz',
+        'sphinx',
+        'sphinxcontrib-bibtex',
+        'sphinxcontrib-napoleon',
+        'sphinx_rtd_theme',
+        'nbsphinx',
+        'm2r',
+        'jsonpatch'
     ]
-  },
-  entry_points = {
-      'console_scripts': ['pyhf=pyhf.commandline:pyhf']
-  },
-  dependency_links = [
-  ]
+}
+extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
+
+setup(
+    name='pyhf',
+    version='0.0.15',
+    description='(partial) pure python histfactory implementation',
+    url='https://github.com/diana-hep/pyhf',
+    author='Lukas Heinrich',
+    author_email='lukas.heinrich@cern.ch',
+    license='Apache',
+    keywords='pyhsics fitting numpy scipy tensorflow pytorch mxnet dask',
+    classifiers=[
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+    ],
+    packages=find_packages(),
+    include_package_data=True,
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*",
+    install_requires=[
+        'scipy',  # requires numpy, which is required by pyhf, tensorflow, and mxnet
+        'click>=6.0',  # for console scripts,
+        'tqdm',  # for readxml
+        'six',  # for modifiers
+        'jsonschema>=v3.0.0a2',  # for utils, alpha-release for draft 6
+        'jsonpatch'
+    ],
+    extras_require=extras_require,
+    entry_points={
+        'console_scripts': ['pyhf=pyhf.commandline:pyhf']
+    },
+    dependency_links=[]
 )


### PR DESCRIPTION
# Description

~~Should not be merged in until PR #260 is in and this PR is rebased against it.~~ This can go in before as the Dask backend isn't ready yet.

Taking some inspiration [from Dask](https://github.com/dask/dask/blob/master/setup.py), add a `complete` option for installation that installs all environments defined in `extras_require`.

Additionally adds some extra information into the setup for PyPI such as website, license, keywords, classifiers, and supported Python versions.

As this is a large rewrite `autopep8` is also run over it to enforce PEP8 (as I haven't take care of Issue #185 yet).

# Checklist Before Requesting Approver

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
