### PR TITLE
Require uproot to be version 3.0.0 or newer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
        'coverage>=4.0',  # coveralls
        'matplotlib',
        'jupyter',
-       'uproot',
+       'uproot>=3.0.0',
        'papermill',
        'graphviz',
        'sphinx',


### PR DESCRIPTION
[`uproot` `v3.0.0` introduced a change in the public API for accessing fSumw2](https://github.com/scikit-hep/uproot/issues/130). This is needed to make sure that the code in `pyhf/readxml.py` works with `uproot` that were added in PR #276.

# Checklist Before Requesting Approver

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
