### PR TITLE
Fix concatenate and add missing functionality to backends:

### DIFF
--- a/pyhf/tensor/mxnet_backend.py
+++ b/pyhf/tensor/mxnet_backend.py
@@ -323,25 +323,6 @@ class mxnet_backend(object):
                      for arg in args]
         return nd.stack(*broadcast)
 
-    def tile(self, A, reps):
-        """
-        Repeats the whole array multiple times.
-
-        If reps has length d, and input array has dimension of n. There are three cases:
-
-            - n=d. Repeat i-th dimension of the input by reps[i] times.
-            - n>d. reps is promoted to length n by pre-pending 1's to it. Thus for an input shape (2,3), repos=(2,) is treated as (1,2).
-            - n. The input is promoted to be d-dimensional by prepending new axes. So a shape (2,2) array is promoted to (1,2,2) for 3-D replication:
-
-        Args:
-            A: tensor
-            reps: The numbr of repetitions along each axis
-
-        Returns:
-            MXNet NDArray: The tiled output array
-        """
-        return nd.tile(A, reps)
-
     def einsum(self, subscripts, *operands):
         """
         A generalized contraction between tensors of arbitrary dimension.

--- a/pyhf/tensor/mxnet_backend.py
+++ b/pyhf/tensor/mxnet_backend.py
@@ -128,6 +128,7 @@ class mxnet_backend(object):
             return nd.prod(tensor_in, axis)
 
     def abs(self, tensor):
+        tensor = self.astensor(tensor)
         return nd.abs(tensor)
 
     def ones(self, shape):

--- a/pyhf/tensor/mxnet_backend.py
+++ b/pyhf/tensor/mxnet_backend.py
@@ -127,6 +127,9 @@ class mxnet_backend(object):
         else:
             return nd.prod(tensor_in, axis)
 
+    def abs(self, tensor):
+        return nd.abs(tensor)
+
     def ones(self, shape):
         """
         A new array filled with all ones, with the given shape.
@@ -269,17 +272,18 @@ class mxnet_backend(object):
         return nd.add(nd.multiply(mask, tensor_in_1),
                       nd.multiply(nd.subtract(1, mask), tensor_in_2))
 
-    def concatenate(self, sequence):
+    def concatenate(self, sequence, axis=0):
         """
         Join the elements of the sequence.
 
         Args:
             sequence (Array of Tensors): The sequence of arrays to join
+            axis: dimension along which to concatenate
 
         Returns:
             MXNet NDArray: The ndarray of the joined elements.
         """
-        return nd.concat(*sequence, dim=0)
+        return nd.concat(*sequence, dim=axis)
 
     def simple_broadcast(self, *args):
         """
@@ -318,6 +322,42 @@ class mxnet_backend(object):
                      else nd.broadcast_axis(arg[0], axis=len(arg.shape) - 1, size=max_dim)
                      for arg in args]
         return nd.stack(*broadcast)
+
+    def tile(self, A, reps):
+        """
+        Repeats the whole array multiple times.
+
+        If reps has length d, and input array has dimension of n. There are three cases:
+
+            - n=d. Repeat i-th dimension of the input by reps[i] times.
+            - n>d. reps is promoted to length n by pre-pending 1's to it. Thus for an input shape (2,3), repos=(2,) is treated as (1,2).
+            - n. The input is promoted to be d-dimensional by prepending new axes. So a shape (2,2) array is promoted to (1,2,2) for 3-D replication:
+
+        Args:
+            A: tensor
+            reps: The numbr of repetitions along each axis
+
+        Returns:
+            MXNet NDArray: The tiled output array
+        """
+        return nd.tile(A, reps)
+
+    def einsum(self, subscripts, *operands):
+        """
+        A generalized contraction between tensors of arbitrary dimension.
+
+        Warning: not implemented in MXNet
+
+        Args:
+            subscripts: str, specifies the subscripts for summation
+            operands: list of array_like, these are the tensors for the operation
+
+        Returns:
+            tensor: the calculation based on the Einstein summation convention
+        """
+        raise NotImplementedError("mxnet::einsum is not implemented.")
+        return self.astensor([])
+
 
     def poisson(self, n, lam):
         """

--- a/pyhf/tensor/numpy_backend.py
+++ b/pyhf/tensor/numpy_backend.py
@@ -61,6 +61,7 @@ class numpy_backend(object):
         return np.product(tensor_in, axis = axis)
 
     def abs(self, tensor):
+        tensor = self.astensor(tensor)
         return np.abs(tensor)
 
     def ones(self,shape):

--- a/pyhf/tensor/numpy_backend.py
+++ b/pyhf/tensor/numpy_backend.py
@@ -136,34 +136,6 @@ class numpy_backend(object):
         """
         return np.broadcast_arrays(*args)
 
-    def tile(self, A, reps):
-        """
-        Construct an array by repeating A the number of times given by reps.
-
-        If reps has length d, the result will have dimension of max(d, A.ndim).
-
-        If A.ndim < d, A is promoted to be d-dimensional by prepending new
-        axes. So a shape (3,) array is promoted to (1, 3) for 2-D replication,
-        or shape (1, 1, 3) for 3-D replication. If this is not the desired
-        behavior, promote A to d-dimensions manually before calling this
-        function.
-
-        If A.ndim > d, reps is promoted to A.ndim by pre-pending 1's to it.
-        Thus for an A of shape (2, 3, 4, 5), a reps of (2, 2) is treated as (1,
-        1, 2, 2).
-
-        Note : Although tile may be used for broadcasting, it is strongly
-        recommended to use numpy's broadcasting operations and functions.
-
-        Args:
-            A: tensor
-            reps: The numbr of repetitions along each axis
-
-        Returns:
-            tensor: The tiled output array
-        """
-        return np.tile(A, reps)
-
     def einsum(self, subscripts, *operands):
         """
         Evaluates the Einstein summation convention on the operands.

--- a/pyhf/tensor/numpy_backend.py
+++ b/pyhf/tensor/numpy_backend.py
@@ -60,8 +60,14 @@ class numpy_backend(object):
         tensor_in = self.astensor(tensor_in)
         return np.product(tensor_in, axis = axis)
 
+    def abs(self, tensor):
+        return np.abs(tensor)
+
     def ones(self,shape):
         return np.ones(shape)
+
+    def zeros(self,shape):
+        return np.zeros(shape)
 
     def power(self,tensor_in_1, tensor_in_2):
         tensor_in_1 = self.astensor(tensor_in_1)
@@ -94,8 +100,19 @@ class numpy_backend(object):
         tensor_in_2 = self.astensor(tensor_in_2)
         return np.where(mask, tensor_in_1, tensor_in_2)
 
-    def concatenate(self, sequence):
-        return np.concatenate(sequence)
+    def concatenate(self, sequence, axis=0):
+        """
+        Join a sequence of arrays along an existing axis.
+
+        Args:
+            sequence: sequence of tensors
+            axis: dimension along which to concatenate
+
+        Returns:
+            output: the concatenated tensor
+
+        """
+        return np.concatenate(sequence, axis=axis)
 
     def simple_broadcast(self, *args):
         """
@@ -118,6 +135,53 @@ class numpy_backend(object):
             list of Tensors: The sequence broadcast together.
         """
         return np.broadcast_arrays(*args)
+
+    def tile(self, A, reps):
+        """
+        Construct an array by repeating A the number of times given by reps.
+
+        If reps has length d, the result will have dimension of max(d, A.ndim).
+
+        If A.ndim < d, A is promoted to be d-dimensional by prepending new
+        axes. So a shape (3,) array is promoted to (1, 3) for 2-D replication,
+        or shape (1, 1, 3) for 3-D replication. If this is not the desired
+        behavior, promote A to d-dimensions manually before calling this
+        function.
+
+        If A.ndim > d, reps is promoted to A.ndim by pre-pending 1's to it.
+        Thus for an A of shape (2, 3, 4, 5), a reps of (2, 2) is treated as (1,
+        1, 2, 2).
+
+        Note : Although tile may be used for broadcasting, it is strongly
+        recommended to use numpy's broadcasting operations and functions.
+
+        Args:
+            A: tensor
+            reps: The numbr of repetitions along each axis
+
+        Returns:
+            tensor: The tiled output array
+        """
+        return np.tile(A, reps)
+
+    def einsum(self, subscripts, *operands):
+        """
+        Evaluates the Einstein summation convention on the operands.
+
+        Using the Einstein summation convention, many common multi-dimensional
+        array operations can be represented in a simple fashion. This function
+        provides a way to compute such summations. The best way to understand
+        this function is to try the examples below, which show how many common
+        NumPy functions can be implemented as calls to einsum.
+
+        Args:
+            subscripts: str, specifies the subscripts for summation
+            operands: list of array_like, these are the tensors for the operation
+
+        Returns:
+            tensor: the calculation based on the Einstein summation convention
+        """
+        return np.einsum(subscripts, *operands)
 
     def poisson(self, n, lam):
         n = np.asarray(n)

--- a/pyhf/tensor/pytorch_backend.py
+++ b/pyhf/tensor/pytorch_backend.py
@@ -66,6 +66,7 @@ class pytorch_backend(object):
         return torch.prod(tensor_in) if axis is None else torch.prod(tensor_in, axis)
 
     def abs(self, tensor):
+        tensor = self.astensor(tensor)
         return torch.abs(tensor)
 
     def ones(self, shape):

--- a/pyhf/tensor/pytorch_backend.py
+++ b/pyhf/tensor/pytorch_backend.py
@@ -163,7 +163,8 @@ class pytorch_backend(object):
         Returns:
             tensor: the calculation based on the Einstein summation convention
         """
-        return torch.einsum(subscripts, operands)
+        ops = tuple(self.astensor(op) for op in operands)
+        return torch.einsum(subscripts, ops)
 
 
     def poisson(self, n, lam):

--- a/pyhf/tensor/pytorch_backend.py
+++ b/pyhf/tensor/pytorch_backend.py
@@ -65,8 +65,14 @@ class pytorch_backend(object):
         tensor_in = self.astensor(tensor_in)
         return torch.prod(tensor_in) if axis is None else torch.prod(tensor_in, axis)
 
+    def abs(self, tensor):
+        return torch.abs(tensor)
+
     def ones(self, shape):
         return torch.Tensor(torch.ones(shape))
+
+    def zeros(self, shape):
+        return torch.Tensor(torch.zeros(shape))
 
     def power(self, tensor_in_1, tensor_in_2):
         tensor_in_1 = self.astensor(tensor_in_1)
@@ -99,8 +105,19 @@ class pytorch_backend(object):
         tensor_in_2 = self.astensor(tensor_in_2)
         return mask * tensor_in_1 + (1-mask) * tensor_in_2
 
-    def concatenate(self, sequence):
-        return torch.cat(sequence)
+    def concatenate(self, sequence, axis=0):
+        """
+        Join a sequence of arrays along an existing axis.
+
+        Args:
+            sequence: sequence of tensors
+            axis: dimension along which to concatenate
+
+        Returns:
+            output: the concatenated tensor
+
+        """
+        return torch.cat(sequence, dim=axis)
 
     def simple_broadcast(self, *args):
         """
@@ -133,6 +150,34 @@ class pytorch_backend(object):
         broadcast = [arg if len(arg) > 1 else arg.expand(max_dim)
                      for arg in args]
         return broadcast
+
+    def tile(self, A, reps):
+        """
+        Repeats the whole array multiple times.
+
+        Args:
+            A: tensor
+            reps: The numbr of repetitions along each axis
+
+        Returns:
+            tensor: The tiled output array
+        """
+        return A.repeat(*reps)
+
+    def einsum(self, subscripts, *operands):
+        """
+        This function provides a way of computing multilinear expressions (i.e.
+        sums of products) using the Einstein summation convention.
+
+        Args:
+            subscripts: str, specifies the subscripts for summation
+            operands: list of array_like, these are the tensors for the operation
+
+        Returns:
+            tensor: the calculation based on the Einstein summation convention
+        """
+        return torch.einsum(subscripts, operands)
+
 
     def poisson(self, n, lam):
         return self.normal(n,lam, self.sqrt(lam))

--- a/pyhf/tensor/pytorch_backend.py
+++ b/pyhf/tensor/pytorch_backend.py
@@ -151,19 +151,6 @@ class pytorch_backend(object):
                      for arg in args]
         return broadcast
 
-    def tile(self, A, reps):
-        """
-        Repeats the whole array multiple times.
-
-        Args:
-            A: tensor
-            reps: The numbr of repetitions along each axis
-
-        Returns:
-            tensor: The tiled output array
-        """
-        return A.repeat(*reps)
-
     def einsum(self, subscripts, *operands):
         """
         This function provides a way of computing multilinear expressions (i.e.

--- a/pyhf/tensor/tensorflow_backend.py
+++ b/pyhf/tensor/tensorflow_backend.py
@@ -79,8 +79,14 @@ class tensorflow_backend(object):
         tensor_in = self.astensor(tensor_in)
         return tf.reduce_prod(tensor_in) if axis is None else tf.reduce_prod(tensor_in, axis)
 
+    def abs(self, tensor):
+        return tf.abs(tensor)
+
     def ones(self, shape):
         return tf.ones(shape)
+
+    def zeros(self, shape):
+        return tf.zeros(shape)
 
     def power(self, tensor_in_1, tensor_in_2):
         tensor_in_1 = self.astensor(tensor_in_1)
@@ -113,8 +119,19 @@ class tensorflow_backend(object):
         tensor_in_2 = self.astensor(tensor_in_2)
         return mask * tensor_in_1 + (1-mask) * tensor_in_2
 
-    def concatenate(self, sequence):
-        return tf.concat(sequence, axis=0)
+    def concatenate(self, sequence, axis=0):
+        """
+        Join a sequence of arrays along an existing axis.
+
+        Args:
+            sequence: sequence of tensors
+            axis: dimension along which to concatenate
+
+        Returns:
+            output: the concatenated tensor
+
+        """
+        return tf.concat(sequence, axis=axis)
 
     def simple_broadcast(self, *args):
         """
@@ -157,8 +174,38 @@ class tensorflow_backend(object):
             raise error
 
         broadcast = [arg if generic_len(arg) > 1 else
-                     tf.tile(tf.slice(arg, [0], [1]), tf.stack([max_dim])) for arg in args]
+                     self.tile(tf.slice(arg, [0], [1]), tf.stack([max_dim])) for arg in args]
         return broadcast
+
+    def tile(self, A, reps):
+        """
+        Repeats the whole array multiple times.
+
+        Args:
+            A: tensor
+            reps: The numbr of repetitions along each axis
+
+        Returns:
+            tensor: The tiled output array
+        """
+        return tf.tile(A, reps)
+
+    def einsum(self, subscripts, *operands):
+        """
+        A generalized contraction between tensors of arbitrary dimension.
+
+        This function returns a tensor whose elements are defined by equation,
+        which is written in a shorthand form inspired by the Einstein summation
+        convention.
+
+        Args:
+            subscripts: str, specifies the subscripts for summation
+            operands: list of array_like, these are the tensors for the operation
+
+        Returns:
+            tensor: the calculation based on the Einstein summation convention
+        """
+        return tf.einsum(subscripts, *operands)
 
     def poisson(self, n, lam):
         # could be changed to actual Poisson easily

--- a/pyhf/tensor/tensorflow_backend.py
+++ b/pyhf/tensor/tensorflow_backend.py
@@ -174,21 +174,8 @@ class tensorflow_backend(object):
             raise error
 
         broadcast = [arg if generic_len(arg) > 1 else
-                     self.tile(tf.slice(arg, [0], [1]), tf.stack([max_dim])) for arg in args]
+                     tf.tile(tf.slice(arg, [0], [1]), tf.stack([max_dim])) for arg in args]
         return broadcast
-
-    def tile(self, A, reps):
-        """
-        Repeats the whole array multiple times.
-
-        Args:
-            A: tensor
-            reps: The numbr of repetitions along each axis
-
-        Returns:
-            tensor: The tiled output array
-        """
-        return tf.tile(A, reps)
 
     def einsum(self, subscripts, *operands):
         """

--- a/pyhf/tensor/tensorflow_backend.py
+++ b/pyhf/tensor/tensorflow_backend.py
@@ -80,6 +80,7 @@ class tensorflow_backend(object):
         return tf.reduce_prod(tensor_in) if axis is None else tf.reduce_prod(tensor_in, axis)
 
     def abs(self, tensor):
+        tensor = self.astensor(tensor)
         return tf.abs(tensor)
 
     def ones(self, shape):

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -61,14 +61,23 @@ def test_einsum():
     backends = [numpy_backend(poisson_from_normal=True),
                 pytorch_backend(),
                 tensorflow_backend(session=tf_sess),
-                # mxnet_backend() #no einsum in mxnet
+                mxnet_backend() #no einsum in mxnet
                 ]
-    for b in backends:
+
+
+
+    for b in backends[:-1]:
         pyhf.set_backend(b)
 
         x = np.arange(20).reshape(5,4).tolist()
         assert np.all(b.tolist(b.einsum('ij->ji',x)) == np.asarray(x).T.tolist())
-        assert b.tolist('i,j->ij',b.astensor([1,1,1]),b.astensor([1,2,3])).tolist() == [[1,2,3]]*3
+        assert b.tolist(b.einsum('i,j->ij',b.astensor([1,1,1]),b.astensor([1,2,3]))) == [[1,2,3]]*3
+
+    for b in backends[-1:]:
+        pyhf.set_backend(b)
+        x = np.arange(20).reshape(5,4).tolist()
+        with pytest.raises(NotImplementedError):
+            assert b.einsum('ij->ji',[1,2,3])
 
 def test_pdf_eval():
     tf_sess = tf.Session()

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -54,6 +54,7 @@ def test_common_tensor_backends():
             == [[1, 1, 1], [2, 3, 4], [5, 6, 7]]
         assert tb.tolist(tb.ones((4,5)))  == [[1.]*5]*4
         assert tb.tolist(tb.zeros((4,5))) == [[0.]*5]*4
+        assert tb.tolist(tb.abs(tb.astensor([-1,-2]))) == [1,2]
         with pytest.raises(Exception):
             tb.simple_broadcast([1], [2, 3], [5, 6, 7])
 

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -56,6 +56,20 @@ def test_common_tensor_backends():
             tb.simple_broadcast([1], [2, 3], [5, 6, 7])
 
 
+def test_einsum():
+    tf_sess = tf.Session()
+    backends = [numpy_backend(poisson_from_normal=True),
+                pytorch_backend(),
+                tensorflow_backend(session=tf_sess),
+                # mxnet_backend() #no einsum in mxnet
+                ]
+    for b in backends:
+        pyhf.set_backend(b)
+
+        x = np.arange(20).reshape(5,4).tolist()
+        assert np.all(b.tolist(b.einsum('ij->ji',x)) == np.asarray(x).T.tolist())
+        assert b.tolist('i,j->ij',b.astensor([1,1,1]),b.astensor([1,2,3])).tolist() == [[1,2,3]]*3
+
 def test_pdf_eval():
     tf_sess = tf.Session()
     backends = [numpy_backend(poisson_from_normal=True),

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -54,7 +54,7 @@ def test_common_tensor_backends():
             == [[1, 1, 1], [2, 3, 4], [5, 6, 7]]
         assert tb.tolist(tb.ones((4,5)))  == [[1.]*5]*4
         assert tb.tolist(tb.zeros((4,5))) == [[0.]*5]*4
-        assert tb.tolist(tb.abs(tb.astensor([-1,-2]))) == [1,2]
+        assert tb.tolist(tb.abs([-1,-2])) == [1,2]
         with pytest.raises(Exception):
             tb.simple_broadcast([1], [2, 3], [5, 6, 7])
 

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -52,10 +52,8 @@ def test_common_tensor_backends():
             == [[1, 1, 1], [2, 3, 4], [5, 6, 7]]
         assert list(map(tb.tolist, tb.simple_broadcast([1], [2, 3, 4], [5, 6, 7]))) \
             == [[1, 1, 1], [2, 3, 4], [5, 6, 7]]
-        assert list(map(tb.tolist, tb.ones((4,5)))) \
-            == [[0.]*5]*4
-        assert list(map(tb.tolist, tb.zeros((4,5)))) \
-            == [[0.]*5]*4
+        assert tb.tolist(tb.ones((4,5)))  == [[1.]*5]*4
+        assert tb.tolist(tb.zeros((4,5))) == [[0.]*5]*4
         with pytest.raises(Exception):
             tb.simple_broadcast([1], [2, 3], [5, 6, 7])
 

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -52,6 +52,10 @@ def test_common_tensor_backends():
             == [[1, 1, 1], [2, 3, 4], [5, 6, 7]]
         assert list(map(tb.tolist, tb.simple_broadcast([1], [2, 3, 4], [5, 6, 7]))) \
             == [[1, 1, 1], [2, 3, 4], [5, 6, 7]]
+        assert list(map(tb.tolist, tb.ones((4,5)))) \
+            == [[0.]*5]*4
+        assert list(map(tb.tolist, tb.zeros((4,5)))) \
+            == [[0.]*5]*4
         with pytest.raises(Exception):
             tb.simple_broadcast([1], [2, 3], [5, 6, 7])
 


### PR DESCRIPTION
# Description

Add the following functionality to backends in preparation for tensorizing the interpolation code as in #251 

- einsum
- zeros
- abs

NB: mxnet does not support einsum. In lieu of this, I added a `raise NotImplementedError` when einsum is called.

# Checklist Before Requesting Approver

- [ ] Tests are passing
- [ ] "WIP" removed from the title of the pull request
