### PR TITLE
Use mathmode outside of bold environment

### DIFF
--- a/docs/examples/notebooks/hello-world.ipynb
+++ b/docs/examples/notebooks/hello-world.ipynb
@@ -29,7 +29,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Returning the observed and expected $\\mathrm{CL}_{s}$**"
+    "**Returning the observed and expected** $\\mathrm{CL}_{s}$"
    ]
   },
   {
@@ -57,7 +57,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Returning the observed $\\mathrm{CL}_{s}$, $\\mathrm{CL}_{s+b}$, and $\\mathrm{CL}_{b}$**"
+    "**Returning the observed** $\\mathrm{CL}_{s}$, $\\mathrm{CL}_{s+b}$, **and** $\\mathrm{CL}_{b}$"
    ]
   },
   {
@@ -101,7 +101,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Returning the expected $\\mathrm{CL}_{s}$ band values**"
+    "**Returning the expected** $\\mathrm{CL}_{s}$ **band values**"
    ]
   },
   {

--- a/docs/examples/notebooks/hello-world.ipynb
+++ b/docs/examples/notebooks/hello-world.ipynb
@@ -29,7 +29,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Returning the observed and expected $CL_{s}$**"
+    "**Returning the observed and expected $\\mathrm{CL}_{s}$**"
    ]
   },
   {
@@ -57,7 +57,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Returning the observed $CL_{s}$, $CL_{s+b}$, and $CL_{b}$**"
+    "**Returning the observed $\\mathrm{CL}_{s}$, $\\mathrm{CL}_{s+b}$, and $\\mathrm{CL}_{b}$**"
    ]
   },
   {
@@ -84,7 +84,7 @@
    "source": [
     "A reminder that \n",
     "$$\n",
-    "CL_{s} = \\frac{CL_{s+b}}{CL_{b}} = \\frac{p_{s+b}}{1-p_{b}}\n",
+    "\\mathrm{CL}_{s} = \\frac{\\mathrm{CL}_{s+b}}{\\mathrm{CL}_{b}} = \\frac{p_{s+b}}{1-p_{b}}\n",
     "$$"
    ]
   },
@@ -101,7 +101,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Returning the expected $CL_{s}$ band values**"
+    "**Returning the expected $\\mathrm{CL}_{s}$ band values**"
    ]
   },
   {


### PR DESCRIPTION
# Description

Resolves #351 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
- Fix the rendering issue with Sphinx caused by having a mathmode environment inside of a bold text environment by ending and starting the bold outside of the mathmode
- Use \mathrm{CL} for proper formatting in mathmode
```
