### PR TITLE
Add a way to subscribe/trigger events globally

### DIFF
--- a/pyhf/events.py
+++ b/pyhf/events.py
@@ -1,6 +1,3 @@
-import logging
-log = logging.getLogger(__name__)
-
 __events = {}
 __disabled_events = set([])
 class Events(list):

--- a/pyhf/events.py
+++ b/pyhf/events.py
@@ -1,12 +1,12 @@
 __events = {}
 __disabled_events = set([])
-class Events(list):
+class Callables(list):
     def __call__(self, *args, **kwargs):
         for f in self:
             f(*args, **kwargs)
 
     def __repr__(self):
-        return "Events(%s)" % list.__repr__(self)
+        return "Callables(%s)" % list.__repr__(self)
 
 """
 
@@ -22,7 +22,7 @@ class Events(list):
 def subscribe(event):
     global __events
     def __decorator(func):
-        __events.setdefault(event, Events()).append(func)
+        __events.setdefault(event, Callables()).append(func)
         return func
     return __decorator
 

--- a/pyhf/events.py
+++ b/pyhf/events.py
@@ -1,0 +1,55 @@
+import sys
+
+# this is meant to wrap the Wrapper object
+class Wrapper(object):
+    __events = {}
+    class Events(list):
+        def __call__(self, *args, **kwargs):
+            for f in self:
+                f(*args, **kwargs)
+
+        def __repr__(self):
+            return "Events(%s)" % list.__repr__(self)
+
+    def __init__(self, name, filepath):
+        import logging
+        self.log = logging.getLogger(name)
+        self.__name__ = name
+        self.__file__ = filepath
+
+    """
+    If we reach this, we already know the attribute is missing...
+    """
+    def __getattr__(self, name):
+        def noop(*args, **kwargs): pass
+        if name.startswith('trigger_'):
+            self.log.error('Triggering "{0:s}" but nobody is listening!'.format(name.split('_')[-1]))
+            return noop
+        raise AttributeError
+
+    """
+
+        This is meant to be used as a decorator.
+
+        >>> @pyhf.events.subscribe('myevent')
+        ... def test(a,b):
+        ...   print a+b
+        ...
+        >>> pyhf.events.trigger_myevent(1,2)
+        3
+    """
+    def subscribe(self, event):
+        def __decorator(func):
+            self.__events.setdefault(event, self.Events()).append(func)
+            setattr(self, 'trigger_{0:s}'.format(event), self.__events.get(event))
+            return func
+        return __decorator
+
+    def unsubscribe(self, event):
+        if event in self.__events:
+            events = self.__events.pop(event)
+            del events[:]
+            delattr(self, 'trigger_{0:s}'.format(event))
+        return
+
+sys.modules[__name__] = Wrapper(__name__, __file__)

--- a/pyhf/events.py
+++ b/pyhf/events.py
@@ -1,56 +1,54 @@
-import sys
+import logging
+log = logging.getLogger(__name__)
 
-# this is meant to wrap the Wrapper object
-class Wrapper(object):
-    __events = {}
-    class Events(list):
-        def __call__(self, *args, **kwargs):
-            for f in self:
-                f(*args, **kwargs)
+__events = {}
+__disabled_events = set([])
+class Events(list):
+    def __call__(self, *args, **kwargs):
+        for f in self:
+            f(*args, **kwargs)
 
-        def __repr__(self):
-            return "Events(%s)" % list.__repr__(self)
+    def __repr__(self):
+        return "Events(%s)" % list.__repr__(self)
 
-    def __init__(self, name, filepath):
-        import logging
-        self.log = logging.getLogger(name)
-        self.__name__ = name
-        self.__file__ = filepath
-        self.prefix = 'trigger_'
+"""
 
-    """
-    If we reach this, we already know the attribute is missing...
-    """
-    def __getattr__(self, name):
-        def noop(*args, **kwargs): pass
-        if name.startswith(self.prefix):
-          self.log.error('Triggering "{0:s}" but nobody is listening!'.format(name[len(self.prefix):]))
-          return noop
-        raise AttributeError
+    This is meant to be used as a decorator.
 
-    """
+    >>> @pyhf.events.subscribe('myevent')
+    ... def test(a,b):
+    ...   print a+b
+    ...
+    >>> pyhf.events.trigger_myevent(1,2)
+    3
+"""
+def subscribe(event):
+    global __events
+    def __decorator(func):
+        __events.setdefault(event, Events()).append(func)
+        return func
+    return __decorator
 
-        This is meant to be used as a decorator.
+"""
+Trigger an event if not disabled.
+"""
+def trigger(event):
+    global __events, __disabled_events
+    def noop(*args, **kwargs): pass
+    def _trigger(*args, **kwargs):
+        return __events.get(event, noop)(*args, **kwargs)
+    return noop if event in __disabled_events else _trigger
 
-        >>> @pyhf.events.subscribe('myevent')
-        ... def test(a,b):
-        ...   print a+b
-        ...
-        >>> pyhf.events.trigger_myevent(1,2)
-        3
-    """
-    def subscribe(self, event):
-        def __decorator(func):
-            self.__events.setdefault(event, self.Events()).append(func)
-            setattr(self, '{0:s}{1:s}'.format(self.prefix, event), self.__events.get(event))
-            return func
-        return __decorator
+"""
+Disable an event from firing.
+"""
+def disable(event):
+    global __disabled_events
+    __disabled_events.add(event)
 
-    def unsubscribe(self, event):
-        if event in self.__events:
-            events = self.__events.pop(event)
-            del events[:]
-            delattr(self, '{0:s}{1:s}'.format(self.prefix, event))
-        return
-
-sys.modules[__name__] = Wrapper(__name__, __file__)
+"""
+Enable an event to be fired if disabled.
+"""
+def enable(event):
+    global __disabled_events
+    __disabled_events.remove(event)

--- a/pyhf/events.py
+++ b/pyhf/events.py
@@ -25,7 +25,7 @@ class Wrapper(object):
         def noop(*args, **kwargs): pass
         if name.startswith(self.prefix):
           self.log.error('Triggering "{0:s}" but nobody is listening!'.format(name[len(self.prefix):]))
-            return noop
+          return noop
         raise AttributeError
 
     """

--- a/pyhf/events.py
+++ b/pyhf/events.py
@@ -1,5 +1,8 @@
 __events = {}
 __disabled_events = set([])
+
+def noop(*args, **kwargs): pass
+
 class Callables(list):
     def __call__(self, *args, **kwargs):
         for f in self:
@@ -30,11 +33,9 @@ def subscribe(event):
 Trigger an event if not disabled.
 """
 def trigger(event):
-    global __events, __disabled_events
-    def noop(*args, **kwargs): pass
-    def _trigger(*args, **kwargs):
-        return __events.get(event, noop)(*args, **kwargs)
-    return noop if event in __disabled_events else _trigger
+    global __events, __disabled_events, noop
+    is_noop = bool(event in __disabled_events or event not in __events)
+    return noop if is_noop else __events.get(event)
 
 """
 Disable an event from firing.

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,44 @@
+import pytest
+import pyhf.events as events
+import mock
+
+def test_subscribe_event():
+    ename = 'test'
+
+    m = mock.Mock()
+    events.subscribe(ename)(m)
+
+    assert ename in events.__events
+    assert m in events.__events.get(ename)
+    del events.__events[ename]
+
+def test_event():
+    ename = 'test'
+
+    m = mock.Mock()
+    events.subscribe(ename)(m)
+
+    events.trigger(ename)()
+    m.assert_called_once()
+    del events.__events[ename]
+
+def test_disable_event():
+    ename = 'test'
+
+    m = mock.Mock()
+    events.subscribe(ename)(m)
+
+    events.disable(ename)
+    assert m.called == False
+    assert ename in events.__disabled_events
+    assert events.trigger(ename) == events.noop
+    assert events.trigger(ename)() == events.noop()
+    assert m.called == False
+    events.enable(ename)
+    assert ename not in events.__disabled_events
+    del events.__events[ename]
+
+def test_trigger_noevent():
+    assert 'fake' not in events.__events
+    assert events.trigger('fake') == events.noop
+    assert events.trigger('fake')() == events.noop()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -26,6 +26,8 @@ def test_disable_event():
     ename = 'test'
 
     m = mock.Mock()
+    noop, noop_m = events.noop, mock.Mock()
+    events.noop = noop_m
     events.subscribe(ename)(m)
 
     events.disable(ename)
@@ -34,11 +36,18 @@ def test_disable_event():
     assert events.trigger(ename) == events.noop
     assert events.trigger(ename)() == events.noop()
     assert m.called == False
+    assert noop_m.is_called_once()
     events.enable(ename)
     assert ename not in events.__disabled_events
     del events.__events[ename]
+    events.noop = noop
 
 def test_trigger_noevent():
+    noop, noop_m = events.noop, mock.Mock()
+
     assert 'fake' not in events.__events
     assert events.trigger('fake') == events.noop
     assert events.trigger('fake')() == events.noop()
+    assert noop_m.is_called_once()
+
+    events.noop = noop


### PR DESCRIPTION
# Description

This is to help with #285 which needs an easy way to trigger recomputation in the case where the tensorlib changes. Since this needs to be somewhat globally-triggering with callbacks, it's easier to go for some sort of sub/pub model. I've implemented a bare-bones version that should handle all we need to do.

The idea is to do something like

```python
def normsys_combined(self):
    def __init__(self):
        pass

    @pyhf.events.subscribe('tensorlib_change')
    def _precompute(self):
        # if this is called, the backend was changed so do something
```

and then `pyhf/__init__.py#set_backend` can simply call `pyhf.events.trigger('tensorlib_change')()` to trigger the change. There's zero checks on the arguments passed through to function calls, but it is flexible and can allow for passing through arguments from the trigger to the callbacks as long as the callbacks can handle the arguments.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
