### PR TITLE
Pin tensorflow-probability to release v0.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 extras_require = {
     'tensorflow': [
         'tensorflow>=1.10.0',
-        'tensorflow-probability>=0.3.0',
+        'tensorflow-probability==0.3.0',
         'numpy<=1.14.5,>=1.14.0',  # Lower of 1.14.0 instead of 1.13.3 to ensure doctest pass
         'setuptools<=39.1.0',
     ],


### PR DESCRIPTION
# Description

This PR is a temporary patch in response to Issue #302.

Until a resolution to the issue of tensorflow-probability's change of the Poisson `log_prob` in release v0.4.0 to no longer support a continuous approximation to the Poisson p.m.f. can be reached with the help of the `tfp` dev team then `tfp` should be frozen at v0.3.0 to allow for continued
development. This API change in `tfp` is breaking and so it can't be easily fixed without fundamental changes in either `pyhf` or `tfp`.

Hopefully a resolution comes out of `tfp` Issue https://github.com/tensorflow/probability/issues/182

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [ ] Summarize commit messages into a comprehensive review of the PR
