### PR TITLE
Make GitHub install instructions easier

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -1,10 +1,20 @@
 Developing
 ==========
 
-To develop, we suggest using `virtual environments <https://virtualenvwrapper.readthedocs.io/en/latest/>`__ together with ``pip`` or using `pipenv <https://pipenv.readthedocs.io/en/latest/>`__. To get all necessary packages for development::
+To develop, we suggest using `virtual environments <https://virtualenvwrapper.readthedocs.io/en/latest/>`__ together with ``pip`` or using `pipenv <https://pipenv.readthedocs.io/en/latest/>`__. Once the environment is activated, clone the repo from GitHub
+
+.. code-block:: console
+
+    git clone https://github.com/diana-hep/pyhf.git
+
+and install all necessary packages for development
+
+.. code-block:: console
 
     pip install --ignore-installed -U -e .[complete]
 
-Then setup the Git pre-commit hook for `Black <https://github.com/ambv/black>`__  by running::
+Then setup the Git pre-commit hook for `Black <https://github.com/ambv/black>`__  by running
+
+.. code-block:: console
 
     pre-commit install

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -21,8 +21,8 @@ and activating it
     source pyhf/bin/activate
 
 
-Install from `PyPI <https://pypi.org/project/pyhf/>`__...
----------------------------------------------------------
+Install latest stable release from `PyPI <https://pypi.org/project/pyhf/>`__...
+-------------------------------------------------------------------------------
 
 ... with NumPy backend
 ++++++++++++++++++++++
@@ -59,64 +59,45 @@ Install from `PyPI <https://pypi.org/project/pyhf/>`__...
 
     pip install pyhf[tensorflow,torch,mxnet]
 
-Install from `GitHub <https://github.com/diana-hep/pyhf>`__...
---------------------------------------------------------------
-
-.. code-block:: console
-
-    git clone https://github.com/diana-hep/pyhf.git
-    cd pyhf
+Install latest development version from `GitHub <https://github.com/diana-hep/pyhf>`__...
+-----------------------------------------------------------------------------------------
 
 ... with NumPy backend
 ++++++++++++++++++++++
 
 .. code-block:: console
 
-    pip install --ignore-installed -U .
+    pip install --ignore-installed -U "git+https://github.com/diana-hep/pyhf.git#egg=pyhf"
 
 ... with TensorFlow backend
 +++++++++++++++++++++++++++
 
 .. code-block:: console
 
-    pip install --ignore-installed -U .[tensorflow]
+    pip install --ignore-installed -U "git+https://github.com/diana-hep/pyhf.git#egg=pyhf[tensorflow]"
 
 ... with PyTorch backend
 ++++++++++++++++++++++++
 
 .. code-block:: console
 
-    pip install --ignore-installed -U .[torch]
+    pip install --ignore-installed -U "git+https://github.com/diana-hep/pyhf.git#egg=pyhf[torch]"
 
 ... with MXNet backend
 ++++++++++++++++++++++
 
 .. code-block:: console
 
-    pip install --ignore-installed -U .[mxnet]
+    pip install --ignore-installed -U "git+https://github.com/diana-hep/pyhf.git#egg=pyhf[mxnet]"
 
 ... with all backends
 +++++++++++++++++++++
 
 .. code-block:: console
 
-    pip install --ignore-installed -U .[tensorflow,torch,mxnet]
+    pip install --ignore-installed -U "git+https://github.com/diana-hep/pyhf.git#egg=pyhf[tensorflow,torch,mxnet]"
 
-Updating :code:`pyhf`...
-------------------------
-
-... if installed from PyPI
-++++++++++++++++++++++++++
+Updating :code:`pyhf`
+---------------------
 
 Rerun the installation command. As the upgrade flag, :code:`-U`, is used then the libraries will be updated.
-
-... if installed from GitHub
-++++++++++++++++++++++++++++
-
-Pull the latest commits from GitHub
-
-.. code-block:: console
-
-    git pull
-
-and then rerun the installation command. As the upgrade flag, :code:`-U`, is used then the libraries will be updated.


### PR DESCRIPTION
# Description

By using the `pip` [VCS support `git+` feature](https://pip.pypa.io/en/stable/reference/pip_install/#git) make it easier for end users to install from GitHub. In addition, clarify that doing so gets the latest development version and not necessarily a stable release as PyPI does.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use the pip VCS support git+ feature (c.f. https://pip.pypa.io/en/stable/reference/pip_install/#git) to make it easier for end users to install from GitHub. In addition, clarify that doing so gets the latest development version and not necessarily a stable release as PyPI does.
* Specify code-block type for Sphinx in docs/development.rst
```
