### PR TITLE
Insert the POI parameter correctly using POI index in opt_tflow

### DIFF
--- a/pyhf/optimize/opt_tflow.py
+++ b/pyhf/optimize/opt_tflow.py
@@ -41,7 +41,7 @@ class tflow_optimizer(object):
         poi_par   = self.tb.astensor([constrained_mu])
 
         nuis_cat = self.tb.concatenate(nuis_pars)
-        pars = self.tb.concatenate([nuis_cat[:0],poi_par,nuis_cat[0:]])
+        pars = self.tb.concatenate([nuis_cat[:pdf.config.poi_index],poi_par,nuis_cat[pdf.config.poi_index:]])
         objective = objective(pars,data,pdf)
         hessian   = tf.hessians(objective, nuis_cat)[0]
         gradient  = tf.gradients(objective, nuis_cat)[0]


### PR DESCRIPTION
# Description

`opt_tflow` doesn't insert the POI correctly. Assumed that it was the first one in the list of parameters, but might not always be the case. Need to respect the ordering.

Thanks to @dantrim for providing an example that found the bug.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
