### PR TITLE
Fix table in README to be rendered properly in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ Computational Backends:
 
 Available Optimizers
 
-| NumPy        |Tensorflow           |PyTorch  | MxNet|
-|:------------- |:-------------:|:-----|:-|
-| SLSQP (`scipy.optimize`)    | Newton's Method (autodiff)| Newton's Method (autodiff) | N/A |
-| MINUIT (`iminuit`)      |       |    | |
+| NumPy                       | Tensorflow                                | PyTorch                    | MxNet|
+|:----------------------------|:-----------------------------------------:|:---------------------------|:-----|
+| SLSQP (`scipy.optimize`)    | Newton's Method (autodiff)                | Newton's Method (autodiff) |  N/A |
+| MINUIT (`iminuit`)          |                                         . |                          . |    . |
 
 
 ## Todo


### PR DESCRIPTION
# Description

This resolves #250. The table now renders properly in the sphinx website by adding a period `.` instead of relying on spaces. I also tried to use non-breakable spaces `&nbsp;` but those are escaped and treated literally in converting from markdown to rST.

<img width="1320" alt="screenshot 2018-10-25 15 35 07" src="https://user-images.githubusercontent.com/761483/47534270-95bb9900-d86b-11e8-8d3a-57c35de7a72d.png">

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
Add periods to empty table cells so that rST renders the table correctly.
```