### PR TITLE
Use scipy.special.xlogy in poisson computation for numpy backend

### DIFF
--- a/pyhf/tensor/numpy_backend.py
+++ b/pyhf/tensor/numpy_backend.py
@@ -1,6 +1,6 @@
 import numpy as np
 import logging
-from scipy.special import gammaln
+from scipy.special import gammaln, xlogy
 from scipy.stats import norm
 log = logging.getLogger(__name__)
 
@@ -160,7 +160,7 @@ class numpy_backend(object):
         n = np.asarray(n)
         if self.pois_from_norm:
             return self.normal(n,lam, self.sqrt(lam))
-        return np.exp(n*np.log(lam)-lam-gammaln(n+1.))
+        return np.exp(xlogy(n, lam) - lam - gammaln(n + 1.))
 
     def normal(self, x, mu, sigma):
         return norm.pdf(x, loc=mu, scale=sigma)


### PR DESCRIPTION
This is a micro-optimization on the computation of the poisson in the numpy backend.

# Description

When the observed events are equal to zero the log is not computed in the expression

    np.exp(n*np.log(lam)-lam-gammaln(n+1.))

using [`scipy.special.xlogy(n, lambda)`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.special.xlogy.html), which return `0` if `n==0` (also when `lambda==0`) without computing the log.
In principle further optimization is possible, returning just `np.exp(-lam)` when `n == 0` but probably this require some python control flow you want to avoid (and `np.where` is not lazy).

Quick performance test:

    def f2(l, n):   # present one
        return np.exp(n*np.log(l)-l-gammaln(n+1.))

    def f3(l, n):   # new branch
        return np.exp(xlogy(n, l)-l-gammaln(n+1.))

There is a 40% speed improvement when the observed data are 0

    L = np.random.randint(1, 100, size=1000000)
    N = np.zeros(1000000)

    %timeit f2(L, N)  # present
    10 loops, best of 3: 63.4 ms per loop

    %timeit f3(L, N)  # new branch
    10 loops, best of 3: 40.4 ms per loop

when N>1 there is no difference:

    L = np.random.randint(1, 100, size=1000000)
    N = np.random.randint(1, 100, size=1000000)

    --> 105 (f2) / 109 ms (f3)


as a bonus five warnings in the test are removed.

# Checklist Before Requesting Approver

- [x] Tests are passing

When running on master I have 

    ============== 8 failed, 98 passed, 70 warnings in 444.06 seconds ==============

on this branch

    ============== 8 failed, 98 passed, 65 warnings in 474.10 seconds ==============


Five RuntimeWarning are removed in this branch (all the same)
```
/home/turra/pyhf/pyhf/tensor/numpy_backend.py:163: RuntimeWarning: divide by zero encountered in log
return np.exp(n*np.log(lam)-lam-gammaln(n+1.))
```

- [x] "WIP" removed from the title of the pull request
