### PR TITLE
Add boolean_mask back to backend

### DIFF
--- a/pyhf/tensor/mxnet_backend.py
+++ b/pyhf/tensor/mxnet_backend.py
@@ -81,6 +81,10 @@ class mxnet_backend(object):
     def gather(self,tensor,indices):
         return tensor[indices]
 
+    def boolean_mask(self, tensor, mask):
+        raise NotImplementedError("mxnet::boolean_mask is not implemented.")
+        return
+
     def astensor(self, tensor_in, dtype = 'float'):
         """
         Convert to a MXNet NDArray.

--- a/pyhf/tensor/numpy_backend.py
+++ b/pyhf/tensor/numpy_backend.py
@@ -44,6 +44,9 @@ class numpy_backend(object):
     def gather(self,tensor,indices):
         return tensor[indices]
 
+    def boolean_mask(self, tensor, mask):
+        return tensor[mask]
+
     def isfinite(self, tensor):
         return np.isfinite(tensor)
 

--- a/pyhf/tensor/pytorch_backend.py
+++ b/pyhf/tensor/pytorch_backend.py
@@ -65,6 +65,10 @@ class pytorch_backend(object):
     def gather(self,tensor,indices):
         return torch.take(tensor,indices.type(torch.LongTensor))
 
+    def boolean_mask(self, tensor, mask):
+        mask = self.astensor(mask).type(torch.ByteTensor)
+        return torch.masked_select(tensor,mask)
+
     def reshape(self, tensor, newshape):
         return torch.reshape(tensor,newshape)
 

--- a/pyhf/tensor/tensorflow_backend.py
+++ b/pyhf/tensor/tensorflow_backend.py
@@ -57,6 +57,9 @@ class tensorflow_backend(object):
     def gather(self,tensor,indices):
         return tf.gather(tensor,indices)
 
+    def boolean_mask(self, tensor, mask):
+        return tf.boolean_mask(tensor,mask)
+
     def isfinite(self, tensor):
         return tf.is_finite(tensor)
 

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -83,6 +83,12 @@ def test_pdf_calculations(backend):
     assert tb.tolist(
         tb.poisson_logpdf(tb.astensor([0, 0, 1, 1]), tb.astensor([0, 1, 0, 1]))) == pytest.approx(np.log([np.nan, 0.3678794503211975, 0.0, 0.3678794503211975]).tolist(), nan_ok=True)
 
+@pytest.mark.skip_mxnet
+def test_boolean_mask(backend):
+    tb = pyhf.tensorlib
+    assert tb.tolist(tb.boolean_mask(tb.astensor([1,2,3,4,5,6]), tb.astensor([True, True, False, True, False, False], dtype='bool'))) == [1, 2, 4]
+    assert tb.tolist(tb.boolean_mask(tb.astensor([[1,2],[3,4],[5,6]]), tb.astensor([[True, True], [False, True], [False, False]], dtype='bool'))) == [1, 2, 4]
+
 def test_1D_gather(backend):
     tb = pyhf.tensorlib
     assert tb.tolist(tb.gather(tb.astensor([1,2,3,4,5,6]), tb.astensor([4,0,3,2], dtype='int'))) == [5, 1, 4, 3]


### PR DESCRIPTION
# Description

I missed this in #287 because I couldn't find a solution for mxnet. This adds boolean_mask and tests to all the backends (except mxnet). This is for #285.

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

> Add boolean_mask back into all the backends (except mxnet) and adds tests.
