### PR TITLE
fix up indexing of summed_mask in shapesys, staterror

### DIFF
--- a/pyhf/modifiers/shapesys.py
+++ b/pyhf/modifiers/shapesys.py
@@ -58,7 +58,7 @@ class shapesys_combined(object):
                 zero_mask = summed_mask == 0
                 # then apply the mask
                 summed_mask[positive_mask] = inds
-                summed_mask[zero_mask] = -1
+                summed_mask[zero_mask] = 0
                 # nb: old code above was
                 #     summed_mask[summed_mask > 0] = inds
                 #     summed_mask[summed_mask == 0] = -1

--- a/pyhf/modifiers/shapesys.py
+++ b/pyhf/modifiers/shapesys.py
@@ -59,10 +59,6 @@ class shapesys_combined(object):
                 # then apply the mask
                 summed_mask[positive_mask] = inds
                 summed_mask[zero_mask] = 0
-                # nb: old code above was
-                #     summed_mask[summed_mask > 0] = inds
-                #     summed_mask[summed_mask == 0] = -1
-                # This code broke when the `inds` included a '0' because it would replace that value with -1.
                 access_rows.append(summed_mask.tolist())
             self._factor_access_indices = default_backend.tolist(default_backend.stack(access_rows))
             self.finalize(pdfconfig)

--- a/pyhf/modifiers/staterror.py
+++ b/pyhf/modifiers/staterror.py
@@ -56,10 +56,6 @@ class staterror_combined(object):
                 # then apply the mask
                 summed_mask[positive_mask] = inds
                 summed_mask[zero_mask] = 0
-                # nb: old code above was
-                #     summed_mask[summed_mask > 0] = inds
-                #     summed_mask[summed_mask == 0] = -1
-                # This code broke when the `inds` included a '0' because it would replace that value with -1.
                 access_rows.append(summed_mask.tolist())
             self._factor_access_indices = default_backend.tolist(default_backend.stack(access_rows))
             self.finalize(pdfconfig)

--- a/pyhf/modifiers/staterror.py
+++ b/pyhf/modifiers/staterror.py
@@ -50,8 +50,16 @@ class staterror_combined(object):
             for mask,inds in zip(staterror_mask, self._staterror_indices):
                 summed_mask = default_backend.sum(mask[:,0,:],axis=0)
                 assert default_backend.shape(summed_mask[summed_mask >  0]) == default_backend.shape(default_backend.astensor(inds))
-                summed_mask[summed_mask >  0] = inds
-                summed_mask[summed_mask == 0] = -1
+                # make masks of > 0 and == 0
+                positive_mask = summed_mask > 0
+                zero_mask = summed_mask == 0
+                # then apply the mask
+                summed_mask[positive_mask] = inds
+                summed_mask[zero_mask] = 0
+                # nb: old code above was
+                #     summed_mask[summed_mask > 0] = inds
+                #     summed_mask[summed_mask == 0] = -1
+                # This code broke when the `inds` included a '0' because it would replace that value with -1.
                 access_rows.append(summed_mask.tolist())
             self._factor_access_indices = default_backend.tolist(default_backend.stack(access_rows))
             self.finalize(pdfconfig)


### PR DESCRIPTION
# Description

The main difficulty with shapesys/staterror as it affects multiple (non-consecutive) bins is the way we do masking. For situations where we need to figure out whether to enable the mask or not, it was filling in `-1` when the parameter index was `0` which is not good. Additionally, `tensorflow.gather()` is not happy with `-1`.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
