### PR TITLE
Add luminosity uncertainty calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Computational Backends:
 - [x] PyTorch
 - [x] TensorFlow
 - [x] MXNet
+- [x] Lumi Uncertainty
 
 Available Optimizers
 
@@ -57,7 +58,6 @@ Available Optimizers
 
 
 ## Todo
-- [ ] Lumi Uncertainty
 - [ ] StatConfig
 - [ ] Non-asymptotic calculators
 

--- a/docs/examples/notebooks/binderexample/StatisticalAnalysis.ipynb
+++ b/docs/examples/notebooks/binderexample/StatisticalAnalysis.ipynb
@@ -116,7 +116,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pdf = pyhf.Model({'channels': parsed['channels']}, poiname = 'SigXsecOverSM')\n",
+    "pdf = pyhf.Model({'channels': parsed['channels'], 'parameters': parsed['toplvl']['measurements'][0]['config']['parameters']}, poiname = 'SigXsecOverSM')\n",
     "data = obs_data + pdf.config.auxdata"
    ]
   },

--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -110,7 +110,7 @@ def cls(workspace, output_file, measurement, patch):
                 measurements[measurement_index]['name']
             )
         )
-        spec = {'channels': d['channels']}
+        spec = {'channels': d['channels'], 'parameters': d['toplvl']['measurements'][measurement_index].get('parameters',[])}
         for p in patch:
             with click.open_file(p, 'r') as read_file:
                 p = jsonpatch.JsonPatch(json.loads(read_file.read()))

--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -112,10 +112,11 @@ def cls(workspace, output_file, measurement, patch):
         )
         spec = {
             'channels': d['channels'],
-            'parameters': d['toplvl']['measurements'][measurement_index].get(
+            'parameters': d['toplvl']['measurements'][measurement_index]['config'].get(
                 'parameters', []
             ),
         }
+
         for p in patch:
             with click.open_file(p, 'r') as read_file:
                 p = jsonpatch.JsonPatch(json.loads(read_file.read()))

--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -110,7 +110,12 @@ def cls(workspace, output_file, measurement, patch):
                 measurements[measurement_index]['name']
             )
         )
-        spec = {'channels': d['channels'], 'parameters': d['toplvl']['measurements'][measurement_index].get('parameters',[])}
+        spec = {
+            'channels': d['channels'],
+            'parameters': d['toplvl']['measurements'][measurement_index].get(
+                'parameters', []
+            ),
+        }
         for p in patch:
             with click.open_file(p, 'r') as read_file:
                 p = jsonpatch.JsonPatch(json.loads(read_file.read()))

--- a/pyhf/data/spec.json
+++ b/pyhf/data/spec.json
@@ -73,10 +73,11 @@
             "lumi": {
                 "type": "object",
                 "properties": {
+                    "name": { "const": "lumi" },
                     "type": { "const": "lumi" },
                     "data": { "type": "null" }
                 },
-                "required": ["type", "data"],
+                "required": ["name", "type", "data"],
                 "additionalProperties": false
             },
             "normfactor": {

--- a/pyhf/data/spec.json
+++ b/pyhf/data/spec.json
@@ -39,6 +39,7 @@
                     "items": {
                         "anyOf": [
                             { "$ref": "#/definitions/modifier/histosys" },
+                            { "$ref": "#/definitions/modifier/lumi" },
                             { "$ref": "#/definitions/modifier/normfactor" },
                             { "$ref": "#/definitions/modifier/normsys" },
                             { "$ref": "#/definitions/modifier/shapefactor" },
@@ -65,6 +66,16 @@
                         },
                         "required": ["lo_data", "hi_data"]
                     }
+                },
+                "required": ["name", "type", "data"],
+                "additionalProperties": false
+            },
+            "lumi": {
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" },
+                    "type": { "const": "lumi" },
+                    "data": { "type": "null" }
                 },
                 "required": ["name", "type", "data"],
                 "additionalProperties": false

--- a/pyhf/data/spec.json
+++ b/pyhf/data/spec.json
@@ -73,11 +73,10 @@
             "lumi": {
                 "type": "object",
                 "properties": {
-                    "name": { "type": "string" },
                     "type": { "const": "lumi" },
                     "data": { "type": "null" }
                 },
-                "required": ["name", "type", "data"],
+                "required": ["type", "data"],
                 "additionalProperties": false
             },
             "normfactor": {

--- a/pyhf/data/spec.json
+++ b/pyhf/data/spec.json
@@ -24,7 +24,8 @@
                 "name": { "type": "string" },
                 "inits": { "type": "array", "items": {"type": "number"}, "minItems": 1 },
                 "bounds": { "type": "array", "items": {"type": "array", "items": {"type": "number", "minItems": 2, "maxItems": 2}}, "minItems": 1 },
-                "factors": { "type": "array", "items": {"type": "number"}, "minItems": 1 }
+                "factors": { "type": "array", "items": {"type": "number"}, "minItems": 1 },
+                "sigmas": { "type": "array", "items": {"type": "number"}, "minItems": 1}
             },
             "required": ["name"],
             "additionalProperties": false

--- a/pyhf/data/spec.json
+++ b/pyhf/data/spec.json
@@ -26,7 +26,8 @@
                 "bounds": { "type": "array", "items": {"type": "array", "items": {"type": "number", "minItems": 2, "maxItems": 2}}, "minItems": 1 },
                 "auxdata": { "type": "array", "items": {"type": "number"}, "minItems": 1 },
                 "factors": { "type": "array", "items": {"type": "number"}, "minItems": 1 },
-                "sigmas": { "type": "array", "items": {"type": "number"}, "minItems": 1}
+                "sigmas": { "type": "array", "items": {"type": "number"}, "minItems": 1},
+                "fixed": { "type": "boolean" }
             },
             "required": ["name"],
             "additionalProperties": false

--- a/pyhf/data/spec.json
+++ b/pyhf/data/spec.json
@@ -24,6 +24,7 @@
                 "name": { "type": "string" },
                 "inits": { "type": "array", "items": {"type": "number"}, "minItems": 1 },
                 "bounds": { "type": "array", "items": {"type": "array", "items": {"type": "number", "minItems": 2, "maxItems": 2}}, "minItems": 1 },
+                "auxdata": { "type": "array", "items": {"type": "number"}, "minItems": 1 },
                 "factors": { "type": "array", "items": {"type": "number"}, "minItems": 1 },
                 "sigmas": { "type": "array", "items": {"type": "number"}, "minItems": 1}
             },

--- a/pyhf/modifiers/__init__.py
+++ b/pyhf/modifiers/__init__.py
@@ -176,6 +176,7 @@ def modifier(*args, **kwargs):
 
 
 from .histosys import histosys, histosys_combined
+from .lumi import lumi, lumi_combined
 from .normfactor import normfactor, normfactor_combined
 from .normsys import normsys, normsys_combined
 from .shapefactor import shapefactor, shapefactor_combined
@@ -193,6 +194,7 @@ uncombined = {
 
 combined = {
     'histosys': histosys_combined,
+    'lumi': lumi_combined,
     'normfactor': normfactor_combined,
     'normsys': normsys_combined,
     'shapefactor': shapefactor_combined,
@@ -203,6 +205,8 @@ combined = {
 __all__ = [
     'histosys',
     'histosys_combined',
+    'lumi',
+    'lumi_combined',
     'normfactor',
     'normfactor_combined',
     'normsys',

--- a/pyhf/modifiers/__init__.py
+++ b/pyhf/modifiers/__init__.py
@@ -185,6 +185,7 @@ from .staterror import staterror, staterror_combined
 
 uncombined = {
     'histosys': histosys,
+    'lumi': lumi,
     'normfactor': normfactor,
     'normsys': normsys,
     'shapefactor': shapefactor,

--- a/pyhf/modifiers/lumi.py
+++ b/pyhf/modifiers/lumi.py
@@ -1,0 +1,59 @@
+import logging
+
+from . import modifier
+from ..paramsets import constrained_by_normal
+from .. import get_backend, default_backend, events
+
+log = logging.getLogger(__name__)
+
+
+@modifier(
+    name='lumi', constrained=True, pdf_type='normal', op_code='multiplication'
+)
+class lumi(object):
+    @classmethod
+    def required_parset(cls, n_parameters):
+        return {
+            'paramset_type': constrained_by_normal,
+            'n_parameters': 1,
+            'modifier': cls.__name__,
+            'is_constrained': cls.is_constrained,
+            'is_shared': True,
+            'op_code': cls.op_code,
+            'inits': (0.0,),
+            'bounds': ((-5.0, 5.0),),
+            'auxdata': (0.0,),
+        }
+
+
+class lumi_combined(object):
+    def __init__(self, lumi_mods, pdfconfig, mega_mods):
+        self._lumi_mods = lumi_mods
+        self._parindices = list(range(len(pdfconfig.suggested_init())))
+        self._lumi_indices = [
+            self._parindices[pdfconfig.par_slice(m)] for m in lumi_mods
+        ]
+        self._lumi_mask = [
+            [[mega_mods[s][m]['data']['mask']] for s in pdfconfig.samples]
+            for m in lumi_mods
+        ]
+
+        self._precompute()
+        events.subscribe('tensorlib_changed')(self._precompute)
+
+    def _precompute(self):
+        tensorlib, _ = get_backend()
+        self.lumi_mask = tensorlib.astensor(self._lumi_mask)
+        self.lumi_default = tensorlib.ones(tensorlib.shape(self.lumi_mask))
+
+        self.default_value = tensorlib.astensor([1.0])
+        self.sample_ones = tensorlib.ones(tensorlib.shape(self.lumi_mask)[1])
+        self.alpha_ones = tensorlib.astensor([1])
+
+    def apply(self, pars):
+        tensorlib, _ = get_backend()
+
+        if not tensorlib.shape(self.lumi_indices)[0]:
+            return
+
+        return

--- a/pyhf/modifiers/lumi.py
+++ b/pyhf/modifiers/lumi.py
@@ -27,12 +27,14 @@ class lumi(object):
 class lumi_combined(object):
     def __init__(self, lumi_mods, pdfconfig, mega_mods):
         self._parindices = list(range(len(pdfconfig.suggested_init())))
-        self._lumi_indices = [
-            self._parindices[pdfconfig.par_slice(m)] for m in lumi_mods
-        ]
+
+        pnames = [pname for _, _, pname in lumi_mods]
+        keys = ['{}/{}'.format(mtype, m) for m, mtype, _ in lumi_mods]
+        lumi_mods = [m for m, _, _ in lumi_mods]
+        self._lumi_indices = [self._parindices[pdfconfig.par_slice(p)] for p in pnames]
+
         self._lumi_mask = [
-            [[mega_mods[s][m]['data']['mask']] for s in pdfconfig.samples]
-            for m in lumi_mods
+            [[mega_mods[s][m]['data']['mask']] for s in pdfconfig.samples] for m in keys
         ]
         self._precompute()
         events.subscribe('tensorlib_changed')(self._precompute)

--- a/pyhf/modifiers/lumi.py
+++ b/pyhf/modifiers/lumi.py
@@ -7,9 +7,7 @@ from .. import get_backend, default_backend, events
 log = logging.getLogger(__name__)
 
 
-@modifier(
-    name='lumi', constrained=True, pdf_type='normal', op_code='multiplication'
-)
+@modifier(name='lumi', constrained=True, pdf_type='normal', op_code='multiplication')
 class lumi(object):
     @classmethod
     def required_parset(cls, n_parameters):
@@ -43,9 +41,7 @@ class lumi_combined(object):
         tensorlib, _ = get_backend()
         self.lumi_mask = default_backend.astensor(self._lumi_mask)
         self.lumi_default = default_backend.ones(self.lumi_mask.shape)
-        self.lumi_indices = default_backend.astensor(
-            self._lumi_indices, dtype='int'
-        )
+        self.lumi_indices = default_backend.astensor(self._lumi_indices, dtype='int')
 
     def apply(self, pars):
         tensorlib, _ = get_backend()
@@ -58,8 +54,6 @@ class lumi_combined(object):
             lumis, tensorlib.shape(lumis) + (1, 1)
         )
         results_lumi = tensorlib.where(
-            lumi_mask,
-            results_lumi,
-            tensorlib.astensor(self.lumi_default),
+            lumi_mask, results_lumi, tensorlib.astensor(self.lumi_default)
         )
         return results_lumi

--- a/pyhf/modifiers/lumi.py
+++ b/pyhf/modifiers/lumi.py
@@ -18,9 +18,10 @@ class lumi(object):
             'is_constrained': cls.is_constrained,
             'is_shared': True,
             'op_code': cls.op_code,
-            'inits': (0.0,),
-            'bounds': ((-5.0, 5.0),),
-            'auxdata': (0.0,),
+            'inits': (1.0,),  # lumi
+            'bounds': ((0.0, 10.0),),  # (0, 10*lumi)
+            'auxdata': (1.0,),  # lumi
+            'sigmas': (0.0,),  # lumi * lumirelerror
         }
 
 

--- a/pyhf/modifiers/lumi.py
+++ b/pyhf/modifiers/lumi.py
@@ -18,10 +18,10 @@ class lumi(object):
             'is_constrained': cls.is_constrained,
             'is_shared': True,
             'op_code': cls.op_code,
-            'inits': (1.0,),  # lumi
-            'bounds': ((0.0, 10.0),),  # (0, 10*lumi)
-            'auxdata': (1.0,),  # lumi
-            'sigmas': (0.0,),  # lumi * lumirelerror
+            'inits': None,  # lumi
+            'bounds': None,  # (0, 10*lumi)
+            'auxdata': None,  # lumi
+            'sigmas': None,  # lumi * lumirelerror
         }
 
 

--- a/pyhf/paramsets.py
+++ b/pyhf/paramsets.py
@@ -50,6 +50,7 @@ def reduce_paramsets_requirements(paramsets_requirements, paramsets_user_configs
         'bounds',
         'auxdata',
         'factors',
+        'sigmas',
     ]
 
     """

--- a/pyhf/paramsets.py
+++ b/pyhf/paramsets.py
@@ -18,7 +18,9 @@ class constrained_by_normal(paramset):
         super(constrained_by_normal, self).__init__(**kwargs)
         self.pdf_type = 'normal'
         self.auxdata = kwargs.pop('auxdata')
-        self.sigmas = kwargs.pop('sigmas')
+        sigmas = kwargs.pop('sigmas', None)
+        if sigmas:
+            self.sigmas = sigmas
 
     def expected_data(self, pars):
         return pars

--- a/pyhf/paramsets.py
+++ b/pyhf/paramsets.py
@@ -68,7 +68,7 @@ def reduce_paramsets_requirements(paramsets_requirements, paramsets_user_configs
         combined_paramset = {}
         for k in paramset_keys:
             for paramset_requirement in paramset_requirements:
-                v = paramset_requirement.get(k)
+                v = paramset_requirement.get(k, 'undefined')
                 combined_paramset.setdefault(k, set([])).add(v)
 
             if len(combined_paramset[k]) != 1:
@@ -82,6 +82,8 @@ def reduce_paramsets_requirements(paramsets_requirements, paramsets_user_configs
                 # get user-defined-config if it exists or set to default config
                 v = paramset_user_configs.get(k, default_v)
                 # if v is a tuple, it's not user-configured, so convert to list
+                if v == 'undefined':
+                    continue
                 if isinstance(v, tuple):
                     v = list(v)
                 # this implies user-configured, so check that it has the right number of elements
@@ -91,7 +93,7 @@ def reduce_paramsets_requirements(paramsets_requirements, paramsets_user_configs
                             len(v), k, len(default_v)
                         )
                     )
-                elif v and not default_v:
+                elif v and default_v == 'undefined':
                     raise exceptions.InvalidModel(
                         '{} does not use the {} attribute.'.format(paramset_name, k)
                     )

--- a/pyhf/paramsets.py
+++ b/pyhf/paramsets.py
@@ -18,6 +18,7 @@ class constrained_by_normal(paramset):
         super(constrained_by_normal, self).__init__(**kwargs)
         self.pdf_type = 'normal'
         self.auxdata = kwargs.pop('auxdata')
+        self.sigmas = kwargs.pop('sigmas')
 
     def expected_data(self, pars):
         return pars

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -198,6 +198,7 @@ class Model(object):
                 'nom_data': [],
                 'mask': [],
             },
+            'lumi': lambda: {'mask': []},
             'normsys': lambda: {'hi': [], 'lo': [], 'nom_data': [], 'mask': []},
             'normfactor': lambda: {'mask': []},
             'shapefactor': lambda: {'mask': []},
@@ -280,7 +281,7 @@ class Model(object):
                         mega_mods[s][key]['data']['mask'] += [maskval] * len(
                             nom
                         )  # broadcasting
-                    elif mtype in ['normfactor', 'shapefactor']:
+                    elif mtype in ['normfactor', 'shapefactor', 'lumi']:
                         maskval = True if thismod else False
                         mega_mods[s][key]['data']['mask'] += [maskval] * len(
                             nom

--- a/pyhf/readxml.py
+++ b/pyhf/readxml.py
@@ -217,7 +217,7 @@ def process_measurements(toplvl):
             for param_name in param.text.split(' '):
                 # lumi will always be the first parameter
                 if param_name == 'Lumi':
-                    result['config']['parameters'][0].update(overall_param_object)
+                    result['config']['parameters'][0].update(overall_param_obj)
                 else:
                     param_obj = {'name': param_name}
                     param_obj.update(overall_param_obj)

--- a/pyhf/readxml.py
+++ b/pyhf/readxml.py
@@ -189,10 +189,7 @@ def process_measurements(toplvl):
     for x in toplvl.findall('Measurement'):
         result = {
             'name': x.attrib['Name'],
-            'config': {
-                'poi': x.findall('POI')[0].text,
-                'parameters': [],
-            },
+            'config': {'poi': x.findall('POI')[0].text, 'parameters': []},
         }
         for param in x.findall('ParamSetting'):
             # determine what all parameters in the paramsetting have in common
@@ -205,11 +202,17 @@ def process_measurements(toplvl):
             # might be specifying multiple parameters in the same ParamSetting
             for param_name in param.text.split(' '):
                 if param_name == 'Lumi':
-                  lumi = float(x.attrib['Lumi'])
-                  lumierr = lumi*float(x.attrib['LumiRelErr'])
-                  param_obj = {'name': 'lumi', 'auxdata': [lumi], 'bounds': [[0., 10.*lumi]], 'inits': [lumi], 'sigmas': [lumierr]}
+                    lumi = float(x.attrib['Lumi'])
+                    lumierr = lumi * float(x.attrib['LumiRelErr'])
+                    param_obj = {
+                        'name': 'lumi',
+                        'auxdata': [lumi],
+                        'bounds': [[0.0, 10.0 * lumi]],
+                        'inits': [lumi],
+                        'sigmas': [lumierr],
+                    }
                 else:
-                  param_obj = {'name': param_name}
+                    param_obj = {'name': param_name}
                 param_obj.update(overall_param_obj)
                 result['config']['parameters'].append(param_obj)
         results.append(result)

--- a/pyhf/readxml.py
+++ b/pyhf/readxml.py
@@ -198,7 +198,7 @@ def process_measurements(toplvl):
                     {
                         'name': 'lumi',
                         'auxdata': [lumi],
-                        'bounds': [[0.0, 10.0 * lumi]],
+                        'bounds': [[lumi - 5.0 * lumierr, lumi + 5.0 * lumierr]],
                         'inits': [lumi],
                         'sigmas': [lumierr],
                     }

--- a/pyhf/readxml.py
+++ b/pyhf/readxml.py
@@ -204,12 +204,12 @@ def process_measurements(toplvl):
 
             # might be specifying multiple parameters in the same ParamSetting
             for param_name in param.text.split(' '):
-                param_obj = {'name': param_name}
                 if param_name == 'Lumi':
-                  param_obj['name'] = 'lumi'
                   lumi = float(x.attrib['Lumi'])
                   lumierr = lumi*float(x.attrib['LumiRelErr'])
-                  param_obj.update({'auxdata': [lumi], 'bounds': [[0, 10*lumi]], 'inits': [lumi], 'sigma': [lumierr]})
+                  param_obj = {'name': 'lumi', 'auxdata': [lumi], 'bounds': [[0., 10.*lumi]], 'inits': [lumi], 'sigma': [lumierr]}
+                else:
+                  param_obj = {'name': param_name}
                 param_obj.update(overall_param_obj)
                 result['config']['parameters'].append(param_obj)
         results.append(result)

--- a/pyhf/readxml.py
+++ b/pyhf/readxml.py
@@ -68,6 +68,14 @@ def process_sample(
     data, err = import_root_histogram(rootdir, inputfile, histopath, histoname)
 
     modifiers = []
+    # first check if we need to add lumi modifier for this sample
+    if sample.attrib.get("NormalizeByTheory", "False") == 'True':
+        modifiers.append(
+            {
+                'type': 'lumi',
+                'data': None
+            }
+        )
 
     modtags = tqdm.tqdm(
         sample.iter(), unit='modifier', disable=not (track_progress), total=len(sample)

--- a/pyhf/readxml.py
+++ b/pyhf/readxml.py
@@ -70,12 +70,7 @@ def process_sample(
     modifiers = []
     # first check if we need to add lumi modifier for this sample
     if sample.attrib.get("NormalizeByTheory", "False") == 'True':
-        modifiers.append(
-            {
-                'type': 'lumi',
-                'data': None
-            }
-        )
+        modifiers.append({'name': 'lumi', 'type': 'lumi', 'data': None})
 
     modtags = tqdm.tqdm(
         sample.iter(), unit='modifier', disable=not (track_progress), total=len(sample)

--- a/pyhf/readxml.py
+++ b/pyhf/readxml.py
@@ -207,7 +207,7 @@ def process_measurements(toplvl):
                 if param_name == 'Lumi':
                   lumi = float(x.attrib['Lumi'])
                   lumierr = lumi*float(x.attrib['LumiRelErr'])
-                  param_obj = {'name': 'lumi', 'auxdata': [lumi], 'bounds': [[0., 10.*lumi]], 'inits': [lumi], 'sigma': [lumierr]}
+                  param_obj = {'name': 'lumi', 'auxdata': [lumi], 'bounds': [[0., 10.*lumi]], 'inits': [lumi], 'sigmas': [lumierr]}
                 else:
                   param_obj = {'name': param_name}
                 param_obj.update(overall_param_obj)

--- a/pyhf/readxml.py
+++ b/pyhf/readxml.py
@@ -191,8 +191,6 @@ def process_measurements(toplvl):
             'name': x.attrib['Name'],
             'config': {
                 'poi': x.findall('POI')[0].text,
-                'lumi': float(x.attrib['Lumi']),
-                'lumirelerr': float(x.attrib['LumiRelErr']),
                 'parameters': [],
             },
         }
@@ -207,6 +205,11 @@ def process_measurements(toplvl):
             # might be specifying multiple parameters in the same ParamSetting
             for param_name in param.text.split(' '):
                 param_obj = {'name': param_name}
+                if param_name == 'Lumi':
+                  param_obj['name'] = 'lumi'
+                  lumi = float(x.attrib['Lumi'])
+                  lumierr = lumi*float(x.attrib['LumiRelErr'])
+                  param_obj.update({'auxdata': [lumi], 'bounds': [[0, 10*lumi]], 'inits': [lumi], 'sigma': [lumierr]})
                 param_obj.update(overall_param_obj)
                 result['config']['parameters'].append(param_obj)
         results.append(result)

--- a/pyhf/readxml.py
+++ b/pyhf/readxml.py
@@ -184,6 +184,35 @@ def process_channel(channelxml, rootdir, track_progress=False):
     return channelname, parsed_data, results
 
 
+def process_measurements(toplvl):
+    results = []
+    for x in toplvl.findall('Measurement'):
+        result = {
+            'name': x.attrib['Name'],
+            'config': {
+                'poi': x.findall('POI')[0].text,
+                'lumi': float(x.attrib['Lumi']),
+                'lumirelerr': float(x.attrib['LumiRelErr']),
+                'parameters': [],
+            },
+        }
+        for param in x.findall('ParamSetting'):
+            # determine what all parameters in the paramsetting have in common
+            overall_param_obj = {}
+            if param.attrib.get('Const'):
+                overall_param_obj['fixed'] = param.attrib['Const'] == 'True'
+            if param.attrib.get('Val'):
+                overall_param_obj['value'] = param.attrib['Val']
+
+            # might be specifying multiple parameters in the same ParamSetting
+            for param_name in param.text.split(' '):
+                param_obj = {'name': param_name}
+                param_obj.update(overall_param_obj)
+                result['config']['parameters'].append(param_obj)
+        results.append(result)
+    return results
+
+
 def parse(configfile, rootdir, track_progress=False):
     toplvl = ET.parse(configfile)
     inputs = tqdm.tqdm(
@@ -203,10 +232,7 @@ def parse(configfile, rootdir, track_progress=False):
     return {
         'toplvl': {
             'resultprefix': toplvl.getroot().attrib['OutputFilePrefix'],
-            'measurements': [
-                {'name': x.attrib['Name'], 'config': {'poi': x.findall('POI')[0].text}}
-                for x in toplvl.findall('Measurement')
-            ],
+            'measurements': process_measurements(toplvl),
         },
         'channels': [{'name': k, 'samples': v['samples']} for k, v in channels.items()],
         'data': {k: v['data'] for k, v in channels.items()},

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -131,7 +131,6 @@ def test_import_histosys():
         for channel in pdf.spec['channels']
     }
 
-    assert channels['channel2']['samples'][0]['modifiers'][0]['type'] == 'histosys'
     assert channels['channel2']['samples'][0]['modifiers'][0]['type'] == 'lumi'
     assert channels['channel2']['samples'][0]['modifiers'][1]['type'] == 'histosys'
 

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -47,13 +47,16 @@ def test_import_prepHistFactory():
     assert 'background1' in samples['channel1']
     assert 'background2' in samples['channel1']
 
-    assert pdf.spec['channels'][0]['samples'][2]['modifiers'][0]['type'] == 'staterror'
-    assert pdf.spec['channels'][0]['samples'][2]['modifiers'][0]['data'] == [0, 10.0]
+    assert pdf.spec['channels'][0]['samples'][1]['modifiers'][0]['type'] == 'lumi'
+    assert pdf.spec['channels'][0]['samples'][2]['modifiers'][0]['type'] == 'lumi'
 
-    assert pdf.spec['channels'][0]['samples'][1]['modifiers'][0]['type'] == 'staterror'
+    assert pdf.spec['channels'][0]['samples'][2]['modifiers'][1]['type'] == 'staterror'
+    assert pdf.spec['channels'][0]['samples'][2]['modifiers'][1]['data'] == [0, 10.0]
+
+    assert pdf.spec['channels'][0]['samples'][1]['modifiers'][1]['type'] == 'staterror'
     assert all(
         np.isclose(
-            pdf.spec['channels'][0]['samples'][1]['modifiers'][0]['data'], [5.0, 0.0]
+            pdf.spec['channels'][0]['samples'][1]['modifiers'][1]['data'], [5.0, 0.0]
         )
     )
 
@@ -63,10 +66,10 @@ def test_import_prepHistFactory():
     ]
 
     assert pdf.config.auxdata_order == sorted(
-        ['syst1', 'staterror_channel1', 'syst2', 'syst3']
+        ['lumi', 'syst1', 'staterror_channel1', 'syst2', 'syst3']
     )
 
-    assert data == [122.0, 112.0, 1.0, 1.0, 0.0, 0.0, 0.0]
+    assert data == [122.0, 112.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0]
 
     pars = pdf.config.suggested_init()
     pars[pdf.config.par_slice('SigXsecOverSM')] = [2.0]
@@ -95,6 +98,8 @@ def test_import_histosys():
     }
 
     assert channels['channel2']['samples'][0]['modifiers'][0]['type'] == 'histosys'
+    assert channels['channel2']['samples'][0]['modifiers'][0]['type'] == 'lumi'
+    assert channels['channel2']['samples'][0]['modifiers'][1]['type'] == 'histosys'
 
 
 def test_import_filecache(mocker):

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -27,17 +27,20 @@ def test_import_measurements():
 
     measurement_configs = measurements[0]['config']
 
-    assert 'lumi' in measurement_configs
-    assert measurement_configs['lumi'] == 1.0
-    assert 'lumirelerr' in measurement_configs
-    assert measurement_configs['lumirelerr'] == 0.1
     assert 'parameters' in measurement_configs
-
     assert len(measurement_configs['parameters']) == 2
-    assert measurement_configs['parameters'][0]['name'] == 'Lumi'
+    assert measurement_configs['parameters'][0]['name'] == 'lumi'
     assert measurement_configs['parameters'][1]['name'] == 'alpha_syst1'
-    assert measurement_configs['lumi'] == 1
 
+    lumi_param_config = measurement_configs['parameters'][0]
+    assert 'auxdata' in lumi_param_config
+    assert lumi_param_config['auxdata'] == [1.0]
+    assert 'bounds' in lumi_param_config
+    assert lumi_param_config['bounds'] == [[0, 10.0]]
+    assert 'inits' in lumi_param_config
+    assert lumi_param_config['inits'] == [1.0]
+    assert 'sigma' in lumi_param_config
+    assert lumi_param_config['sigma'] == [0.1]
 
 def test_import_prepHistFactory():
     parsed_xml = pyhf.readxml.parse(

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -39,8 +39,8 @@ def test_import_measurements():
     assert lumi_param_config['bounds'] == [[0, 10.0]]
     assert 'inits' in lumi_param_config
     assert lumi_param_config['inits'] == [1.0]
-    assert 'sigma' in lumi_param_config
-    assert lumi_param_config['sigma'] == [0.1]
+    assert 'sigmas' in lumi_param_config
+    assert lumi_param_config['sigmas'] == [0.1]
 
 
 def test_import_prepHistFactory():
@@ -49,7 +49,7 @@ def test_import_prepHistFactory():
     )
 
     # build the spec, strictly checks properties included
-    spec = {'channels': parsed_xml['channels']}
+    spec = {'channels': parsed_xml['channels'], 'parameters': parsed_xml['toplvl']['measurements'][0]['config']['parameters']}
     pdf = pyhf.Model(spec, poiname='SigXsecOverSM')
 
     data = [
@@ -97,7 +97,7 @@ def test_import_prepHistFactory():
         ['lumi', 'syst1', 'staterror_channel1', 'syst2', 'syst3']
     )
 
-    assert data == [122.0, 112.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0]
+    assert data == [122.0, 112.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0]
 
     pars = pdf.config.suggested_init()
     pars[pdf.config.par_slice('SigXsecOverSM')] = [2.0]
@@ -110,7 +110,7 @@ def test_import_histosys():
     )
 
     # build the spec, strictly checks properties included
-    spec = {'channels': parsed_xml['channels']}
+    spec = {'channels': parsed_xml['channels'], 'parameters': parsed_xml['toplvl']['measurements'][0]['config']['parameters']}
     pdf = pyhf.Model(spec, poiname='SigXsecOverSM')
 
     data = [

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -49,7 +49,10 @@ def test_import_prepHistFactory():
     )
 
     # build the spec, strictly checks properties included
-    spec = {'channels': parsed_xml['channels'], 'parameters': parsed_xml['toplvl']['measurements'][0]['config']['parameters']}
+    spec = {
+        'channels': parsed_xml['channels'],
+        'parameters': parsed_xml['toplvl']['measurements'][0]['config']['parameters'],
+    }
     pdf = pyhf.Model(spec, poiname='SigXsecOverSM')
 
     data = [
@@ -110,7 +113,10 @@ def test_import_histosys():
     )
 
     # build the spec, strictly checks properties included
-    spec = {'channels': parsed_xml['channels'], 'parameters': parsed_xml['toplvl']['measurements'][0]['config']['parameters']}
+    spec = {
+        'channels': parsed_xml['channels'],
+        'parameters': parsed_xml['toplvl']['measurements'][0]['config']['parameters'],
+    }
     pdf = pyhf.Model(spec, poiname='SigXsecOverSM')
 
     data = [

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -36,7 +36,7 @@ def test_import_measurements():
     assert 'auxdata' in lumi_param_config
     assert lumi_param_config['auxdata'] == [1.0]
     assert 'bounds' in lumi_param_config
-    assert lumi_param_config['bounds'] == [[0, 10.0]]
+    assert lumi_param_config['bounds'] == [[0.5, 1.5]]
     assert 'inits' in lumi_param_config
     assert lumi_param_config['inits'] == [1.0]
     assert 'sigmas' in lumi_param_config

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -42,6 +42,7 @@ def test_import_measurements():
     assert 'sigma' in lumi_param_config
     assert lumi_param_config['sigma'] == [0.1]
 
+
 def test_import_prepHistFactory():
     parsed_xml = pyhf.readxml.parse(
         'validation/xmlimport_input/config/example.xml', 'validation/xmlimport_input/'

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -15,6 +15,30 @@ def assert_equal_dictionary(d1, d2):
             assert d1[k] == d2[k]
 
 
+def test_import_measurements():
+    parsed_xml = pyhf.readxml.parse(
+        'validation/xmlimport_input/config/example.xml', 'validation/xmlimport_input/'
+    )
+    assert 'toplvl' in parsed_xml
+    assert 'measurements' in parsed_xml['toplvl']
+
+    measurements = parsed_xml['toplvl']['measurements']
+    assert len(measurements) == 4
+
+    measurement_configs = measurements[0]['config']
+
+    assert 'lumi' in measurement_configs
+    assert measurement_configs['lumi'] == 1.0
+    assert 'lumirelerr' in measurement_configs
+    assert measurement_configs['lumirelerr'] == 0.1
+    assert 'parameters' in measurement_configs
+
+    assert len(measurement_configs['parameters']) == 2
+    assert measurement_configs['parameters'][0]['name'] == 'Lumi'
+    assert measurement_configs['parameters'][1]['name'] == 'alpha_syst1'
+    assert measurement_configs['lumi'] == 1
+
+
 def test_import_prepHistFactory():
     parsed_xml = pyhf.readxml.parse(
         'validation/xmlimport_input/config/example.xml', 'validation/xmlimport_input/'

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -437,7 +437,7 @@ def test_override_paramsets_incorrect_num_parameters():
         pyhf.Model(spec)
 
 
-def test_lumi_change():
+def test_lumi_np_scaling():
     spec = {
         "channels": [
             {
@@ -455,11 +455,7 @@ def test_lumi_change():
                         ],
                         "name": "signal",
                     },
-                    {
-                        "data": [100.0, 0.0],
-                        "modifiers": [{"data": None, "name": "lumi", "type": "lumi"}],
-                        "name": "background1",
-                    },
+                    {"data": [100.0, 0.0], "name": "background1", "modifiers": []},
                     {
                         "data": [0.0, 100.0],
                         "modifiers": [{"data": None, "name": "lumi", "type": "lumi"}],
@@ -479,5 +475,44 @@ def test_lumi_change():
         ],
     }
     pdf = pyhf.pdf.Model(spec, poiname="SigXsecOverSM")
-    assert pdf.expected_data([1.0, 1.0]).tolist() == [120.0, 110.0, 1.0]
-    assert pdf.expected_data([2.0, 1.0]).tolist() == [120.0*2, 110.0*2, 1.0]
+
+    poi_slice = pdf.config.par_slice('SigXsecOverSM')
+    lumi_slice = pdf.config.par_slice('lumi')
+
+    index_bkg1 = pdf.config.samples.index('background1')
+    index_bkg2 = pdf.config.samples.index('background2')
+    index_sig = pdf.config.samples.index('signal')
+    bkg1_slice = slice(index_bkg1, index_bkg1 + 1)
+    bkg2_slice = slice(index_bkg2, index_bkg2 + 1)
+    sig_slice = slice(index_sig, index_sig + 1)
+
+    alpha_lumi = np.random.uniform(0.0, 10.0, 1)[0]
+
+    mods = [None, None, None]
+    pars = [None, None]
+
+    pars[poi_slice], pars[lumi_slice] = [[1.0], [1.0]]
+    mods[sig_slice], mods[bkg1_slice], mods[bkg2_slice] = [
+        [[[1.0, 1.0]]],
+        [[[1.0, 1.0]]],
+        [[[1.0, 1.0]]],
+    ]
+    assert pdf._modifications(np.array(pars))[1][
+        pdf._factor_mods.index('lumi')
+    ].tolist() == [mods]
+    assert pdf.expected_data(pars).tolist() == [120.0, 110.0, 1.0]
+
+    pars[poi_slice], pars[lumi_slice] = [[1.0], [alpha_lumi]]
+    mods[sig_slice], mods[bkg1_slice], mods[bkg2_slice] = [
+        [[[alpha_lumi, alpha_lumi]]],
+        [[[1.0, 1.0]]],
+        [[[alpha_lumi, alpha_lumi]]],
+    ]
+    assert pdf._modifications(np.array(pars))[1][
+        pdf._factor_mods.index('lumi')
+    ].tolist() == [mods]
+    assert pytest.approx(pdf.expected_data(pars).tolist()) == [
+        100 + 20.0 * alpha_lumi,
+        110.0 * alpha_lumi,
+        1.0 * alpha_lumi,
+    ]

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -497,9 +497,7 @@ def test_lumi_np_scaling():
         [[[1.0, 1.0]]],
         [[[1.0, 1.0]]],
     ]
-    assert pdf._modifications(np.array(pars))[1][
-        pdf._factor_mods.index('lumi')
-    ].tolist() == [mods]
+    assert pdf._modifications(np.array(pars))[1][0].tolist() == [mods]
     assert pdf.expected_data(pars).tolist() == [120.0, 110.0, 1.0]
 
     pars[poi_slice], pars[lumi_slice] = [[1.0], [alpha_lumi]]
@@ -508,9 +506,7 @@ def test_lumi_np_scaling():
         [[[1.0, 1.0]]],
         [[[alpha_lumi, alpha_lumi]]],
     ]
-    assert pdf._modifications(np.array(pars))[1][
-        pdf._factor_mods.index('lumi')
-    ].tolist() == [mods]
+    assert pdf._modifications(np.array(pars))[1][0].tolist() == [mods]
     assert pytest.approx(pdf.expected_data(pars).tolist()) == [
         100 + 20.0 * alpha_lumi,
         110.0 * alpha_lumi,

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -435,3 +435,49 @@ def test_override_paramsets_incorrect_num_parameters():
     }
     with pytest.raises(pyhf.exceptions.InvalidModel):
         pyhf.Model(spec)
+
+
+@pytest.mark.parametrize('lumi', [1.0, 1.1, 1.2])
+def test_lumi_change(lumi):
+    spec = {
+        "channels": [
+            {
+                "name": "channel1",
+                "samples": [
+                    {
+                        "data": [20.0, 10.0],
+                        "modifiers": [
+                            {
+                                "data": None,
+                                "name": "SigXsecOverSM",
+                                "type": "normfactor",
+                            },
+                            {"data": None, "name": "lumi", "type": "lumi"},
+                        ],
+                        "name": "signal",
+                    },
+                    {
+                        "data": [100.0, 0.0],
+                        "modifiers": [{"data": None, "name": "lumi", "type": "lumi"}],
+                        "name": "background1",
+                    },
+                    {
+                        "data": [0.0, 100.0],
+                        "modifiers": [{"data": None, "name": "lumi", "type": "lumi"}],
+                        "name": "background2",
+                    },
+                ],
+            }
+        ],
+        "parameters": [
+            {
+                "auxdata": [lumi],
+                "bounds": [[0.0, lumi * 10.0]],
+                "inits": [lumi],
+                "name": "lumi",
+                "sigmas": [0.1],
+            }
+        ],
+    }
+    pdf = pyhf.pdf.Model(spec, poiname="SigXsecOverSM")
+    assert pdf.expected_data([1.0, 1.0]).tolist() == [120.0 * lumi, 110.0 * lumi, lumi]

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -437,8 +437,7 @@ def test_override_paramsets_incorrect_num_parameters():
         pyhf.Model(spec)
 
 
-@pytest.mark.parametrize('lumi', [1.0, 1.1, 1.2])
-def test_lumi_change(lumi):
+def test_lumi_change():
     spec = {
         "channels": [
             {
@@ -471,13 +470,14 @@ def test_lumi_change(lumi):
         ],
         "parameters": [
             {
-                "auxdata": [lumi],
-                "bounds": [[0.0, lumi * 10.0]],
-                "inits": [lumi],
+                "auxdata": [1.0],
+                "bounds": [[0.0, 10.0]],
+                "inits": [1.0],
                 "name": "lumi",
                 "sigmas": [0.1],
             }
         ],
     }
     pdf = pyhf.pdf.Model(spec, poiname="SigXsecOverSM")
-    assert pdf.expected_data([1.0, 1.0]).tolist() == [120.0 * lumi, 110.0 * lumi, lumi]
+    assert pdf.expected_data([1.0, 1.0]).tolist() == [120.0, 110.0, 1.0]
+    assert pdf.expected_data([2.0, 1.0]).tolist() == [120.0*2, 110.0*2, 1.0]

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -90,7 +90,7 @@ def spec_1bin_lumi(source=source_1bin_example1()):
                         'name': 'background',
                         'data': source['bindata']['bkg'],
                         'modifiers': [
-                            { 'name': 'lumi', 'type': 'lumi', 'data': None, }
+                            { 'type': 'lumi', 'data': None, }
                         ],
                     },
                 ],

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -72,6 +72,7 @@ def setup_1bin_shapesys(
         'expected': {'result': expected_result, 'config': config},
     }
 
+
 @pytest.fixture(scope='module')
 def spec_1bin_lumi(source=source_1bin_example1()):
     spec = {
@@ -89,9 +90,7 @@ def spec_1bin_lumi(source=source_1bin_example1()):
                     {
                         'name': 'background',
                         'data': source['bindata']['bkg'],
-                        'modifiers': [
-                            { 'type': 'lumi', 'data': None, }
-                        ],
+                        'modifiers': [{'name': 'lumi', 'type': 'lumi', 'data': None}],
                     },
                 ],
             }
@@ -131,7 +130,6 @@ def setup_1bin_lumi(
         'mu': mu,
         'expected': {'result': expected_result, 'config': config},
     }
-
 
 
 @pytest.fixture(scope='module')

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -72,6 +72,67 @@ def setup_1bin_shapesys(
         'expected': {'result': expected_result, 'config': config},
     }
 
+@pytest.fixture(scope='module')
+def spec_1bin_lumi(source=source_1bin_example1()):
+    spec = {
+        'channels': [
+            {
+                'name': 'singlechannel',
+                'samples': [
+                    {
+                        'name': 'signal',
+                        'data': source['bindata']['sig'],
+                        'modifiers': [
+                            {'name': 'mu', 'type': 'normfactor', 'data': None}
+                        ],
+                    },
+                    {
+                        'name': 'background',
+                        'data': source['bindata']['bkg'],
+                        'modifiers': [
+                            { 'name': 'lumi', 'type': 'lumi', 'data': None, }
+                        ],
+                    },
+                ],
+            }
+        ]
+    }
+    return spec
+
+
+@pytest.fixture(scope='module')
+def expected_result_1bin_lumi(mu=1.0):
+    ## TO DO - FIX THIS
+    if mu == 1:
+        expected_result = {
+            "exp": [
+                0.06371799398864626,
+                0.15096503398048894,
+                0.3279606950533305,
+                0.6046087303039118,
+                0.8662627605298466,
+            ],
+            "obs": 0.4541865416107029,
+        }
+    return expected_result
+
+
+@pytest.fixture(scope='module')
+def setup_1bin_lumi(
+    source=source_1bin_example1(),
+    spec=spec_1bin_lumi(source_1bin_example1()),
+    mu=1,
+    expected_result=expected_result_1bin_lumi(1.0),
+    config={'init_pars': 2, 'par_bounds': 2},
+):
+    return {
+        'source': source,
+        'spec': spec,
+        'mu': mu,
+        'expected': {'result': expected_result, 'config': config},
+    }
+
+
 
 @pytest.fixture(scope='module')
 def source_1bin_normsys():
@@ -635,6 +696,7 @@ def validate_hypotest(pdf, data, mu_test, expected_result, tolerance=1e-6):
     'setup_and_tolerance',
     [
         (setup_1bin_shapesys(), 1e-6),
+        (setup_1bin_lumi(), 1e-6),
         (setup_1bin_normsys(), 1e-6),
         (setup_2bin_histosys(), 8e-5),
         (setup_2bin_2channel(), 1e-6),
@@ -644,6 +706,7 @@ def validate_hypotest(pdf, data, mu_test, expected_result, tolerance=1e-6):
     ],
     ids=[
         '1bin_shapesys_mu1',
+        '1bin_lumi_mu1',
         '1bin_normsys_mu1',
         '2bin_histosys_mu1',
         '2bin_2channel_mu1',

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -76,42 +76,49 @@ def setup_1bin_shapesys(
 @pytest.fixture(scope='module')
 def spec_1bin_lumi(source=source_1bin_example1()):
     spec = {
-        'channels': [
+        "channels": [
             {
-                'name': 'singlechannel',
-                'samples': [
+                "name": "channel1",
+                "samples": [
                     {
-                        'name': 'signal',
-                        'data': source['bindata']['sig'],
-                        'modifiers': [
-                            {'name': 'mu', 'type': 'normfactor', 'data': None}
+                        "data": [20.0, 10.0],
+                        "modifiers": [
+                            {"data": None, "name": "mu", "type": "normfactor"}
                         ],
+                        "name": "signal",
                     },
                     {
-                        'name': 'background',
-                        'data': source['bindata']['bkg'],
-                        'modifiers': [{'name': 'lumi', 'type': 'lumi', 'data': None}],
+                        "data": [100.0, 0.0],
+                        "modifiers": [{"data": None, "name": "lumi", "type": "lumi"}],
+                        "name": "background1",
+                    },
+                    {
+                        "data": [0.0, 100.0],
+                        "modifiers": [{"data": None, "name": "lumi", "type": "lumi"}],
+                        "name": "background2",
                     },
                 ],
             }
-        ]
+        ],
+        "parameters": [
+            {
+                "auxdata": [1.0],
+                "bounds": [[0.0, 10.0]],
+                "inits": [1.0],
+                "name": "lumi",
+                "sigmas": [0.1],
+            }
+        ],
     }
     return spec
 
 
 @pytest.fixture(scope='module')
 def expected_result_1bin_lumi(mu=1.0):
-    ## TO DO - FIX THIS
     if mu == 1:
         expected_result = {
-            "exp": [
-                0.06371799398864626,
-                0.15096503398048894,
-                0.3279606950533305,
-                0.6046087303039118,
-                0.8662627605298466,
-            ],
-            "obs": 0.4541865416107029,
+            "exp": [0.00905976, 0.0357287, 0.12548957, 0.35338293, 0.69589171],
+            "obs": 0.00941757,
         }
     return expected_result
 


### PR DESCRIPTION
# Description

This is the last piece needed for the MBJ validation. The luminosity is a modifier that affects some samples in some channels, but is a globally shared modifier (as such, the name is fixed to `lumi` in the spec). This is going to be similar to what normsys currently does, but globally shared.

- `readxml.py` is updated to check for this.
- `modifiers/lumi.py` is added with a gaussian constraint
- `tests/test_validation.py` is set-up to check for the calculation, but will need to run it in HistFactory to get the right calculation [e.g. use one of the validation XML files that already exist]

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
- the luminosity uncertainty is a global multiplicative scale factor, constrained by a gaussian whose mu is the single nuisance parameter constrained as follows (based on HistFactory):
  - inits = [lumi]
  - auxdata = [lumi]
  - sigmas = [lumi * lumirelerror]
  - bounds = [[0, 10*lumi]]
- tests are added to validate the expected scaling behavior of the luminosity uncertainty
- the spec is updated to allow for sigmas to be configured for lumi and set for constrained_by_normal
- paramset reduction now handles the situation for paramset requirements that cannot have a default value (None) versus paramset requirements that should not be defined ('undefined')
```