### PR TITLE
Use version dependent open to get README

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,12 +7,8 @@ import sys
 this_directory = path.abspath(path.dirname(__file__))
 if sys.version_info.major < 3:
     from io import open
-
-    with open(path.join(this_directory, 'README.md'), encoding='utf-8') as readme_md:
-        long_description = readme_md.read()
-else:
-    with open(path.join(this_directory, 'README.md'), encoding='utf-8') as readme_md:
-        long_description = readme_md.read()
+with open(path.join(this_directory, 'README.md'), encoding='utf-8') as readme_md:
+    long_description = readme_md.read()
 
 extras_require = {
     'tensorflow': [

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,17 @@
 
 from setuptools import setup, find_packages
 from os import path
+import sys
 
 this_directory = path.abspath(path.dirname(__file__))
-with open(path.join(this_directory, 'README.md'), encoding='utf-8') as readme_md:
-    long_description = readme_md.read()
+if sys.version_info.major < 3:
+    from io import open
+
+    with open(path.join(this_directory, 'README.md'), encoding='utf-8') as readme_md:
+        long_description = readme_md.read()
+else:
+    with open(path.join(this_directory, 'README.md'), encoding='utf-8') as readme_md:
+        long_description = readme_md.read()
 
 extras_require = {
     'tensorflow': [


### PR DESCRIPTION
# Description

Python3's `open` supports encoding, but Python2's `open` does not so it must use `io.open`

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
- Python3's open supports encoding, but Python2's open does not so it must use io.open
- Fixes a bug present in PR #338 and PR #339 that were not caught in the craziness of the great GitHub outage of 2018-10-21/22 and resulted in erroneous early merges
```
