### PR TITLE
Have Selenium properly wait for page load

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,7 @@ jobs:
     - cd docs && make html && cd -
     - touch docs/_build/html/.nojekyll
     # Open Binder example in browser to trigger repo2docker to build image
+    - python binder/trigger_binder.py --url https://mybinder.org/v2/gh/diana-hep/pyhf/master
     - python binder/trigger_binder.py --url https://mybinder.org/v2/gh/diana-hep/pyhf/master?filepath=docs%2Fexamples%2Fnotebooks%2Fbinderexample%2FStatisticalAnalysis.ipynb
     deploy:
       provider: pages

--- a/binder/trigger_binder.py
+++ b/binder/trigger_binder.py
@@ -19,15 +19,14 @@ class SeleniumSession():
         else:
             self.browser = webdriver.Chrome(chrome_options=self.options)
 
-    # Taken from http://www.obeythetestinggoat.com/how-to-get-selenium-to-wait-for-page-load-after-a-click.html
     @contextmanager
-    def wait_for_page_load(self, timeout=30):
+    def wait_for_page_load(self, timeout=20):
         old_page = self.browser.find_element_by_tag_name('html')
         yield
         WebDriverWait(self.browser, timeout).until(staleness_of(old_page))
 
     def trigger_binder(self, url):
-        with self.wait_for_page_load(timeout=10):
+        with self.wait_for_page_load():
             self.browser.get(url)
 
 

--- a/binder/trigger_binder.py
+++ b/binder/trigger_binder.py
@@ -1,24 +1,41 @@
 #!/usr/bin/env python
 
 import argparse
-import time
+from contextlib import contextmanager
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support.expected_conditions import staleness_of
+
+
+class SeleniumSession():
+    def __init__(self, args):
+        self.options = Options()
+        self.options.set_headless()
+        self.options.add_argument('--no-sandbox')
+        if args.chromedriver_path is not None:
+            self.browser = webdriver.Chrome(
+                args.chromedriver_path, chrome_options=self.options)
+        else:
+            self.browser = webdriver.Chrome(chrome_options=self.options)
+
+    # Taken from http://www.obeythetestinggoat.com/how-to-get-selenium-to-wait-for-page-load-after-a-click.html
+    @contextmanager
+    def wait_for_page_load(self, timeout=30):
+        old_page = self.browser.find_element_by_tag_name('html')
+        yield
+        WebDriverWait(self.browser, timeout).until(staleness_of(old_page))
+
+    def trigger_binder(self, url):
+        with self.wait_for_page_load(timeout=10):
+            self.browser.get(url)
 
 
 def main(args):
-    options = Options()
-    options.set_headless()
-    options.add_argument('--no-sandbox')
-    if args.chromedriver_path is not None:
-        driver = webdriver.Chrome(args.chromedriver_path, chrome_options=options)
-    else:
-        driver = webdriver.Chrome(chrome_options=options)
+    driver = SeleniumSession(args)
     if args.is_verbose:
         print('Chrome Headless Browser Invoked')
-    driver.get(args.url)
-    time.sleep(10)
-    driver.close()
+    driver.trigger_binder(args.url)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Description

Have Selenium properly wait for the Binder page to load to trigger the Binder build. Just using `time.sleep` is not necessarily sufficient.

Also trigger Binder builds for the entire repo as well as the example notebook.

Following the example at [How to get Selenium to wait for page load after a click](http://www.obeythetestinggoat.com/how-to-get-selenium-to-wait-for-page-load-after-a-click.html)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
