### PR TITLE
Enable shared nuisance parameters over modifier types

### DIFF
--- a/pyhf/modifiers/histosys.py
+++ b/pyhf/modifiers/histosys.py
@@ -28,9 +28,11 @@ class histosys(object):
 class histosys_combined(object):
     def __init__(self, histosys_mods, pdfconfig, mega_mods):
         self._parindices = list(range(len(pdfconfig.suggested_init())))
-        self._histo_indices = [
-            self._parindices[pdfconfig.par_slice(m)] for m in histosys_mods
-        ]
+
+        pnames = [pname for _, _, pname in histosys_mods]
+        keys = ['{}/{}'.format(mtype, m) for m, mtype, _ in histosys_mods]
+        histosys_mods = [m for m, _, _ in histosys_mods]
+        self._histo_indices = [self._parindices[pdfconfig.par_slice(p)] for p in pnames]
         self._histosys_histoset = [
             [
                 [
@@ -40,11 +42,10 @@ class histosys_combined(object):
                 ]
                 for s in pdfconfig.samples
             ]
-            for m in histosys_mods
+            for m in keys
         ]
         self._histosys_mask = [
-            [[mega_mods[s][m]['data']['mask']] for s in pdfconfig.samples]
-            for m in histosys_mods
+            [[mega_mods[s][m]['data']['mask']] for s in pdfconfig.samples] for m in keys
         ]
 
         if len(histosys_mods):

--- a/pyhf/modifiers/normfactor.py
+++ b/pyhf/modifiers/normfactor.py
@@ -26,12 +26,16 @@ class normfactor(object):
 class normfactor_combined(object):
     def __init__(self, normfactor_mods, pdfconfig, mega_mods):
         self._parindices = list(range(len(pdfconfig.suggested_init())))
+
+        pnames = [pname for _, _, pname in normfactor_mods]
+        keys = ['{}/{}'.format(mtype, m) for m, mtype, _ in normfactor_mods]
+        normfactor_mods = [m for m, _, _ in normfactor_mods]
+
         self._normfactor_indices = [
-            self._parindices[pdfconfig.par_slice(m)] for m in normfactor_mods
+            self._parindices[pdfconfig.par_slice(p)] for p in pnames
         ]
         self._normfactor_mask = [
-            [[mega_mods[s][m]['data']['mask']] for s in pdfconfig.samples]
-            for m in normfactor_mods
+            [[mega_mods[s][m]['data']['mask']] for s in pdfconfig.samples] for m in keys
         ]
         self._precompute()
         events.subscribe('tensorlib_changed')(self._precompute)

--- a/pyhf/modifiers/normsys.py
+++ b/pyhf/modifiers/normsys.py
@@ -28,8 +28,13 @@ class normsys(object):
 class normsys_combined(object):
     def __init__(self, normsys_mods, pdfconfig, mega_mods):
         self._parindices = list(range(len(pdfconfig.suggested_init())))
+
+        pnames = [pname for _, _, pname in normsys_mods]
+        keys = ['{}/{}'.format(mtype, m) for m, mtype, _ in normsys_mods]
+        normsys_mods = [m for m, _, _ in normsys_mods]
+
         self._normsys_indices = [
-            self._parindices[pdfconfig.par_slice(m)] for m in normsys_mods
+            self._parindices[pdfconfig.par_slice(p)] for p in pnames
         ]
         self._normsys_histoset = [
             [
@@ -40,11 +45,10 @@ class normsys_combined(object):
                 ]
                 for s in pdfconfig.samples
             ]
-            for m in normsys_mods
+            for m in keys
         ]
         self._normsys_mask = [
-            [[mega_mods[s][m]['data']['mask']] for s in pdfconfig.samples]
-            for m in normsys_mods
+            [[mega_mods[s][m]['data']['mask']] for s in pdfconfig.samples] for m in keys
         ]
 
         if len(normsys_mods):

--- a/pyhf/modifiers/shapefactor.py
+++ b/pyhf/modifiers/shapefactor.py
@@ -62,13 +62,17 @@ class shapefactor_combined(object):
 
         and at that point can be used to compute the effect of shapefactor.
         """
+
+        pnames = [pname for _, _, pname in shapefactor_mods]
+        keys = ['{}/{}'.format(mtype, m) for m, mtype, _ in shapefactor_mods]
+        shapefactor_mods = [m for m, _, _ in shapefactor_mods]
+
         self._parindices = list(range(len(pdfconfig.suggested_init())))
         self._shapefactor_indices = [
-            self._parindices[pdfconfig.par_slice(m)] for m in shapefactor_mods
+            self._parindices[pdfconfig.par_slice(p)] for p in pnames
         ]
         self._shapefactor_mask = [
-            [[mega_mods[s][m]['data']['mask']] for s in pdfconfig.samples]
-            for m in shapefactor_mods
+            [[mega_mods[s][m]['data']['mask']] for s in pdfconfig.samples] for m in keys
         ]
         global_concatenated_bin_indices = [
             j for c in pdfconfig.channels for j in range(pdfconfig.channel_nbins[c])

--- a/pyhf/modifiers/shapesys.py
+++ b/pyhf/modifiers/shapesys.py
@@ -44,8 +44,7 @@ class shapesys_combined(object):
             self._parindices[pdfconfig.par_slice(p)] for p in pnames
         ]
         self._shapesys_mask = [
-            [[[mega_mods][s][m]['data']['mask']] for s in pdfconfig.samples]
-            for m in keys
+            [[mega_mods[s][m]['data']['mask']] for s in pdfconfig.samples] for m in keys
         ]
         self.__shapesys_uncrt = default_backend.astensor(
             [

--- a/pyhf/modifiers/shapesys.py
+++ b/pyhf/modifiers/shapesys.py
@@ -31,14 +31,21 @@ class shapesys(object):
 
 class shapesys_combined(object):
     def __init__(self, shapesys_mods, pdfconfig, mega_mods):
+
+        pnames = [pname for _, _, pname in shapesys_mods]
+        keys = ['{}/{}'.format(mtype, m) for m, mtype, _ in shapesys_mods]
+        shapesys_mods = [m for m, _, _ in shapesys_mods]
+
         self._shapesys_mods = shapesys_mods
+        self._pnames = pnames
+
         self._parindices = list(range(len(pdfconfig.suggested_init())))
         self._shapesys_indices = [
-            self._parindices[pdfconfig.par_slice(m)] for m in shapesys_mods
+            self._parindices[pdfconfig.par_slice(p)] for p in pnames
         ]
         self._shapesys_mask = [
-            [[mega_mods[s][m]['data']['mask']] for s in pdfconfig.samples]
-            for m in shapesys_mods
+            [[[mega_mods][s][m]['data']['mask']] for s in pdfconfig.samples]
+            for m in keys
         ]
         self.__shapesys_uncrt = default_backend.astensor(
             [
@@ -49,7 +56,7 @@ class shapesys_combined(object):
                     ]
                     for s in pdfconfig.samples
                 ]
-                for m in shapesys_mods
+                for m in keys
             ]
         )
 
@@ -94,7 +101,7 @@ class shapesys_combined(object):
             self.factor_access_indices = None
 
     def finalize(self, pdfconfig):
-        for uncert_this_mod, mod in zip(self.__shapesys_uncrt, self._shapesys_mods):
+        for uncert_this_mod, pname in zip(self.__shapesys_uncrt, self._pnames):
             unc_nom = default_backend.astensor(
                 [x for x in uncert_this_mod[:, :, :] if any(x[0][x[0] > 0])]
             )
@@ -115,9 +122,9 @@ class shapesys_combined(object):
 
             factors = numerator / denominator
             factors = factors[factors > 0]
-            assert len(factors) == pdfconfig.param_set(mod).n_parameters
-            pdfconfig.param_set(mod).factors = default_backend.tolist(factors)
-            pdfconfig.param_set(mod).auxdata = default_backend.tolist(factors)
+            assert len(factors) == pdfconfig.param_set(pname).n_parameters
+            pdfconfig.param_set(pname).factors = default_backend.tolist(factors)
+            pdfconfig.param_set(pname).auxdata = default_backend.tolist(factors)
 
     def apply(self, pars):
         tensorlib, _ = get_backend()

--- a/pyhf/modifiers/staterror.py
+++ b/pyhf/modifiers/staterror.py
@@ -27,13 +27,17 @@ class staterror(object):
 class staterror_combined(object):
     def __init__(self, staterr_mods, pdfconfig, mega_mods):
         self._parindices = list(range(len(pdfconfig.suggested_init())))
+
+        pnames = [pname for _, _, pname in staterr_mods]
+        keys = ['{}/{}'.format(mtype, m) for m, mtype, _ in staterr_mods]
+        staterr_mods = [m for m, _, _ in staterr_mods]
+
         self._staterror_indices = [
-            self._parindices[pdfconfig.par_slice(m)] for m in staterr_mods
+            self._parindices[pdfconfig.par_slice(p)] for p in pnames
         ]
         self._staterr_mods = staterr_mods
         self._staterror_mask = [
-            [[mega_mods[s][m]['data']['mask']] for s in pdfconfig.samples]
-            for m in staterr_mods
+            [[mega_mods[s][m]['data']['mask']] for s in pdfconfig.samples] for m in keys
         ]
         self.__staterror_uncrt = default_backend.astensor(
             [
@@ -44,7 +48,7 @@ class staterror_combined(object):
                     ]
                     for s in pdfconfig.samples
                 ]
-                for m in staterr_mods
+                for m in keys
             ]
         )
 

--- a/pyhf/paramsets.py
+++ b/pyhf/paramsets.py
@@ -60,7 +60,7 @@ def reduce_paramset_requirements(paramset_requirements):
                 combined_param.setdefault(k, set([])).add(param.get(k))
 
         for k in param_keys:
-            if len(combined_param[k]) != 1:
+            if len(combined_param[k]) != 1 and k != 'op_code':
                 raise exceptions.InvalidNameReuse(
                     "Multiple values for '{}' ({}) were found for {}. Use unique modifier names or use qualify_names=True when constructing the pdf.".format(
                         k, list(combined_param[k]), param_name


### PR DESCRIPTION
# Description

this resolves the case in #272 of shared parsets over multiple modifiers

```
roohf not shared
{
    "CLs_exp": [
        0.15719136360999494,
        0.28707182742358117,
        0.49040108398224225,
        0.7391079566241138,
        0.9260249020571463
    ],
    "CLs_obs": 0.6624276086776395
}


roohf shared
{
    "CLs_exp": [
        0.1824533173540692,
        0.31861297860704774,
        0.5224666964320326,
        0.7615731173535661,
        0.9344146382006049
    ],
    "CLs_obs": 0.6768036954464488
}

pyhf shared
{
    "CLs_exp": [
        0.18257145128940405,
        0.31875687511186174,
        0.5226093840643298,
        0.761670602736219,
        0.9344501334751033
    ],
    "CLs_obs": 0.6768690617184364
}
```

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [ ] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* expand config.modifiers to include mapping to parameter set (modname,type,paramset)
* use type/modname key to identify modifier data in mega_mods
* use paramset name in combined modifier appliers to select parset
* enables shared nuisance parameters across modifier types
```