### PR TITLE
precomputes all modifications at once

### DIFF
--- a/pyhf/modifiers/histosys.py
+++ b/pyhf/modifiers/histosys.py
@@ -5,7 +5,7 @@ from . import modifier
 from .. import get_backend
 from ..interpolate import interpolator
 
-@modifier(name='histosys', constrained=True, shared=True)
+@modifier(name='histosys', constrained=True, shared=True, op_code = 'addition')
 class histosys(object):
     """HistoSys modifier
 

--- a/pyhf/modifiers/normfactor.py
+++ b/pyhf/modifiers/normfactor.py
@@ -3,7 +3,7 @@ log = logging.getLogger(__name__)
 
 from . import modifier
 
-@modifier(name='normfactor', shared=True)
+@modifier(name='normfactor', shared=True, op_code = 'multiplication')
 class normfactor(object):
     def __init__(self, nom_data, modifier_data):
         self.n_parameters = 1

--- a/pyhf/modifiers/normsys.py
+++ b/pyhf/modifiers/normsys.py
@@ -5,7 +5,7 @@ from . import modifier
 from .. import get_backend
 from ..interpolate import interpolator
 
-@modifier(name='normsys', constrained=True, shared=True)
+@modifier(name='normsys', constrained=True, shared=True, op_code = 'multiplication')
 class normsys(object):
     def __init__(self, nom_data, modifier_data):
         self.n_parameters     = 1

--- a/pyhf/modifiers/shapefactor.py
+++ b/pyhf/modifiers/shapefactor.py
@@ -3,7 +3,7 @@ log = logging.getLogger(__name__)
 
 from . import modifier
 
-@modifier(name='shapefactor', shared=True)
+@modifier(name='shapefactor', shared=True, op_code = 'multiplication')
 class shapefactor(object):
     def __init__(self, nom_data, modifier_data):
         self.n_parameters = len(nom_data)

--- a/pyhf/modifiers/shapesys.py
+++ b/pyhf/modifiers/shapesys.py
@@ -4,7 +4,7 @@ log = logging.getLogger(__name__)
 from . import modifier
 from .. import get_backend
 
-@modifier(name='shapesys', constrained=True, pdf_type='poisson')
+@modifier(name='shapesys', constrained=True, pdf_type='poisson', op_code = 'multiplication')
 class shapesys(object):
     def __init__(self, nom_data, modifier_data):
         self.n_parameters = len(nom_data)

--- a/pyhf/modifiers/staterror.py
+++ b/pyhf/modifiers/staterror.py
@@ -4,7 +4,7 @@ log = logging.getLogger(__name__)
 from . import modifier
 from .. import get_backend
 
-@modifier(name='staterror', shared=True, constrained=True)
+@modifier(name='staterror', shared=True, constrained=True, op_code = 'multiplication')
 class staterror(object):
     def __init__(self, nom_data, modifier_data):
         self.n_parameters     = len(nom_data)

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -233,11 +233,17 @@ class Model(object):
 
         for channel in self.spec['channels']:
             for sample in channel['samples']:
-                #sum of lists is concat
+                #concatenate list of lists using sum() and an initial value of []
+                #to get a list of all prefactors that should be multiplied to the 
+                #base histogram (the deltas below + the nominal)
                 factors = sum([
                     all_results.get(x,{}).get(channel['name'],{}).get(sample['name'],[])
                     for x in factor_mods
                 ],[]) 
+
+                #concatenate list of lists using sum() and an initial value of []
+                #to get a list of all deltas that should be addded to the 
+                #nominal values
                 deltas  = sum([
                     all_results.get(x,{}).get(channel['name'],{}).get(sample['name'],[])
                     for x in delta_mods

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -154,10 +154,14 @@ class Model(object):
     def _expected_sample(self, nominal, factors, deltas):
         tensorlib, _ = get_backend()
 
+
+        all_deltas = tensorlib.sum(tensorlib.stack(deltas), axis=0)
+        nominal_plus_deltas = tensorlib.stack(
+                    [nominal,all_deltas]
+        )
         basefactor = [
             tensorlib.sum(
-                tensorlib.stack(
-                    [nominal,tensorlib.sum(tensorlib.stack(deltas), axis=0)]),
+                nominal_plus_deltas,
                 axis=0)
                 if len(deltas) > 0
                 else nominal
@@ -177,11 +181,6 @@ class Model(object):
         total_factors = tensorlib.product(stacked_factors_binwise, axis=0)
         return total_factors
 
-        # return tensorlib.product(
-        #             tensorlib.stack(
-        #                   tensorlib.simple_broadcast(*factors)
-        #             ),
-        #        axis=0)
 
         #the base value for each bin is either the nominal with deltas applied
         #if there were any otherwise just the nominal

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -157,15 +157,13 @@ class Model(object):
         nominal_plus_deltas = None
         if len(deltas):
             all_deltas = tensorlib.sum(tensorlib.stack(deltas), axis=0)
-            nominal_plus_deltas = tensorlib.stack(
-                        [nominal,all_deltas]
-            )
+            nominal_and_deltas  = tensorlib.stack([nominal,all_deltas])
+            nominal_plus_deltas = tensorlib.sum(nominal_and_deltas,axis=0)
+
         basefactor = [
-            tensorlib.sum(
-                nominal_plus_deltas,
-                axis=0)
-                if len(deltas) > 0
-                else nominal
+            nominal_plus_deltas
+            if len(deltas) > 0
+            else nominal
         ]
         factors += basefactor
 

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -153,18 +153,23 @@ class Model(object):
 
     def _expected_sample(self, nominal, factors, deltas):
         tensorlib, _ = get_backend()
-
-        nominal_plus_deltas = None
+        
+        #the base value for each bin is either the nominal with deltas applied
+        #if there were any otherwise just the nominal
         if len(deltas):
+            #stack all bin-wise shifts in the yield value (delta) from the modifiers
+            #on top of each other and sum through the first axis
+            #will give us a overall shift to apply to the nominal histo
             all_deltas = tensorlib.sum(tensorlib.stack(deltas), axis=0)
+
+            #stack nominal and deltas and sum through first axis again
+            #to arrive at yield value after deltas (but before factor mods)
             nominal_and_deltas  = tensorlib.stack([nominal,all_deltas])
             nominal_plus_deltas = tensorlib.sum(nominal_and_deltas,axis=0)
+            basefactor = [nominal_plus_deltas]
+        else:
+            basefactor = [nominal]
 
-        basefactor = [
-            nominal_plus_deltas
-            if len(deltas) > 0
-            else nominal
-        ]
         factors += basefactor
 
         #multiplicative modifiers are either a single float that should be broadcast

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -185,36 +185,6 @@ class Model(object):
         total_factors = tensorlib.product(stacked_factors_binwise, axis=0)
         return total_factors
 
-
-        #the base value for each bin is either the nominal with deltas applied
-        #if there were any otherwise just the nominal
-        if len(deltas):
-            #stack all bin-wise shifts in the yield value (delta) from the modifiers
-            #on top of each other and sum through the first axis
-            #will give us a overall shift to apply to the nominal histo
-            overall_delta_from_modifiers = tensorlib.sum(tensorlib.stack(deltas), axis=0)
-
-            #stack nominal and deltas and sum through first axis again
-            #to arrive at yield value after deltas (but before factor mods)
-            nominal_and_deltas  = tensorlib.stack([nominal,overall_delta_from_modifiers])
-            basefactor = tensorlib.sum(nominal_and_deltas,axis=0)
-        else:
-            basefactor = nominal
-        factors += [basefactor]
-
-        #multiplicative modifiers are either a single float that should be broadcast
-        #to all bins or a list of floats (one for each bin of the histogram)
-        binwise_factors = tensorlib.simple_broadcast(*factors)
-
-        #now we arrange all factors on top of each other so that for each bin we 
-        #have all multiplicative factors
-        stacked_factors_binwise = tensorlib.stack(binwise_factors)
-
-        #binwise multiply all multiplicative factors such that we arrive
-        #at a single number for each bin
-        total_factors = tensorlib.product(stacked_factors_binwise, axis=0)
-        return total_factors
-
     def _all_modifications(self, pars):
         """
         The idea is that we compute all bin-values at once.. each bin is a product of various factors, but sum are per-channel the other per-channel

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -154,11 +154,12 @@ class Model(object):
     def _expected_sample(self, nominal, factors, deltas):
         tensorlib, _ = get_backend()
 
-
-        all_deltas = tensorlib.sum(tensorlib.stack(deltas), axis=0)
-        nominal_plus_deltas = tensorlib.stack(
-                    [nominal,all_deltas]
-        )
+        nominal_plus_deltas = None
+        if len(deltas):
+            all_deltas = tensorlib.sum(tensorlib.stack(deltas), axis=0)
+            nominal_plus_deltas = tensorlib.stack(
+                        [nominal,all_deltas]
+            )
         basefactor = [
             tensorlib.sum(
                 nominal_plus_deltas,

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -223,8 +223,9 @@ class Model(object):
         # first, collect the factors from all modifiers
 
         all_modifications = {}
-        factor_mods = ['normfactor','normsys','shapesys','shapefactor','staterror']
-        delta_mods  = ['histosys']
+        mods_and_ops = [(x,getattr(modifiers,x).op_code) for x in modifiers.__all__]
+        factor_mods = [x[0] for x in mods_and_ops if x[1]=='multiplication']
+        delta_mods  = [x[0] for x in mods_and_ops if x[1]=='addition']
 
         all_results = {}
         for mtype in factor_mods + delta_mods:

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -153,17 +153,35 @@ class Model(object):
 
     def _expected_sample(self, nominal, factors, deltas):
         tensorlib, _ = get_backend()
-        basefactor = [
-            tensorlib.sum(
-                tensorlib.stack(
-                    [nominal,tensorlib.sum(tensorlib.stack(deltas), axis=0)]),
-                axis=0)
-                if len(deltas) > 0 
-                else nominal
-        ]
+
+        #the base value for each bin is either the nominal with deltas applied
+        #if there were any otherwise just the nominal
+        if len(deltas):
+            #stack all bin-wise shifts in the yield value (delta) from the modifiers
+            #on top of each other and sum through the first axis
+            #will give us a overall shift to apply to the nominal histo
+            overall_delta_from_modifiers = tensorlib.sum(tensorlib.stack(deltas), axis=0)
+
+            #stack nominal and deltas and sum through first axis again
+            #to arrive at yield value after deltas (but before factor mods)
+            nominal_and_deltas  = tensorlib.stack([nominal,overall_delta_from_modifiers])
+            basefactor = tensorlib.sum(nominal_and_deltas,axis=0)
+        else:
+            basefactor = nominal
         factors += basefactor
 
-        return tensorlib.product(tensorlib.stack(tensorlib.simple_broadcast(*factors)), axis=0)
+        #multiplicative modifiers are either a single float that should be broadcast
+        #to all bins or a list of floats (one for each bin of the histogram)
+        binwise_factors = tensorlib.simple_broadcast(*factors)
+
+        #now we arrange all factors on top of each other so that for each bin we 
+        #have all multiplicative factors
+        stacked_factors_binwise = tensorlib.stack(binwise_factors)
+
+        #binwise multiply all multiplicative factors such that we arrive
+        #at a single number for each bin
+        total_factors = tensorlib.product(stacked_factors_binwise, axis=0)
+        return total_factors
 
     def _all_modifications(self, pars):
         """

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -164,7 +164,24 @@ class Model(object):
         ]
         factors += basefactor
 
-        return tensorlib.product(tensorlib.stack(tensorlib.simple_broadcast(*factors)), axis=0)
+        #multiplicative modifiers are either a single float that should be broadcast
+        #to all bins or a list of floats (one for each bin of the histogram)
+        binwise_factors = tensorlib.simple_broadcast(*factors)
+
+        #now we arrange all factors on top of each other so that for each bin we 
+        #have all multiplicative factors
+        stacked_factors_binwise = tensorlib.stack(binwise_factors)
+
+        #binwise multiply all multiplicative factors such that we arrive
+        #at a single number for each bin
+        total_factors = tensorlib.product(stacked_factors_binwise, axis=0)
+        return total_factors
+
+        # return tensorlib.product(
+        #             tensorlib.stack(
+        #                   tensorlib.simple_broadcast(*factors)
+        #             ),
+        #        axis=0)
 
         #the base value for each bin is either the nominal with deltas applied
         #if there were any otherwise just the nominal

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -154,6 +154,18 @@ class Model(object):
     def _expected_sample(self, nominal, factors, deltas):
         tensorlib, _ = get_backend()
 
+        basefactor = [
+            tensorlib.sum(
+                tensorlib.stack(
+                    [nominal,tensorlib.sum(tensorlib.stack(deltas), axis=0)]),
+                axis=0)
+                if len(deltas) > 0
+                else nominal
+        ]
+        factors += basefactor
+
+        return tensorlib.product(tensorlib.stack(tensorlib.simple_broadcast(*factors)), axis=0)
+
         #the base value for each bin is either the nominal with deltas applied
         #if there were any otherwise just the nominal
         if len(deltas):
@@ -168,7 +180,7 @@ class Model(object):
             basefactor = tensorlib.sum(nominal_and_deltas,axis=0)
         else:
             basefactor = nominal
-        factors += basefactor
+        factors += [basefactor]
 
         #multiplicative modifiers are either a single float that should be broadcast
         #to all bins or a list of floats (one for each bin of the histogram)

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -163,7 +163,14 @@ class Model(object):
 
     def expected_sample(self, channel, sample, pars):
         tensorlib, _ = get_backend()
-        #public API only, not efficient
+        """
+        Public API only, not efficient or fast. We compute all modification for
+        all samples in this method even though we are only interested in the
+        modifications in a single sample.
+
+        Alternatively the _all_modifications() could take a list of
+        channel/samples for which it should compute modificiations.
+        """
         all_modifications = self._all_modifications(pars)
         return self._expected_sample(
             tensorlib.astensor(sample['data']), #nominal

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -142,6 +142,14 @@ class Model(object):
                             )
         return mtype_results
 
+    def expected_sample(self, channel, sample, pars):
+        #public API only, not efficient
+        all_modifications = self._all_modifications(pars)
+        return self._expected_sample(
+            sample['data'], #nominal
+            *all_modifications[channel['name']][sample['name']] #mods
+        )
+
     def _all_modifications(self, pars):
         """
         The idea is that we compute all bin-values at once.. each bin is a product of various factors, but sum are per-channel the other per-channel
@@ -225,7 +233,8 @@ class Model(object):
                 ] = (factors, deltas)
         return all_modifications
 
-    def expected_sample(self, nominal, factors, deltas):
+
+    def _expected_sample(self, nominal, factors, deltas):
         tensorlib, _ = get_backend()
         basefactor = [
             tensorlib.sum(
@@ -264,7 +273,7 @@ class Model(object):
         all_modifications = self._all_modifications(pars)
         for channel in self.spec['channels']:
             sample_stack = [
-                self.expected_sample(
+                self._expected_sample(
                     sample['data'], #nominal
                     *all_modifications[channel['name']][sample['name']] #mods
                 )

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -143,10 +143,11 @@ class Model(object):
         return mtype_results
 
     def expected_sample(self, channel, sample, pars):
+        tensorlib, _ = get_backend()
         #public API only, not efficient
         all_modifications = self._all_modifications(pars)
         return self._expected_sample(
-            sample['data'], #nominal
+            tensorlib.astensor(sample['data']), #nominal
             *all_modifications[channel['name']][sample['name']] #mods
         )
 
@@ -274,7 +275,7 @@ class Model(object):
         for channel in self.spec['channels']:
             sample_stack = [
                 self._expected_sample(
-                    sample['data'], #nominal
+                    tensorlib.astensor(sample['data']), #nominal
                     *all_modifications[channel['name']][sample['name']] #mods
                 )
                 for sample in channel['samples']

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -146,7 +146,32 @@ class Model(object):
             if mtype in self.combined_mods.keys():
                 return self.combined_mods[mtype].apply(pars)
 
-        before the loops.
+        before the loops. This returns a bookkeeping dictionary of the following structure
+
+            _mtype_results_dict == {
+                channel1: {
+                    sample1: [
+                        mod1.apply(),
+                        mod2.apply(),
+                        ...
+                    ],
+                    sample2: [
+                        mod1.apply(),
+                        mod3.apply(),
+                        mod5.apply(),
+                        ...
+                    ]
+                },
+                channel2: {
+                    sample2: [
+                        mod2.apply(),
+                        mod3.apply(),
+                        mod4.apply()
+                    ],
+                    ...
+                },
+                ...
+            }
         """
         mtype_results = {}
         for channel in self.spec['channels']:

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -151,6 +151,20 @@ class Model(object):
             *all_modifications[channel['name']][sample['name']] #mods
         )
 
+    def _expected_sample(self, nominal, factors, deltas):
+        tensorlib, _ = get_backend()
+        basefactor = [
+            tensorlib.sum(
+                tensorlib.stack(
+                    [nominal,tensorlib.sum(tensorlib.stack(deltas), axis=0)]),
+                axis=0)
+                if len(deltas) > 0 
+                else nominal
+        ]
+        factors += basefactor
+
+        return tensorlib.product(tensorlib.stack(tensorlib.simple_broadcast(*factors)), axis=0)
+        
     def _all_modifications(self, pars):
         """
         The idea is that we compute all bin-values at once.. each bin is a product of various factors, but sum are per-channel the other per-channel
@@ -233,22 +247,6 @@ class Model(object):
                     sample['name']
                 ] = (factors, deltas)
         return all_modifications
-
-
-    def _expected_sample(self, nominal, factors, deltas):
-        tensorlib, _ = get_backend()
-        basefactor = [
-            tensorlib.sum(
-                tensorlib.stack(
-                    [nominal,tensorlib.sum(tensorlib.stack(deltas), axis=0)]),
-                axis=0)
-                if len(deltas) > 0 
-                else nominal
-        ]
-
-        factors += basefactor
-
-        return tensorlib.product(tensorlib.stack(tensorlib.simple_broadcast(*factors)), axis=0)
 
     def expected_auxdata(self, pars):
         # probably more correctly this should be the expectation value of the constraint_pdf

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -153,7 +153,7 @@ class Model(object):
 
     def _expected_sample(self, nominal, factors, deltas):
         tensorlib, _ = get_backend()
-        
+
         #the base value for each bin is either the nominal with deltas applied
         #if there were any otherwise just the nominal
         if len(deltas):
@@ -176,7 +176,7 @@ class Model(object):
         #to all bins or a list of floats (one for each bin of the histogram)
         binwise_factors = tensorlib.simple_broadcast(*factors)
 
-        #now we arrange all factors on top of each other so that for each bin we 
+        #now we arrange all factors on top of each other so that for each bin we
         #have all multiplicative factors
         stacked_factors_binwise = tensorlib.stack(binwise_factors)
 
@@ -254,21 +254,21 @@ class Model(object):
         for channel in self.spec['channels']:
             for sample in channel['samples']:
                 #concatenate list of lists using sum() and an initial value of []
-                #to get a list of all prefactors that should be multiplied to the 
+                #to get a list of all prefactors that should be multiplied to the
                 #base histogram (the deltas below + the nominal)
                 factors = sum([
                     all_results.get(x,{}).get(channel['name'],{}).get(sample['name'],[])
                     for x in factor_mods
-                ],[]) 
+                ],[])
 
                 #concatenate list of lists using sum() and an initial value of []
-                #to get a list of all deltas that should be addded to the 
+                #to get a list of all deltas that should be addded to the
                 #nominal values
                 deltas  = sum([
                     all_results.get(x,{}).get(channel['name'],{}).get(sample['name'],[])
                     for x in delta_mods
                 ],[])
-                
+
                 all_modifications.setdefault(
                     channel['name'],{})[
                     sample['name']

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -262,7 +262,7 @@ class Model(object):
             tocat = [thisaux] if auxdata is None else [auxdata, thisaux]
             auxdata = tensorlib.concatenate(tocat)
         return auxdata
-        
+
     def expected_actualdata(self, pars):
         tensorlib, _ = get_backend()
         pars = tensorlib.astensor(pars)

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -164,7 +164,7 @@ class Model(object):
         factors += basefactor
 
         return tensorlib.product(tensorlib.stack(tensorlib.simple_broadcast(*factors)), axis=0)
-        
+
     def _all_modifications(self, pars):
         """
         The idea is that we compute all bin-values at once.. each bin is a product of various factors, but sum are per-channel the other per-channel
@@ -262,8 +262,7 @@ class Model(object):
             tocat = [thisaux] if auxdata is None else [auxdata, thisaux]
             auxdata = tensorlib.concatenate(tocat)
         return auxdata
-
-
+        
     def expected_actualdata(self, pars):
         tensorlib, _ = get_backend()
         pars = tensorlib.astensor(pars)

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -20,7 +20,7 @@ def test_import_default_modifiers(test_modifierPair):
     assert hasattr(modifier, 'pdf_type')
     assert hasattr(modifier, 'op_code')
     assert modifier.pdf_type == test_mod_type
-    assert modifier.op_code == 'addition'
+    assert modifier.op_code in ['addition','multiplication']
 
 # we make sure modifiers have right structure
 def test_modifiers_structure():


### PR DESCRIPTION
# Description

This PR refactors the pdf to compute all modifications needed in one go. This should be possible independent of #231 #251 but help with the overall refactoring by collecting all necessary computations in a single function that can then be optimized

# Checklist Before Requesting Approver

- [ ] Tests are passing
- [ ] "WIP" removed from the title of the pull request
