### PR TITLE
Remove notebooks untested in the CI from website examples

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -13,8 +13,11 @@ Notebooks:
 
    examples/notebooks/hello-world.ipynb
    examples/notebooks/binderexample/StatisticalAnalysis.ipynb
-   examples/notebooks/Recast.ipynb
    examples/notebooks/ShapeFactor.ipynb
+   examples/notebooks/multiBinPois.ipynb
+   examples/notebooks/multichannel-coupled-histo.ipynb
+..
+   examples/notebooks/Recast.ipynb
    examples/notebooks/StatError.ipynb
    examples/notebooks/example-mxnet.ipynb
    examples/notebooks/example-tensorflow.ipynb
@@ -22,8 +25,6 @@ Notebooks:
    examples/notebooks/histosys-pytorch.ipynb
    examples/notebooks/histosys.ipynb
    examples/notebooks/importxml.ipynb
-   examples/notebooks/multiBinPois.ipynb
-   examples/notebooks/multichannel-coupled-histo.ipynb
    examples/notebooks/multichannel-coupled-normsys.ipynb
    examples/notebooks/multichannel-normsys.ipynb
    examples/notebooks/normsys.ipynb


### PR DESCRIPTION
# Description

Given the discussion in Issue #325 the notebooks that are shown on the website as examples should all be in [the CI](https://github.com/diana-hep/pyhf/blob/7486cac7e82dc1a5c6a47cbb472cc1920c220444/tests/test_notebooks.py). Until PR #285 is done and there is time to go through and clean up and rewrite all of the notebooks it is easier to just comment them out for the time being so that we don't confuse new users.

**Note:** This PR does _not_ fix Issue #325. It will have to be resolved after PR #285 is done.

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

> All the notebooks that are shown on the website as examples should all be in the CI. Until the megachannel overhaul is complete and there is time to to go through and clean up and rewrite all of the notebooks it is easier to just comment them out for the time being so that we don't confuse new users.
