### PR TITLE
Feature: (automatically) set backends through a fixture

### DIFF
--- a/pyhf/readxml.py
+++ b/pyhf/readxml.py
@@ -21,7 +21,7 @@ def extract_error(h):
     Returns:
         list: The uncertainty for each bin in the histogram
     """
-    err = h.fSumw2[1:-1] if h.fSumw2 else h.numpy[0]
+    err = h.variances if h.variances else h.numpy[0]
     return np.sqrt(err).tolist()
 
 def import_root_histogram(rootdir, filename, path, name):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,7 @@ def backend(request):
 
     # actual execution here, after all checks is done
     pyhf.set_backend(*request.param)
-    if isinstance(request.param, pyhf.tensor.tensorflow_backend):
+    if isinstance(pyhf.tensorlib, pyhf.tensor.tensorflow_backend):
         tf.reset_default_graph()
         pyhf.tensorlib.session = tf.Session()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,11 @@ import pytest
 import pyhf
 import tensorflow as tf
 
+@pytest.fixture(scope='function', autouse=True)
+def reset_backend():
+    yield reset_backend
+    pyhf.set_backend(pyhf.default_backend)
+
 @pytest.fixture(scope='function', params=[
                              (pyhf.tensor.numpy_backend(),),
                              (pyhf.tensor.tensorflow_backend(session=tf.Session()),),
@@ -50,5 +55,3 @@ def backend(request):
         pyhf.tensorlib.session = tf.Session()
 
     yield request.param
-
-    pyhf.set_backend(pyhf.default_backend)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,37 @@
 import pytest
 import pyhf
+import tensorflow as tf
 
-@pytest.fixture(scope='function', autouse=True)
-def reset_backend():
-  yield reset_backend
-  pyhf.set_backend(pyhf.default_backend)
+@pytest.fixture(scope='function', autouse=True, params=[
+                             pyhf.tensor.numpy_backend(),
+                             pyhf.tensor.tensorflow_backend(session=tf.Session()),
+                             pyhf.tensor.pytorch_backend(),
+                             pyhf.tensor.mxnet_backend(),
+                         ],
+                         ids=[
+                             'numpy',
+                             'tensorflow',
+                             'pytorch',
+                             'mxnet',
+                         ])
+def backend(request):
+    param = request.param
+    # a better way to get the id?
+    param_id = request._fixturedef.ids[request.param_index]
+    skip_backend = request.node.get_marker('skip_{0:s}'.format(param_id))
+    fail_backend = request.node.get_marker('fail_{0:s}'.format(param_id))
+    if skip_backend:
+        pytest.skip("skipping {0:s} as specified".format(param_id))
+        return
+    if fail_backend:
+        pytest.skip("expect {0:s} to fail as specified".format(param_id))
+        return
+
+    pyhf.set_backend(request.param)
+    if isinstance(request.param, pyhf.tensor.tensorflow_backend):
+        tf.reset_default_graph()
+        pyhf.tensorlib.session = tf.Session()
+
+    yield request.param
+
+    pyhf.set_backend(pyhf.default_backend)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,22 @@
 import pytest
 import pyhf
 import tensorflow as tf
+import sys
 
+'''
+This fixture isolates the sys.modules imported in case you need to mess around with them and do not want to break other tests.
+
+This is not done automatically.
+'''
+@pytest.fixture(scope='function')
+def isolate_modules():
+    CACHE_MODULES = sys.modules.copy()
+    yield isolate_modules
+    sys.modules.update(CACHE_MODULES)
+
+'''
+This fixture is automatically run to reset the backend before and after a test function runs.
+'''
 @pytest.fixture(scope='function', autouse=True)
 def reset_backend():
     pyhf.set_backend(pyhf.default_backend)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,16 +3,18 @@ import pyhf
 import tensorflow as tf
 
 @pytest.fixture(scope='function', params=[
-                             pyhf.tensor.numpy_backend(),
-                             pyhf.tensor.tensorflow_backend(session=tf.Session()),
-                             pyhf.tensor.pytorch_backend(),
-                             pyhf.tensor.mxnet_backend(),
+                             (pyhf.tensor.numpy_backend(),),
+                             (pyhf.tensor.tensorflow_backend(session=tf.Session()),),
+                             (pyhf.tensor.pytorch_backend(),),
+                             (pyhf.tensor.mxnet_backend(),),
+                             (pyhf.tensor.numpy_backend(poisson_from_normal=True), pyhf.optimize.minuit_optimizer()),
                          ],
                          ids=[
                              'numpy',
                              'tensorflow',
                              'pytorch',
                              'mxnet',
+                             'numpy_minuit',
                          ])
 def backend(request):
     param = request.param
@@ -42,7 +44,7 @@ def backend(request):
         pytest.xfail("expect {func} to fail as specified".format(func=func_name))
 
     # actual execution here, after all checks is done
-    pyhf.set_backend(request.param)
+    pyhf.set_backend(*request.param)
     if isinstance(request.param, pyhf.tensor.tensorflow_backend):
         tf.reset_default_graph()
         pyhf.tensorlib.session = tf.Session()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,17 +16,32 @@ import tensorflow as tf
                          ])
 def backend(request):
     param = request.param
-    # a better way to get the id?
-    param_id = request._fixturedef.ids[request.param_index]
-    skip_backend = request.node.get_marker('skip_{0:s}'.format(param_id))
-    fail_backend = request.node.get_marker('fail_{0:s}'.format(param_id))
-    if skip_backend:
-        pytest.skip("skipping {0:s} as specified".format(param_id))
-        return
-    if fail_backend:
-        pytest.skip("expect {0:s} to fail as specified".format(param_id))
-        return
+    # a better way to get the id? all the backends we have so far for testing
+    param_ids = request._fixturedef.ids
+    # the backend we're using: numpy, tensorflow, etc...
+    param_id = param_ids[request.param_index]
+    # name of function being called (with params), the original name is .originalname
+    func_name = request._pyfuncitem.name
 
+    # skip backends if specified
+    skip_backend = request.node.get_marker('skip_{param}'.format(param=param_id))
+    # allow the specific backend to fail if specified
+    fail_backend = request.node.get_marker('fail_{param}'.format(param=param_id))
+    # only look at the specific backends
+    only_backends = [pid for pid in param_ids if request.node.get_marker('only_{param}'.format(param=pid))]
+
+    if(skip_backend and (param_id in only_backends)):
+        raise ValueError("Must specify skip_{param} or only_{param} but not both!".format(param=pid))
+
+    if skip_backend:
+        pytest.skip("skipping {func} as specified".format(func=func_name))
+    elif only_backends and param_id not in only_backends:
+        pytest.skip("skipping {func} as specified to only look at: {backends}".format(func=func_name, backends=', '.join(only_backends)))
+
+    if fail_backend:
+        pytest.xfail("expect {func} to fail as specified".format(func=func_name))
+
+    # actual execution here, after all checks is done
     pyhf.set_backend(request.param)
     if isinstance(request.param, pyhf.tensor.tensorflow_backend):
         tf.reset_default_graph()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import pytest
 import pyhf
 import tensorflow as tf
 
-@pytest.fixture(scope='function', autouse=True, params=[
+@pytest.fixture(scope='function', params=[
                              pyhf.tensor.numpy_backend(),
                              pyhf.tensor.tensorflow_backend(session=tf.Session()),
                              pyhf.tensor.pytorch_backend(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import tensorflow as tf
 
 @pytest.fixture(scope='function', autouse=True)
 def reset_backend():
+    pyhf.set_backend(pyhf.default_backend)
     yield reset_backend
     pyhf.set_backend(pyhf.default_backend)
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -12,8 +12,8 @@ def test_missing_backends(isolate_modules, param):
     backend_name, module_name, expectation = param
 
     # delete all of pyhf to force a reload
-    for k in sys.modules.keys():
-        if 'pyhf' in k: del sys.modules[k]
+    for k in [k for k in sys.modules.keys() if 'pyhf' in k]:
+        del sys.modules[k]
 
     # hide
     CACHE_BACKEND, sys.modules[backend_name] = sys.modules[backend_name], None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,6 +1,5 @@
 import pytest
 import sys
-import copy
 
 @pytest.mark.parametrize("param", [
         ["numpy", "numpy_backend", pytest.raises(ImportError)],
@@ -9,12 +8,12 @@ import copy
         ["mxnet", "mxnet_backend", pytest.raises(AttributeError)],
     ],
     ids=["numpy", "pytorch", "tensorflow", "mxnet"])
-def test_missing_backends(param):
+def test_missing_backends(isolate_modules, param):
     backend_name, module_name, expectation = param
 
     # delete all of pyhf to force a reload
     for k in sys.modules.keys():
-        if k.startswith('pyhf'): del sys.modules[k]
+        if 'pyhf' in k: del sys.modules[k]
 
     # hide
     CACHE_BACKEND, sys.modules[backend_name] = sys.modules[backend_name], None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,27 @@
+import pytest
+import sys
+import copy
+
+@pytest.mark.parametrize("param", [
+        ["numpy", "numpy_backend", pytest.raises(ImportError)],
+        ["torch", "pytorch_backend", pytest.raises(AttributeError)],
+        ["tensorflow", "tensorflow_backend", pytest.raises(AttributeError)],
+        ["mxnet", "mxnet_backend", pytest.raises(AttributeError)],
+    ],
+    ids=["numpy", "pytorch", "tensorflow", "mxnet"])
+def test_missing_backends(param):
+    backend_name, module_name, expectation = param
+
+    # delete all of pyhf to force a reload
+    for k in sys.modules.keys():
+        if k.startswith('pyhf'): del sys.modules[k]
+
+    # hide
+    CACHE_BACKEND, sys.modules[backend_name] = sys.modules[backend_name], None
+
+    with expectation:
+        import pyhf.tensor
+        getattr(pyhf.tensor, module_name)
+
+    # put back
+    CACHE_BACKEND, sys.modules[backend_name] = None, CACHE_BACKEND

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -47,25 +47,9 @@ def random_histosets_alphasets_pair():
     h,a = filled_shapes(random_histogramssets,random_alphas)
     return h,a
 
-@pytest.mark.parametrize('backend',
-                         [
-                             pyhf.tensor.numpy_backend(),
-                             pyhf.tensor.tensorflow_backend(session=tf.Session()),
-                             pyhf.tensor.pytorch_backend(),
-                             # pyhf.tensor.mxnet_backend(),
-                         ],
-                         ids=[
-                             'numpy',
-                             'tensorflow',
-                             'pytorch',
-                         ])
+@pytest.mark.skip_mxnet
 @pytest.mark.parametrize("interpcode", [0, 1])
 def test_interpcode(backend, interpcode, random_histosets_alphasets_pair):
-    pyhf.set_backend(backend)
-    if isinstance(pyhf.tensorlib, pyhf.tensor.tensorflow_backend):
-        tf.reset_default_graph()
-        pyhf.tensorlib.session = tf.Session()
-
     histogramssets, alphasets = random_histosets_alphasets_pair
 
     # single-float precision backends, calculate using single-floats
@@ -78,25 +62,9 @@ def test_interpcode(backend, interpcode, random_histosets_alphasets_pair):
 
     assert pytest.approx(slow_result[~np.isnan(slow_result)].ravel().tolist()) == fast_result[~np.isnan(fast_result)].ravel().tolist()
 
-@pytest.mark.parametrize('backend',
-                         [
-                             pyhf.tensor.numpy_backend(),
-                             pyhf.tensor.tensorflow_backend(session=tf.Session()),
-                             pyhf.tensor.pytorch_backend(),
-                             # pyhf.tensor.mxnet_backend(),
-                         ],
-                         ids=[
-                             'numpy',
-                             'tensorflow',
-                             'pytorch',
-                         ])
+@pytest.mark.skip_mxnet
 @pytest.mark.parametrize("do_tensorized_calc", [False, True], ids=['slow','fast'])
-def test_interpcode_0(backend, do_tensorized_calc):
-    pyhf.set_backend(backend)
-    if isinstance(pyhf.tensorlib, pyhf.tensor.tensorflow_backend):
-        tf.reset_default_graph()
-        pyhf.tensorlib.session = tf.Session()
-
+def test_interpcode_0(do_tensorized_calc):
     histogramssets = pyhf.tensorlib.astensor([
         [
             [
@@ -121,26 +89,9 @@ def test_interpcode_0(backend, do_tensorized_calc):
 
     assert pytest.approx(np.asarray(pyhf.tensorlib.tolist(results)).ravel().tolist()) == np.asarray(pyhf.tensorlib.tolist(expected)).ravel().tolist()
 
-
-@pytest.mark.parametrize('backend',
-                         [
-                             pyhf.tensor.numpy_backend(),
-                             pyhf.tensor.tensorflow_backend(session=tf.Session()),
-                             pyhf.tensor.pytorch_backend(),
-                             # pyhf.tensor.mxnet_backend(),
-                         ],
-                         ids=[
-                             'numpy',
-                             'tensorflow',
-                             'pytorch',
-                         ])
+@pytest.mark.skip_mxnet
 @pytest.mark.parametrize("do_tensorized_calc", [False, True], ids=['slow','fast'])
-def test_interpcode_1(backend, do_tensorized_calc):
-    pyhf.set_backend(backend)
-    if isinstance(pyhf.tensorlib, pyhf.tensor.tensorflow_backend):
-        tf.reset_default_graph()
-        pyhf.tensorlib.session = tf.Session()
-
+def test_interpcode_1(do_tensorized_calc):
     histogramssets = pyhf.tensorlib.astensor([
         [
             [

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -64,7 +64,7 @@ def test_interpcode(backend, interpcode, random_histosets_alphasets_pair):
 
 @pytest.mark.skip_mxnet
 @pytest.mark.parametrize("do_tensorized_calc", [False, True], ids=['slow','fast'])
-def test_interpcode_0(do_tensorized_calc):
+def test_interpcode_0(backend, do_tensorized_calc):
     histogramssets = pyhf.tensorlib.astensor([
         [
             [
@@ -91,7 +91,7 @@ def test_interpcode_0(do_tensorized_calc):
 
 @pytest.mark.skip_mxnet
 @pytest.mark.parametrize("do_tensorized_calc", [False, True], ids=['slow','fast'])
-def test_interpcode_1(do_tensorized_calc):
+def test_interpcode_1(backend, do_tensorized_calc):
     histogramssets = pyhf.tensorlib.astensor([
         [
             [

--- a/tests/test_interpolate.py
+++ b/tests/test_interpolate.py
@@ -53,7 +53,7 @@ def test_interpcode(backend, interpcode, random_histosets_alphasets_pair):
     histogramssets, alphasets = random_histosets_alphasets_pair
 
     # single-float precision backends, calculate using single-floats
-    if isinstance(backend, pyhf.tensor.tensorflow_backend) or isinstance(backend, pyhf.tensor.pytorch_backend):
+    if isinstance(pyhf.tensorlib, pyhf.tensor.tensorflow_backend) or isinstance(pyhf.tensorlib, pyhf.tensor.pytorch_backend):
         histogramssets = np.asarray(histogramssets, dtype=np.float32)
         alphasets = np.asarray(alphasets, dtype=np.float32)
 

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -64,33 +64,15 @@ def spec(source):
                          ids=[
                              'mu=1',
                          ])
-@pytest.mark.parametrize('backend',
-                         [
-                             (pyhf.tensor.numpy_backend(poisson_from_normal=True),),
-                             (pyhf.tensor.tensorflow_backend(session=tf.Session()),),
-                             (pyhf.tensor.pytorch_backend(poisson_from_normal=True),),
-                             # pyhf.tensor.mxnet_backend(),
-                             (pyhf.tensor.numpy_backend(poisson_from_normal=True), pyhf.optimize.minuit_optimizer()),
-                         ],
-                         ids=[
-                             'numpy',
-                             'tensorflow',
-                             'pytorch',
-                             # 'mxnet',
-                             'numpy-minuit',
-                         ])
-def test_optim(source, spec, mu, backend):
+@pytest.mark.skip_mxnet
+def test_optim(backend, source, spec, mu):
     pdf = pyhf.Model(spec)
     data = source['bindata']['data'] + pdf.config.auxdata
 
     init_pars = pdf.config.suggested_init()
     par_bounds = pdf.config.suggested_bounds()
 
-    pyhf.set_backend(*backend)
     optim = pyhf.optimizer
-    if isinstance(pyhf.tensorlib, pyhf.tensor.tensorflow_backend):
-        tf.reset_default_graph()
-        pyhf.tensorlib.session = tf.Session()
 
     result = optim.unconstrained_bestfit(
         pyhf.utils.loglambdav, data, pdf, init_pars, par_bounds)

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -6,7 +6,7 @@ import numpy as np
 import json
 
 @pytest.mark.only_numpy
-def test_numpy_pdf_inputs():
+def test_numpy_pdf_inputs(backend):
     source = {
       "binning": [2,-0.5,1.5],
       "bindata": {
@@ -33,7 +33,7 @@ def test_numpy_pdf_inputs():
 
 
 @pytest.mark.only_numpy
-def test_core_pdf_broadcasting():
+def test_core_pdf_broadcasting(backend):
     data    = [10,11,12,13,14,15]
     lambdas = [15,14,13,12,11,10]
     naive_python = [pyhf.tensorlib.poisson(d, lam) for d,lam in zip(data, lambdas)]
@@ -58,7 +58,7 @@ def test_core_pdf_broadcasting():
     assert np.all(naive_python  == broadcasted)
 
 @pytest.mark.only_numpy
-def test_pdf_integration_staterror():
+def test_pdf_integration_staterror(backend):
     spec = {
         'channels': [
             {
@@ -107,7 +107,7 @@ def test_pdf_integration_staterror():
         assert c==e
 
 @pytest.mark.only_numpy
-def test_pdf_integration_histosys():
+def test_pdf_integration_histosys(backend):
     source = json.load(open('validation/data/2bin_histosys_example2.json'))
     spec = {
         'channels': [
@@ -158,7 +158,7 @@ def test_pdf_integration_histosys():
 
 
 @pytest.mark.skip_mxnet
-def test_pdf_integration_normsys():
+def test_pdf_integration_normsys(backend):
     source = json.load(open('validation/data/2bin_histosys_example2.json'))
     spec = {
         'channels': [
@@ -196,7 +196,7 @@ def test_pdf_integration_normsys():
     assert np.allclose(pyhf.tensorlib.tolist(pdf.expected_data(pars, include_auxdata = False)),[100*0.9,150*0.9])
 
 @pytest.mark.only_numpy
-def test_pdf_integration_shapesys():
+def test_pdf_integration_shapesys(backend):
     source = json.load(open('validation/data/2bin_histosys_example2.json'))
     spec = {
         'channels': [

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -12,75 +12,57 @@ import tensorflow as tf
 import pytest
 
 
-def test_common_tensor_backends():
-    tf_sess = tf.Session()
-    for tb in [
-        numpy_backend(),
-        pytorch_backend(),
-        tensorflow_backend(session=tf_sess),
-        mxnet_backend()
-    ]:
-        assert tb.tolist(tb.astensor([1, 2, 3])) == [1, 2, 3]
-        assert tb.tolist(tb.ones((2, 3))) == [[1, 1, 1], [1, 1, 1]]
-        assert tb.tolist(tb.sum([[1, 2, 3], [4, 5, 6]], axis=0)) == [5, 7, 9]
-        assert tb.tolist(
-            tb.product([[1, 2, 3], [4, 5, 6]], axis=0)) == [4, 10, 18]
-        assert tb.tolist(tb.power([1, 2, 3], [1, 2, 3])) == [1, 4, 27]
-        assert tb.tolist(tb.divide([4, 9, 16], [2, 3, 4])) == [2, 3, 4]
-        assert tb.tolist(
-            tb.outer([1, 2, 3], [4, 5, 6])) == [[4, 5, 6], [8, 10, 12], [12, 15, 18]]
-        assert tb.tolist(tb.sqrt([4, 9, 16])) == [2, 3, 4]
-        assert tb.tolist(tb.stack(
-            [tb.astensor([1, 2, 3]), tb.astensor([4, 5, 6])])) == [[1, 2, 3], [4, 5, 6]]
-        assert tb.tolist(tb.concatenate(
-            [tb.astensor([1, 2, 3]), tb.astensor([4, 5, 6])])) == [1, 2, 3, 4, 5, 6]
-        assert tb.tolist(tb.log(tb.exp([2, 3, 4]))) == [2, 3, 4]
-        assert tb.tolist(tb.where(
-            tb.astensor([1, 0, 1]),
-            tb.astensor([1, 1, 1]),
-            tb.astensor([2, 2, 2]))) == [1, 2, 1]
-        assert tb.tolist(
-            tb.clip(tb.astensor([-2, -1, 0, 1, 2]), -1, 1)) == [-1, -1,  0,  1,  1]
-        assert tb.tolist(
-            tb.normal_cdf(tb.astensor([0.8]))) == pytest.approx([0.7881446014166034], 1e-07)
+def test_common_tensor_backends(backend):
+    tb = pyhf.tensorlib
+    assert tb.tolist(tb.astensor([1, 2, 3])) == [1, 2, 3]
+    assert tb.tolist(tb.ones((2, 3))) == [[1, 1, 1], [1, 1, 1]]
+    assert tb.tolist(tb.sum([[1, 2, 3], [4, 5, 6]], axis=0)) == [5, 7, 9]
+    assert tb.tolist(
+        tb.product([[1, 2, 3], [4, 5, 6]], axis=0)) == [4, 10, 18]
+    assert tb.tolist(tb.power([1, 2, 3], [1, 2, 3])) == [1, 4, 27]
+    assert tb.tolist(tb.divide([4, 9, 16], [2, 3, 4])) == [2, 3, 4]
+    assert tb.tolist(
+        tb.outer([1, 2, 3], [4, 5, 6])) == [[4, 5, 6], [8, 10, 12], [12, 15, 18]]
+    assert tb.tolist(tb.sqrt([4, 9, 16])) == [2, 3, 4]
+    assert tb.tolist(tb.stack(
+        [tb.astensor([1, 2, 3]), tb.astensor([4, 5, 6])])) == [[1, 2, 3], [4, 5, 6]]
+    assert tb.tolist(tb.concatenate(
+        [tb.astensor([1, 2, 3]), tb.astensor([4, 5, 6])])) == [1, 2, 3, 4, 5, 6]
+    assert tb.tolist(tb.log(tb.exp([2, 3, 4]))) == [2, 3, 4]
+    assert tb.tolist(tb.where(
+        tb.astensor([1, 0, 1]),
+        tb.astensor([1, 1, 1]),
+        tb.astensor([2, 2, 2]))) == [1, 2, 1]
+    assert tb.tolist(
+        tb.clip(tb.astensor([-2, -1, 0, 1, 2]), -1, 1)) == [-1, -1,  0,  1,  1]
+    assert tb.tolist(
+        tb.normal_cdf(tb.astensor([0.8]))) == pytest.approx([0.7881446014166034], 1e-07)
 
-        assert list(map(tb.tolist, tb.simple_broadcast(
-            tb.astensor([1, 1, 1]),
-            tb.astensor([2]),
-            tb.astensor([3, 3, 3])))) == [[1, 1, 1], [2, 2, 2], [3, 3, 3]]
-        assert list(map(tb.tolist, tb.simple_broadcast(1, [2, 3, 4], [5, 6, 7]))) \
-            == [[1, 1, 1], [2, 3, 4], [5, 6, 7]]
-        assert list(map(tb.tolist, tb.simple_broadcast([1], [2, 3, 4], [5, 6, 7]))) \
-            == [[1, 1, 1], [2, 3, 4], [5, 6, 7]]
-        assert tb.tolist(tb.ones((4,5)))  == [[1.]*5]*4
-        assert tb.tolist(tb.zeros((4,5))) == [[0.]*5]*4
-        assert tb.tolist(tb.abs([-1,-2])) == [1,2]
-        with pytest.raises(Exception):
-            tb.simple_broadcast([1], [2, 3], [5, 6, 7])
+    assert list(map(tb.tolist, tb.simple_broadcast(
+        tb.astensor([1, 1, 1]),
+        tb.astensor([2]),
+        tb.astensor([3, 3, 3])))) == [[1, 1, 1], [2, 2, 2], [3, 3, 3]]
+    assert list(map(tb.tolist, tb.simple_broadcast(1, [2, 3, 4], [5, 6, 7]))) \
+        == [[1, 1, 1], [2, 3, 4], [5, 6, 7]]
+    assert list(map(tb.tolist, tb.simple_broadcast([1], [2, 3, 4], [5, 6, 7]))) \
+        == [[1, 1, 1], [2, 3, 4], [5, 6, 7]]
+    assert tb.tolist(tb.ones((4,5)))  == [[1.]*5]*4
+    assert tb.tolist(tb.zeros((4,5))) == [[0.]*5]*4
+    assert tb.tolist(tb.abs([-1,-2])) == [1,2]
+    with pytest.raises(Exception):
+        tb.simple_broadcast([1], [2, 3], [5, 6, 7])
 
 
-def test_einsum():
-    tf_sess = tf.Session()
-    backends = [numpy_backend(poisson_from_normal=True),
-                pytorch_backend(),
-                tensorflow_backend(session=tf_sess),
-                mxnet_backend() #no einsum in mxnet
-                ]
+def test_einsum(backend):
+    tb = pyhf.tensorlib
+    x = np.arange(20).reshape(5,4).tolist()
 
-
-
-    for b in backends[:-1]:
-        pyhf.set_backend(b)
-
-        x = np.arange(20).reshape(5,4).tolist()
-        assert np.all(b.tolist(b.einsum('ij->ji',x)) == np.asarray(x).T.tolist())
-        assert b.tolist(b.einsum('i,j->ij',b.astensor([1,1,1]),b.astensor([1,2,3]))) == [[1,2,3]]*3
-
-    for b in backends[-1:]:
-        pyhf.set_backend(b)
-        x = np.arange(20).reshape(5,4).tolist()
+    if isinstance(pyhf.tensorlib, pyhf.tensor.mxnet_backend):
         with pytest.raises(NotImplementedError):
-            assert b.einsum('ij->ji',[1,2,3])
+            assert tb.einsum('ij->ji',[1,2,3])
+    else:
+        assert np.all(tb.tolist(tb.einsum('ij->ji',x)) == np.asarray(x).T.tolist())
+        assert tb.tolist(tb.einsum('i,j->ij',tb.astensor([1,1,1]),tb.astensor([1,2,3]))) == [[1,2,3]]*3
 
 def test_pdf_eval():
     tf_sess = tf.Session()


### PR DESCRIPTION
# Description

This PR tries to make testing a lot easier for us moving forward as we start having complexity problems with testing combinations of backends+optimizers and so on and lots of duplicated code. In particular, the fixture is called `backend` so adding a `backend` parameter to any test function you have will automatically wrap that function in setting up the backend correctly, and breaking it down after the test runs. This can be useful with certain backends like tensorflow that need a new session or its internal graph cleared.

Additionally, some extra decorations (`pytest.mark`s) are specified to make this even easier to fine-tune which backends run. Right now, we add 5: `numpy`, `tensorflow`, `pytorch`, `mxnet`, `numpy_minuit`. The last one is numpy with the minuit optimizer.

One can specify, for example, to only run `numpy` and `numpy_minuit`

```python
@pytest.mark.only_numpy
@pytest.mark.only_numpy_minuit
```

or

```python
@pytest.mark.skip_tensorflow
@pytest.mark.skip_pytorch
@pytest.mark.skip_mxnet
```

will be equivalent. The latter will not skip any new backends that get added after this PR, but the former will still only consider those two.

Similarly, if you expect a particular backend to fail for any reason, you can mark that specific backend as failing via

```python
@pytest.mark.fail_tensorflow
```

for example.

# Checklist Before Requesting Approver

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
