### PR TITLE
Add version info through __version__

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,5 +3,4 @@ current_version = 0.0.15
 commit = True
 tag = True
 
-[bumpversion:file:setup.py]
 [bumpversion:file:pyhf/version.py]

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -4,4 +4,4 @@ commit = True
 tag = True
 
 [bumpversion:file:setup.py]
-
+[bumpversion:file:pyhf/version.py]

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,4 +3,5 @@ current_version = 0.0.15
 commit = True
 tag = True
 
+[bumpversion:file:setup.py]
 [bumpversion:file:pyhf/version.py]

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -18,7 +18,7 @@ Describe what did happen
 
 # Steps to Reproduce
 
-Detail your environment and the commands that you are executing to generate the bug. If you have a large program please make a [Gist](https://gist.github.com/) and link it here. Additionally attach any screen shots as needed.
+Detail your environment and `pyhf.__version__` and the commands that you are executing to generate the bug. If you have a large program please make a [Gist](https://gist.github.com/) and link it here. Additionally attach any screen shots as needed.
 
 # Checklist
 

--- a/pyhf/__init__.py
+++ b/pyhf/__init__.py
@@ -1,6 +1,5 @@
 from . import tensor, optimize
 from .version import __version__
-__all__ = ['__version__']  # Used to satisfy pyflakes
 tensorlib = tensor.numpy_backend()
 default_backend = tensorlib
 optimizer = optimize.scipy_optimizer()
@@ -59,4 +58,4 @@ def set_backend(backend, custom_optimizer=None):
 
 
 from .pdf import Model
-__all__ = ["Model", "utils", "modifiers"]
+__all__ = ['Model', 'utils', 'modifiers', '__version__']

--- a/pyhf/__init__.py
+++ b/pyhf/__init__.py
@@ -1,6 +1,6 @@
 from . import tensor, optimize
 from .version import __version__
-assert __version__  # Used to satisfy pyflakes
+__all__ = ['__version__']  # Used to satisfy pyflakes
 tensorlib = tensor.numpy_backend()
 default_backend = tensorlib
 optimizer = optimize.scipy_optimizer()

--- a/pyhf/__init__.py
+++ b/pyhf/__init__.py
@@ -1,4 +1,5 @@
 from . import tensor, optimize
+from .version import __version__
 tensorlib = tensor.numpy_backend()
 default_backend = tensorlib
 optimizer = optimize.scipy_optimizer()

--- a/pyhf/__init__.py
+++ b/pyhf/__init__.py
@@ -1,5 +1,6 @@
 from . import tensor, optimize
 from .version import __version__
+assert __version__  # Used to satisfy pyflakes
 tensorlib = tensor.numpy_backend()
 default_backend = tensorlib
 optimizer = optimize.scipy_optimizer()

--- a/pyhf/version.py
+++ b/pyhf/version.py
@@ -1,0 +1,18 @@
+"""Define pyhf version information."""
+
+# Use semantic versioning (https://semver.org/)
+_MAJOR_VERSION = '0'
+_MINOR_VERSION = '0'
+_PATCH_VERSION = '16'
+
+# When making a PyPI release change to _VERSION_SUFFIX = '' to reflect a
+# stable release. Otherwise, versions are in developenment phase.
+_VERSION_SUFFIX = 'dev'
+
+# Prevent trailing dot when version suffix is empty
+__version__ = '.'.join(s for s in [
+    _MAJOR_VERSION,
+    _MINOR_VERSION,
+    _PATCH_VERSION,
+    _VERSION_SUFFIX,
+] if s)

--- a/pyhf/version.py
+++ b/pyhf/version.py
@@ -1,18 +1,5 @@
 """Define pyhf version information."""
 
 # Use semantic versioning (https://semver.org/)
-_MAJOR_VERSION = '0'
-_MINOR_VERSION = '0'
-_PATCH_VERSION = '16'
-
-# When making a PyPI release change to _VERSION_SUFFIX = '' to reflect a
-# stable release. Otherwise, versions are in developenment phase.
-_VERSION_SUFFIX = 'dev'
-
-# Prevent trailing dot when version suffix is empty
-__version__ = '.'.join(s for s in [
-    _MAJOR_VERSION,
-    _MINOR_VERSION,
-    _PATCH_VERSION,
-    _VERSION_SUFFIX,
-] if s)
+# The version number is controlled through bumpversion.cfg
+__version__ = '0.0.15'

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,14 @@
 #!/usr/bin/env python
 
+import os
+import sys
 from setuptools import setup, find_packages
-from pyhf.version import __version__
+
+# Import directly from version.py by adding to sys.path
+# Otherwise setup won't know what the module as pyhf isn't installed yet
+version_path = os.path.join(os.path.dirname(__file__), 'pyhf')
+sys.path.append(version_path)
+from version import __version__
 
 extras_require = {
     'tensorflow': [

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python
 
+import os
+import sys
 from setuptools import setup, find_packages
+
+# Import directly from version.py by adding to sys.path
+version_path = os.path.join(os.path.dirname(__file__), 'pyhf')
+sys.path.append(version_path)
+from version import __version__
 
 extras_require = {
     'tensorflow': [
@@ -55,7 +62,7 @@ extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 
 setup(
     name='pyhf',
-    version='0.0.15',
+    version=__version__,
     description='(partial) pure python histfactory implementation',
     url='https://github.com/diana-hep/pyhf',
     author='Lukas Heinrich',

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,7 @@
 #!/usr/bin/env python
 
-import os
-import sys
 from setuptools import setup, find_packages
-
-# Import directly from version.py by adding to sys.path
-version_path = os.path.join(os.path.dirname(__file__), 'pyhf')
-sys.path.append(version_path)
-from version import __version__
+from pyhf.version import __version__
 
 extras_require = {
     'tensorflow': [

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,6 @@
 #!/usr/bin/env python
 
-import os
-import sys
 from setuptools import setup, find_packages
-
-# Import directly from version.py by adding to sys.path
-# Otherwise setup won't know what the module as pyhf isn't installed yet
-version_path = os.path.join(os.path.dirname(__file__), 'pyhf')
-sys.path.append(version_path)
-from version import __version__
 
 extras_require = {
     'tensorflow': [
@@ -63,7 +55,7 @@ extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 
 setup(
     name='pyhf',
-    version=__version__,
+    version='0.0.15',
     description='(partial) pure python histfactory implementation',
     url='https://github.com/diana-hep/pyhf',
     author='Lukas Heinrich',


### PR DESCRIPTION
# Description

Add version information to the code in the form of `__version__` so that 

```
pyhf.__version__
```

returns information. So for example

**Edit below:** `0.0.16.dev` to `0.0.15`
```
>>> import pyhf
>>> pyhf.__version__
'0.0.15'
```
~~(implicit here is that as `0.0.15` is the current PyPI release that what is currently in `master` is the next release's development version. There is probably a more industry standard or sane way to do this then what I just proposed here.)~~

~~The [`version.py` file added here is copied from TensorFlow Probability](https://github.com/tensorflow/probability/blob/f8bd785031340f2231ed0e0f01c378c03ac3ce52/tensorflow_probability/python/version.py).~~

[`bumpversion`](https://github.com/peritus/bumpversion) controls the actual version number in all of the code to simplify the process.

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [ ] Summarize commit messages into a comprehensive review of the PR
