### PR TITLE
[WIP] Updates interpolators to allow for precomputation

### DIFF
--- a/pyhf/tensor/backend.py
+++ b/pyhf/tensor/backend.py
@@ -1,0 +1,8 @@
+class Backend(object):
+    """General backend class for all of our backends"""
+
+    def __eq__(self, other):
+        if isinstance(other, Backend):
+            return self.__class__ == other.__class__
+        return False
+

--- a/pyhf/tensor/mxnet_backend.py
+++ b/pyhf/tensor/mxnet_backend.py
@@ -6,8 +6,9 @@ from numbers import Number  # Required for normal()
 from scipy.stats import norm  # Required for normal_cdf()
 log = logging.getLogger(__name__)
 
+from .backend import Backend
 
-class mxnet_backend(object):
+class mxnet_backend(Backend):
     """MXNet backend for pyhf"""
 
     def __init__(self, **kwargs):

--- a/pyhf/tensor/numpy_backend.py
+++ b/pyhf/tensor/numpy_backend.py
@@ -4,8 +4,9 @@ from scipy.special import gammaln
 from scipy.stats import norm
 log = logging.getLogger(__name__)
 
+from .backend import Backend
 
-class numpy_backend(object):
+class numpy_backend(Backend):
     """NumPy backend for pyhf"""
 
     def __init__(self, **kwargs):

--- a/pyhf/tensor/pytorch_backend.py
+++ b/pyhf/tensor/pytorch_backend.py
@@ -3,8 +3,9 @@ import torch.autograd
 import logging
 log = logging.getLogger(__name__)
 
+from .backend import Backend
 
-class pytorch_backend(object):
+class pytorch_backend(Backend):
     """PyTorch backend for pyhf"""
 
     def __init__(self, **kwargs):

--- a/pyhf/tensor/tensorflow_backend.py
+++ b/pyhf/tensor/tensorflow_backend.py
@@ -4,8 +4,9 @@ import tensorflow as tf
 
 log = logging.getLogger(__name__)
 
+from .backend import Backend
 
-class tensorflow_backend(object):
+class tensorflow_backend(Backend):
     """TensorFlow backend for pyhf"""
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
# Description

This PR is to help get ready for #285 by making it more manageable. Change interpolation functions to interpolation classes at a first step. Define an `Interpolator` class which all interpolator codes will inherit from. At the moment, this parent class will just set up the `__init__()` call for us as a way to duck-type things. It will also call the internal `_precompute()` code that is defined for each interpolator that will precompute various bits and pieces for us.

At the end, this might be split up into `pyhf/interpolate/__init__.py` to break it up more to get ready for more interpolator codes in the future.

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [ ] "WIP" removed from the title of the pull request
- [ ] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [ ] Summarize commit messages into a comprehensive review of the PR
