### PR TITLE
Add PR summary responsibility to checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,14 @@ Please first read [CONTRIBUTING.md](https://github.com/diana-hep/pyhf/tree/maste
 
 Please describe the purpose of this pull request in some detail. Reference and link to any relevant issues or pull requests.
 
-# Checklist Before Requesting Approver
+# Checklist Before Requesting Reviewer
 
 - [ ] Tests are passing
 - [ ] "WIP" removed from the title of the pull request
+- [ ] Selected an Assignee for the PR to be responsible for the log summary
+
+# Before Merging
+
+For the PR Assignees:
+
+- [ ] Summarize commit messages into a comprehensive review of the PR

--- a/.github/PULL_REQUEST_TEMPLATE/Bug-Fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/Bug-Fix.md
@@ -4,7 +4,14 @@ Please first read [CONTRIBUTING.md](https://github.com/diana-hep/pyhf/tree/maste
 
 Please describe the purpose of this pull request in some detail and what bug it fixes. Reference and link to any relevant issues or pull requests (such as the issue in which this bug was first discussed).
 
-# Checklist Before Requesting Approver
+# Checklist Before Requesting Reviewer
 
 - [ ] Tests are passing
 - [ ] "WIP" removed from the title of the pull request
+- [ ] Selected an Assignee for the PR to be responsible for the log summary
+
+# Before Merging
+
+For the PR Assignees:
+
+- [ ] Summarize commit messages into a comprehensive review of the PR

--- a/.github/PULL_REQUEST_TEMPLATE/Feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/Feature.md
@@ -4,7 +4,14 @@ Please first read [CONTRIBUTING.md](https://github.com/diana-hep/pyhf/tree/maste
 
 Please describe the purpose of this pull request in some detail and what the specific feature being added will do. Reference and link to any relevant issues or pull requests (such as the issue in which this feature was first suggested).
 
-# Checklist Before Requesting Approver
+# Checklist Before Requesting Reviewer
 
 - [ ] Tests are passing
 - [ ] "WIP" removed from the title of the pull request
+- [ ] Selected an Assignee for the PR to be responsible for the log summary
+
+# Before Merging
+
+For the PR Assignees:
+
+- [ ] Summarize commit messages into a comprehensive review of the PR


### PR DESCRIPTION
Some of our PR commit logs aren't very helpful when trying to figure out what happened and essentially require looking at the PR on GitHub. It is useful to have a comprehensive but readably short commit log for the PR when working from the command line. This just adds an item to the checklist to encourage this.

Perhaps summarizing the PR can be the responsibility of whoever is the Assignee on GitHub?

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request