### PR TITLE
Improve installation instruction clarity

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -32,7 +32,7 @@ Making Probability Distribution Functions (PDFs)
 Backends
 --------
 
-The computational backends that `pyhf` provides interfacing for the vector-based calculations.
+The computational backends that :code:`pyhf` provides interfacing for the vector-based calculations.
 
 .. currentmodule:: pyhf.tensor
 
@@ -80,7 +80,7 @@ Modifiers
 Exceptions
 ----------
 
-Various exceptions, apart from standard python exceptions, that are raised from using the `pyhf` API.
+Various exceptions, apart from standard python exceptions, that are raised from using the :code:`pyhf` API.
 
 .. currentmodule:: pyhf.exceptions
 

--- a/docs/citations.rst
+++ b/docs/citations.rst
@@ -1,7 +1,7 @@
 Use and Citations
 =================
 
-Updating list of citations and use cases of `pyhf`:
+Updating list of citations and use cases of :code:`pyhf`:
 
 .. bibliography:: bib/use_citations.bib
    :list: bullet

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -21,82 +21,82 @@ and activating it
     source pyhf/bin/activate
 
 
-Install from `PyPI <https://pypi.org/project/pyhf/>`__
-------------------------------------------------------
+Install from `PyPI <https://pypi.org/project/pyhf/>`__...
+---------------------------------------------------------
 
-with NumPy backend
-++++++++++++++++++
+... with NumPy backend
+++++++++++++++++++++++
 
 .. code-block:: console
 
     pip install pyhf
 
-with TensorFlow backend
-+++++++++++++++++++++++
+... with TensorFlow backend
++++++++++++++++++++++++++++
 
 .. code-block:: console
 
     pip install pyhf[tensorflow]
 
-with PyTorch backend
-++++++++++++++++++++
+... with PyTorch backend
+++++++++++++++++++++++++
 
 .. code-block:: console
 
     pip install pyhf[torch]
 
-with MXNet backend
-++++++++++++++++++
+... with MXNet backend
+++++++++++++++++++++++
 
 .. code-block:: console
 
     pip install pyhf[mxnet]
 
-with all backends
-+++++++++++++++++
+... with all backends
++++++++++++++++++++++
 
 .. code-block:: console
 
     pip install pyhf[tensorflow,torch,mxnet]
 
-Install from `GitHub <https://github.com/diana-hep/pyhf>`__
------------------------------------------------------------
+Install from `GitHub <https://github.com/diana-hep/pyhf>`__...
+--------------------------------------------------------------
 
 .. code-block:: console
 
     git clone https://github.com/diana-hep/pyhf.git
     cd pyhf
 
-with NumPy backend
-++++++++++++++++++
+... with NumPy backend
+++++++++++++++++++++++
 
 .. code-block:: console
 
     pip install --ignore-installed -U .
 
-with TensorFlow backend
-+++++++++++++++++++++++
+... with TensorFlow backend
++++++++++++++++++++++++++++
 
 .. code-block:: console
 
     pip install --ignore-installed -U .[tensorflow]
 
-with PyTorch backend
-++++++++++++++++++++
+... with PyTorch backend
+++++++++++++++++++++++++
 
 .. code-block:: console
 
     pip install --ignore-installed -U .[torch]
 
-with MXNet backend
-++++++++++++++++++
+... with MXNet backend
+++++++++++++++++++++++
 
 .. code-block:: console
 
     pip install --ignore-installed -U .[mxnet]
 
-with all backends
-+++++++++++++++++
+... with all backends
++++++++++++++++++++++
 
 .. code-block:: console
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -101,3 +101,22 @@ Install from `GitHub <https://github.com/diana-hep/pyhf>`__...
 .. code-block:: console
 
     pip install --ignore-installed -U .[tensorflow,torch,mxnet]
+
+Updating :code:`pyhf`...
+------------------------
+
+... if installed from PyPI
+++++++++++++++++++++++++++
+
+Rerun the installation command. As the upgrade flag, :code:`-U`, is used then the libraries will be updated.
+
+... if installed from GitHub
+++++++++++++++++++++++++++++
+
+Pull the latest commits from GitHub
+
+.. code-block:: console
+
+    git pull
+
+and then rerun the installation command. As the upgrade flag, :code:`-U`, is used then the libraries will be updated.

--- a/docs/talks.rst
+++ b/docs/talks.rst
@@ -1,10 +1,9 @@
 Presentations
 =============
 
-This list will be updated with talks given on `pyhf`:
+This list will be updated with talks given on :code:`pyhf`:
 
 .. bibliography:: bib/talks.bib
    :list: bullet
    :all:
    :style: plain
-


### PR DESCRIPTION
# Description

Given some new user feedback it wasn't immediately clear if the installation instructions were listing options or steps. The use of `...` (hopefully?) make this more clear that they are installation options.

Instructions on how to update an installation of `pyhf` are also added.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

>- Use ellipses to convey that the installation subsections for different ways of installing pyhf are options and not successive steps that need to be executed.
>- Add instructions on how to update an installation of `pyhf`
