### PR TITLE
Allow for parameter configuration from the spec

### DIFF
--- a/pyhf/data/spec.json
+++ b/pyhf/data/spec.json
@@ -24,7 +24,6 @@
                 "name": { "type": "string" },
                 "inits": { "type": "array", "items": {"type": "number"}, "minItems": 1 },
                 "bounds": { "type": "array", "items": {"type": "array", "items": {"type": "number", "minItems": 2, "maxItems": 2}}, "minItems": 1 },
-                "auxdata": { "type": "array", "items": {"type": "number"}, "minItems": 1 },
                 "factors": { "type": "array", "items": {"type": "number"}, "minItems": 1 }
             },
             "required": ["name"],

--- a/pyhf/data/spec.json
+++ b/pyhf/data/spec.json
@@ -2,7 +2,8 @@
     "$schema": "http://json-schema.org/draft-06/schema#",
     "type": "object",
     "properties": {
-        "channels": { "type": "array", "items": {"$ref": "#/definitions/channel"} }
+        "channels": { "type": "array", "items": {"$ref": "#/definitions/channel"} },
+        "parameters": { "type": "array", "items": {"$ref": "#/definitions/parameter"} }
     },
     "additionalProperties": false,
     "required": ["channels"],
@@ -15,6 +16,18 @@
                 "samples": { "type": "array", "items": {"$ref": "#/definitions/sample"}, "minItems": 1 }
             },
             "required": ["name", "samples"],
+            "additionalProperties": false
+        },
+        "parameter": {
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" },
+                "inits": { "type": "array", "items": {"type": "number"}, "minItems": 1 },
+                "bounds": { "type": "array", "items": {"type": "array", "items": {"type": "number", "minItems": 2, "maxItems": 2}}, "minItems": 1 },
+                "auxdata": { "type": "array", "items": {"type": "number"}, "minItems": 1 },
+                "factors": { "type": "array", "items": {"type": "number"}, "minItems": 1 }
+            },
+            "required": ["name"],
             "additionalProperties": false
         },
         "sample": {

--- a/pyhf/modifiers/__init__.py
+++ b/pyhf/modifiers/__init__.py
@@ -182,14 +182,24 @@ from .shapefactor import shapefactor, shapefactor_combined
 from .shapesys import shapesys, shapesys_combined
 from .staterror import staterror, staterror_combined
 
+uncombined = {
+    'histosys': histosys,
+    'normfactor': normfactor,
+    'normsys': normsys,
+    'shapefactor': shapefactor,
+    'shapesys': shapesys,
+    'staterror': staterror,
+}
+
 combined = {
-    'normsys': normsys_combined,
     'histosys': histosys_combined,
     'normfactor': normfactor_combined,
-    'staterror': staterror_combined,
+    'normsys': normsys_combined,
     'shapefactor': shapefactor_combined,
     'shapesys': shapesys_combined,
+    'staterror': staterror_combined,
 }
+
 __all__ = [
     'histosys',
     'histosys_combined',

--- a/pyhf/modifiers/histosys.py
+++ b/pyhf/modifiers/histosys.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 @modifier(name='histosys', constrained=True, op_code='addition')
 class histosys(object):
     @classmethod
-    def required_parset(cls, n_parameters):
+    def required_parset(cls, n_parameters, config={}):
         return {
             'paramset_type': constrained_by_normal,
             'n_parameters': 1,
@@ -19,9 +19,9 @@ class histosys(object):
             'is_constrained': cls.is_constrained,
             'is_shared': True,
             'op_code': cls.op_code,
-            'inits': (0.0,),
-            'bounds': ((-5.0, 5.0),),
-            'auxdata': (0.0,),
+            'inits': config.get('inits', (0.0,)),
+            'bounds': config.get('bounds', ((-5.0, 5.0),)),
+            'auxdata': config.get('auxdata', (0.0,)),
         }
 
 

--- a/pyhf/modifiers/histosys.py
+++ b/pyhf/modifiers/histosys.py
@@ -19,9 +19,9 @@ class histosys(object):
             'is_constrained': cls.is_constrained,
             'is_shared': True,
             'op_code': cls.op_code,
-            'inits': config.get('inits', (0.0,)),
-            'bounds': config.get('bounds', ((-5.0, 5.0),)),
-            'auxdata': config.get('auxdata', (0.0,)),
+            'inits': config.get('inits', [0.0]),
+            'bounds': config.get('bounds', [[-5.0, 5.0]]),
+            'auxdata': config.get('auxdata', [0.0]),
         }
 
 

--- a/pyhf/modifiers/histosys.py
+++ b/pyhf/modifiers/histosys.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 @modifier(name='histosys', constrained=True, op_code='addition')
 class histosys(object):
     @classmethod
-    def required_parset(cls, n_parameters, config={}):
+    def required_parset(cls, n_parameters):
         return {
             'paramset_type': constrained_by_normal,
             'n_parameters': 1,
@@ -19,9 +19,9 @@ class histosys(object):
             'is_constrained': cls.is_constrained,
             'is_shared': True,
             'op_code': cls.op_code,
-            'inits': config.get('inits', [0.0]),
-            'bounds': config.get('bounds', [[-5.0, 5.0]]),
-            'auxdata': config.get('auxdata', [0.0]),
+            'inits': (0.0,),
+            'bounds': ((-5.0, 5.0),),
+            'auxdata': (0.0,),
         }
 
 

--- a/pyhf/modifiers/histosys.py
+++ b/pyhf/modifiers/histosys.py
@@ -18,7 +18,6 @@ class histosys(object):
             'modifier': cls.__name__,
             'is_constrained': cls.is_constrained,
             'is_shared': True,
-            'op_code': cls.op_code,
             'inits': (0.0,),
             'bounds': ((-5.0, 5.0),),
             'auxdata': (0.0,),

--- a/pyhf/modifiers/normfactor.py
+++ b/pyhf/modifiers/normfactor.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 @modifier(name='normfactor', op_code='multiplication')
 class normfactor(object):
     @classmethod
-    def required_parset(cls, n_parameters):
+    def required_parset(cls, n_parameters, config={}):
         return {
             'paramset_type': unconstrained,
             'n_parameters': 1,
@@ -18,8 +18,8 @@ class normfactor(object):
             'is_constrained': cls.is_constrained,
             'is_shared': True,
             'op_code': cls.op_code,
-            'inits': (1.0,),
-            'bounds': ((0, 10),),
+            'inits': config.get('inits', (1.0,)),
+            'bounds': config.get('bounds', ((0, 10),)),
         }
 
 

--- a/pyhf/modifiers/normfactor.py
+++ b/pyhf/modifiers/normfactor.py
@@ -18,8 +18,8 @@ class normfactor(object):
             'is_constrained': cls.is_constrained,
             'is_shared': True,
             'op_code': cls.op_code,
-            'inits': config.get('inits', (1.0,)),
-            'bounds': config.get('bounds', ((0, 10),)),
+            'inits': config.get('inits', [1.0]),
+            'bounds': config.get('bounds', [[0, 10]]),
         }
 
 

--- a/pyhf/modifiers/normfactor.py
+++ b/pyhf/modifiers/normfactor.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 @modifier(name='normfactor', op_code='multiplication')
 class normfactor(object):
     @classmethod
-    def required_parset(cls, n_parameters, config={}):
+    def required_parset(cls, n_parameters):
         return {
             'paramset_type': unconstrained,
             'n_parameters': 1,
@@ -18,8 +18,8 @@ class normfactor(object):
             'is_constrained': cls.is_constrained,
             'is_shared': True,
             'op_code': cls.op_code,
-            'inits': config.get('inits', [1.0]),
-            'bounds': config.get('bounds', [[0, 10]]),
+            'inits': (1.0,),
+            'bounds': ((0, 10),),
         }
 
 

--- a/pyhf/modifiers/normfactor.py
+++ b/pyhf/modifiers/normfactor.py
@@ -17,7 +17,6 @@ class normfactor(object):
             'modifier': cls.__name__,
             'is_constrained': cls.is_constrained,
             'is_shared': True,
-            'op_code': cls.op_code,
             'inits': (1.0,),
             'bounds': ((0, 10),),
         }

--- a/pyhf/modifiers/normsys.py
+++ b/pyhf/modifiers/normsys.py
@@ -18,7 +18,6 @@ class normsys(object):
             'modifier': cls.__name__,
             'is_constrained': cls.is_constrained,
             'is_shared': True,
-            'op_code': cls.op_code,
             'inits': (0.0,),
             'bounds': ((-5.0, 5.0),),
             'auxdata': (0.0,),

--- a/pyhf/modifiers/normsys.py
+++ b/pyhf/modifiers/normsys.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 @modifier(name='normsys', constrained=True, op_code='multiplication')
 class normsys(object):
     @classmethod
-    def required_parset(cls, n_parameters, config={}):
+    def required_parset(cls, n_parameters):
         return {
             'paramset_type': constrained_by_normal,
             'n_parameters': 1,
@@ -19,9 +19,9 @@ class normsys(object):
             'is_constrained': cls.is_constrained,
             'is_shared': True,
             'op_code': cls.op_code,
-            'inits': config.get('inits', [0.0]),
-            'bounds': config.get('bounds', [[-5.0, 5.0]]),
-            'auxdata': config.get('auxdata', [0.0]),
+            'inits': (0.0,),
+            'bounds': ((-5.0, 5.0),),
+            'auxdata': (0.0,),
         }
 
 

--- a/pyhf/modifiers/normsys.py
+++ b/pyhf/modifiers/normsys.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 @modifier(name='normsys', constrained=True, op_code='multiplication')
 class normsys(object):
     @classmethod
-    def required_parset(cls, n_parameters):
+    def required_parset(cls, n_parameters, config={}):
         return {
             'paramset_type': constrained_by_normal,
             'n_parameters': 1,
@@ -19,9 +19,9 @@ class normsys(object):
             'is_constrained': cls.is_constrained,
             'is_shared': True,
             'op_code': cls.op_code,
-            'inits': (0.0,),
-            'bounds': ((-5.0, 5.0),),
-            'auxdata': (0.0,),
+            'inits': config.get('inits', (0.0,)),
+            'bounds': config.get('bounds', ((-5.0, 5.0),)),
+            'auxdata': config.get('auxdata', (0.0,)),
         }
 
 

--- a/pyhf/modifiers/normsys.py
+++ b/pyhf/modifiers/normsys.py
@@ -19,9 +19,9 @@ class normsys(object):
             'is_constrained': cls.is_constrained,
             'is_shared': True,
             'op_code': cls.op_code,
-            'inits': config.get('inits', (0.0,)),
-            'bounds': config.get('bounds', ((-5.0, 5.0),)),
-            'auxdata': config.get('auxdata', (0.0,)),
+            'inits': config.get('inits', [0.0]),
+            'bounds': config.get('bounds', [[-5.0, 5.0]]),
+            'auxdata': config.get('auxdata', [0.0]),
         }
 
 

--- a/pyhf/modifiers/shapefactor.py
+++ b/pyhf/modifiers/shapefactor.py
@@ -18,8 +18,8 @@ class shapefactor(object):
             'is_constrained': cls.is_constrained,
             'is_shared': True,
             'op_code': cls.op_code,
-            'inits': config.get('inits', (1.0,) * n_parameters),
-            'bounds': config.get('bounds', ((0.0, 10.0),) * n_parameters),
+            'inits': config.get('inits', [1.0] * n_parameters),
+            'bounds': config.get('bounds', [[0.0, 10.0]] * n_parameters),
         }
 
 

--- a/pyhf/modifiers/shapefactor.py
+++ b/pyhf/modifiers/shapefactor.py
@@ -17,7 +17,6 @@ class shapefactor(object):
             'modifier': cls.__name__,
             'is_constrained': cls.is_constrained,
             'is_shared': True,
-            'op_code': cls.op_code,
             'inits': (1.0,) * n_parameters,
             'bounds': ((0.0, 10.0),) * n_parameters,
         }

--- a/pyhf/modifiers/shapefactor.py
+++ b/pyhf/modifiers/shapefactor.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 @modifier(name='shapefactor', op_code='multiplication')
 class shapefactor(object):
     @classmethod
-    def required_parset(cls, n_parameters):
+    def required_parset(cls, n_parameters, config={}):
         return {
             'paramset_type': unconstrained,
             'n_parameters': n_parameters,
@@ -18,8 +18,8 @@ class shapefactor(object):
             'is_constrained': cls.is_constrained,
             'is_shared': True,
             'op_code': cls.op_code,
-            'inits': (1.0,) * n_parameters,
-            'bounds': ((0.0, 10.0),) * n_parameters,
+            'inits': config.get('inits', (1.0,) * n_parameters),
+            'bounds': config.get('bounds', ((0.0, 10.0),) * n_parameters),
         }
 
 

--- a/pyhf/modifiers/shapefactor.py
+++ b/pyhf/modifiers/shapefactor.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 @modifier(name='shapefactor', op_code='multiplication')
 class shapefactor(object):
     @classmethod
-    def required_parset(cls, n_parameters, config={}):
+    def required_parset(cls, n_parameters):
         return {
             'paramset_type': unconstrained,
             'n_parameters': n_parameters,
@@ -18,8 +18,8 @@ class shapefactor(object):
             'is_constrained': cls.is_constrained,
             'is_shared': True,
             'op_code': cls.op_code,
-            'inits': config.get('inits', [1.0] * n_parameters),
-            'bounds': config.get('bounds', [[0.0, 10.0]] * n_parameters),
+            'inits': (1.0,) * n_parameters,
+            'bounds': ((0.0, 10.0),) * n_parameters,
         }
 
 

--- a/pyhf/modifiers/shapesys.py
+++ b/pyhf/modifiers/shapesys.py
@@ -20,12 +20,12 @@ class shapesys(object):
             'is_constrained': cls.is_constrained,
             'is_shared': False,
             'op_code': cls.op_code,
-            'inits': config.get('inits', (1.0,) * n_parameters),
-            'bounds': config.get('bounds', ((1e-10, 10.0),) * n_parameters),
+            'inits': config.get('inits', [1.0] * n_parameters),
+            'bounds': config.get('bounds', [1e-10, 10.0] * n_parameters),
             # nb: auxdata/factors set by finalize. Set to non-numeric to crash
             # if we fail to set auxdata/factors correctly
-            'auxdata': (None,) * n_parameters,
-            'factors': (None,) * n_parameters,
+            'auxdata': [None] * n_parameters,
+            'factors': [None] * n_parameters,
         }
 
 

--- a/pyhf/modifiers/shapesys.py
+++ b/pyhf/modifiers/shapesys.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 )
 class shapesys(object):
     @classmethod
-    def required_parset(cls, n_parameters, config={}):
+    def required_parset(cls, n_parameters):
         return {
             'paramset_type': constrained_by_poisson,
             'n_parameters': n_parameters,
@@ -20,12 +20,12 @@ class shapesys(object):
             'is_constrained': cls.is_constrained,
             'is_shared': False,
             'op_code': cls.op_code,
-            'inits': config.get('inits', [1.0] * n_parameters),
-            'bounds': config.get('bounds', [[1e-10, 10.0]] * n_parameters),
+            'inits': (1.0,) * n_parameters,
+            'bounds': ((1e-10, 10.0),) * n_parameters,
             # nb: auxdata/factors set by finalize. Set to non-numeric to crash
             # if we fail to set auxdata/factors correctly
-            'auxdata': [None] * n_parameters,
-            'factors': [None] * n_parameters,
+            'auxdata': (None,) * n_parameters,
+            'factors': (None,) * n_parameters,
         }
 
 

--- a/pyhf/modifiers/shapesys.py
+++ b/pyhf/modifiers/shapesys.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 )
 class shapesys(object):
     @classmethod
-    def required_parset(cls, n_parameters):
+    def required_parset(cls, n_parameters, config={}):
         return {
             'paramset_type': constrained_by_poisson,
             'n_parameters': n_parameters,
@@ -20,8 +20,8 @@ class shapesys(object):
             'is_constrained': cls.is_constrained,
             'is_shared': False,
             'op_code': cls.op_code,
-            'inits': (1.0,) * n_parameters,
-            'bounds': ((1e-10, 10.0),) * n_parameters,
+            'inits': config.get('inits', (1.0,) * n_parameters),
+            'bounds': config.get('bounds', ((1e-10, 10.0),) * n_parameters),
             # nb: auxdata/factors set by finalize. Set to non-numeric to crash
             # if we fail to set auxdata/factors correctly
             'auxdata': (None,) * n_parameters,

--- a/pyhf/modifiers/shapesys.py
+++ b/pyhf/modifiers/shapesys.py
@@ -19,7 +19,6 @@ class shapesys(object):
             'modifier': cls.__name__,
             'is_constrained': cls.is_constrained,
             'is_shared': False,
-            'op_code': cls.op_code,
             'inits': (1.0,) * n_parameters,
             'bounds': ((1e-10, 10.0),) * n_parameters,
             # nb: auxdata/factors set by finalize. Set to non-numeric to crash

--- a/pyhf/modifiers/shapesys.py
+++ b/pyhf/modifiers/shapesys.py
@@ -21,7 +21,7 @@ class shapesys(object):
             'is_shared': False,
             'op_code': cls.op_code,
             'inits': config.get('inits', [1.0] * n_parameters),
-            'bounds': config.get('bounds', [1e-10, 10.0] * n_parameters),
+            'bounds': config.get('bounds', [[1e-10, 10.0]] * n_parameters),
             # nb: auxdata/factors set by finalize. Set to non-numeric to crash
             # if we fail to set auxdata/factors correctly
             'auxdata': [None] * n_parameters,

--- a/pyhf/modifiers/staterror.py
+++ b/pyhf/modifiers/staterror.py
@@ -17,7 +17,6 @@ class staterror(object):
             'modifier': cls.__name__,
             'is_constrained': cls.is_constrained,
             'is_shared': True,
-            'op_code': cls.op_code,
             'inits': (1.0,) * n_parameters,
             'bounds': ((1e-10, 10.0),) * n_parameters,
             'auxdata': (1.0,) * n_parameters,

--- a/pyhf/modifiers/staterror.py
+++ b/pyhf/modifiers/staterror.py
@@ -18,9 +18,9 @@ class staterror(object):
             'is_constrained': cls.is_constrained,
             'is_shared': True,
             'op_code': cls.op_code,
-            'inits': config.get('inits', (1.0,) * n_parameters),
-            'bounds': config.get('bounds', ((1e-10, 10.0),) * n_parameters),
-            'auxdata': config.get('auxdata', (1.0,) * n_parameters),
+            'inits': config.get('inits', [1.0] * n_parameters),
+            'bounds': config.get('bounds', [[1e-10, 10.0]] * n_parameters),
+            'auxdata': config.get('auxdata', [1.0] * n_parameters),
         }
 
 

--- a/pyhf/modifiers/staterror.py
+++ b/pyhf/modifiers/staterror.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 @modifier(name='staterror', constrained=True, op_code='multiplication')
 class staterror(object):
     @classmethod
-    def required_parset(cls, n_parameters):
+    def required_parset(cls, n_parameters, config={}):
         return {
             'paramset_type': constrained_by_normal,
             'n_parameters': n_parameters,
@@ -18,9 +18,9 @@ class staterror(object):
             'is_constrained': cls.is_constrained,
             'is_shared': True,
             'op_code': cls.op_code,
-            'inits': (1.0,) * n_parameters,
-            'bounds': ((1e-10, 10.0),) * n_parameters,
-            'auxdata': (1.0,) * n_parameters,
+            'inits': config.get('inits', (1.0,) * n_parameters),
+            'bounds': config.get('bounds', ((1e-10, 10.0),) * n_parameters),
+            'auxdata': config.get('auxdata', (1.0,) * n_parameters),
         }
 
 

--- a/pyhf/modifiers/staterror.py
+++ b/pyhf/modifiers/staterror.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 @modifier(name='staterror', constrained=True, op_code='multiplication')
 class staterror(object):
     @classmethod
-    def required_parset(cls, n_parameters, config={}):
+    def required_parset(cls, n_parameters):
         return {
             'paramset_type': constrained_by_normal,
             'n_parameters': n_parameters,
@@ -18,9 +18,9 @@ class staterror(object):
             'is_constrained': cls.is_constrained,
             'is_shared': True,
             'op_code': cls.op_code,
-            'inits': config.get('inits', [1.0] * n_parameters),
-            'bounds': config.get('bounds', [[1e-10, 10.0]] * n_parameters),
-            'auxdata': config.get('auxdata', [1.0] * n_parameters),
+            'inits': (1.0,) * n_parameters,
+            'bounds': ((1e-10, 10.0),) * n_parameters,
+            'auxdata': (1.0,) * n_parameters,
         }
 
 

--- a/pyhf/paramsets.py
+++ b/pyhf/paramsets.py
@@ -75,11 +75,15 @@ def reduce_paramset_requirements(paramset_requirements, paramsets_user_configs):
                 if isinstance(v, tuple):
                     v = list(v)
                 # this implies user-configured, so check that it has the right number of elements
-                elif isinstance(v, list) and len(v) != len(default_v):
+                elif isinstance(v, list) and default_v and len(v) != len(default_v):
                     raise exceptions.InvalidModel(
                         'Incorrect number of values ({}) for {} were configured by you, expected {}.'.format(
                             len(v), k, len(default_v)
                         )
+                    )
+                elif v and not default_v:
+                    raise exceptions.InvalidModel(
+                        '{} does not use the {} attribute.'.format(param_name, k)
                     )
 
                 combined_param[k] = v

--- a/pyhf/paramsets.py
+++ b/pyhf/paramsets.py
@@ -58,12 +58,13 @@ def reduce_paramset_requirements(paramset_requirements):
         for param in params:
             for k in param_keys:
                 v = param.get(k)
-                # need to convert lists to tuples
-                if k in ['inits', 'auxdata', 'factors']:
-                    v = tuple(v)
-                # need to convert lists of lists to tuples
-                elif k in ['bounds']:
-                    v = tuple(map(tuple, v))
+                if v:
+                    # need to convert lists to tuples
+                    if k in ['inits', 'auxdata', 'factors']:
+                        v = tuple(v)
+                    # need to convert lists of lists to tuples
+                    elif k in ['bounds']:
+                        v = tuple(map(tuple, v))
                 combined_param.setdefault(k, set([])).add(v)
 
         for k in param_keys:

--- a/pyhf/paramsets.py
+++ b/pyhf/paramsets.py
@@ -49,6 +49,14 @@ def reduce_paramsets_requirements(paramsets_requirements, paramsets_user_configs
         'factors',
     ]
 
+    """
+    - process all defined paramsets
+    - determine the unique set of paramsets by param-name
+    - if the paramset is not unique, complain
+    - if the paramset is unique, build the paramset using the set() defined on its options
+      - if the value is a tuple, this came from default options so convert to a list and use it
+      - if the value is a list, this came from user-define options, so use it
+    """
     for paramset_name in list(paramsets_requirements.keys()):
         paramset_requirements = paramsets_requirements[paramset_name]
         paramset_user_configs = paramsets_user_configs.get(paramset_name, {})

--- a/pyhf/paramsets.py
+++ b/pyhf/paramsets.py
@@ -43,7 +43,6 @@ def reduce_paramsets_requirements(paramsets_requirements, paramsets_user_configs
     paramset_keys = [
         'paramset_type',
         'n_parameters',
-        'op_code',
         'inits',
         'bounds',
         'auxdata',
@@ -61,7 +60,7 @@ def reduce_paramsets_requirements(paramsets_requirements, paramsets_user_configs
                 combined_paramset.setdefault(k, set([])).add(v)
 
         for k in paramset_keys:
-            if len(combined_paramset[k]) != 1 and k != 'op_code':
+            if len(combined_paramset[k]) != 1:
                 raise exceptions.InvalidNameReuse(
                     "Multiple values for '{}' ({}) were found for {}. Use unique modifier names when constructing the pdf.".format(
                         k, list(combined_paramset[k]), paramset_name

--- a/pyhf/paramsets.py
+++ b/pyhf/paramsets.py
@@ -40,7 +40,6 @@ class constrained_by_poisson(paramset):
 def reduce_paramset_requirements(paramset_requirements, paramsets_user_configs):
     reduced_paramset_requirements = {}
 
-    # nb: normsys and histosys have different op_codes so can't currently be shared
     param_keys = [
         'paramset_type',
         'n_parameters',

--- a/pyhf/paramsets.py
+++ b/pyhf/paramsets.py
@@ -57,7 +57,14 @@ def reduce_paramset_requirements(paramset_requirements):
         combined_param = {}
         for param in params:
             for k in param_keys:
-                combined_param.setdefault(k, set([])).add(param.get(k))
+                v = param.get(k)
+                # need to convert lists to tuples
+                if k in ['inits', 'auxdata', 'factors']:
+                    v = tuple(v)
+                # need to convert lists of lists to tuples
+                elif k in ['bounds']:
+                    v = tuple(map(tuple, v))
+                combined_param.setdefault(k, set([])).add(v)
 
         for k in param_keys:
             if len(combined_param[k]) != 1 and k != 'op_code':

--- a/pyhf/paramsets.py
+++ b/pyhf/paramsets.py
@@ -54,12 +54,11 @@ def reduce_paramsets_requirements(paramsets_requirements, paramsets_user_configs
         paramset_user_configs = paramsets_user_configs.get(paramset_name, {})
 
         combined_paramset = {}
-        for paramset_requirement in paramset_requirements:
-            for k in paramset_keys:
+        for k in paramset_keys:
+            for paramset_requirement in paramset_requirements:
                 v = paramset_requirement.get(k)
                 combined_paramset.setdefault(k, set([])).add(v)
 
-        for k in paramset_keys:
             if len(combined_paramset[k]) != 1:
                 raise exceptions.InvalidNameReuse(
                     "Multiple values for '{}' ({}) were found for {}. Use unique modifier names when constructing the pdf.".format(

--- a/pyhf/paramsets.py
+++ b/pyhf/paramsets.py
@@ -37,10 +37,10 @@ class constrained_by_poisson(paramset):
         )
 
 
-def reduce_paramset_requirements(paramset_requirements, paramsets_user_configs):
-    reduced_paramset_requirements = {}
+def reduce_paramsets_requirements(paramsets_requirements, paramsets_user_configs):
+    reduced_paramsets_requirements = {}
 
-    param_keys = [
+    paramset_keys = [
         'paramset_type',
         'n_parameters',
         'op_code',
@@ -50,27 +50,27 @@ def reduce_paramset_requirements(paramset_requirements, paramsets_user_configs):
         'factors',
     ]
 
-    for param_name in list(paramset_requirements.keys()):
-        params = paramset_requirements[param_name]
-        param_user_configs = paramsets_user_configs.get(param_name, {})
+    for paramset_name in list(paramsets_requirements.keys()):
+        paramset_requirements = paramsets_requirements[paramset_name]
+        paramset_user_configs = paramsets_user_configs.get(paramset_name, {})
 
-        combined_param = {}
-        for param in params:
-            for k in param_keys:
-                v = param.get(k)
-                combined_param.setdefault(k, set([])).add(v)
+        combined_paramset = {}
+        for paramset_requirement in paramset_requirements:
+            for k in paramset_keys:
+                v = paramset_requirement.get(k)
+                combined_paramset.setdefault(k, set([])).add(v)
 
-        for k in param_keys:
-            if len(combined_param[k]) != 1 and k != 'op_code':
+        for k in paramset_keys:
+            if len(combined_paramset[k]) != 1 and k != 'op_code':
                 raise exceptions.InvalidNameReuse(
                     "Multiple values for '{}' ({}) were found for {}. Use unique modifier names when constructing the pdf.".format(
-                        k, list(combined_param[k]), param_name
+                        k, list(combined_paramset[k]), paramset_name
                     )
                 )
             else:
-                default_v = combined_param[k].pop()
+                default_v = combined_paramset[k].pop()
                 # get user-defined-config if it exists or set to default config
-                v = param_user_configs.get(k, default_v)
+                v = paramset_user_configs.get(k, default_v)
                 # if v is a tuple, it's not user-configured, so convert to list
                 if isinstance(v, tuple):
                     v = list(v)
@@ -83,11 +83,11 @@ def reduce_paramset_requirements(paramset_requirements, paramsets_user_configs):
                     )
                 elif v and not default_v:
                     raise exceptions.InvalidModel(
-                        '{} does not use the {} attribute.'.format(param_name, k)
+                        '{} does not use the {} attribute.'.format(paramset_name, k)
                     )
 
-                combined_param[k] = v
+                combined_paramset[k] = v
 
-        reduced_paramset_requirements[param_name] = combined_param
+        reduced_paramsets_requirements[paramset_name] = combined_paramset
 
-    return reduced_paramset_requirements
+    return reduced_paramsets_requirements

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -330,8 +330,16 @@ class Model(object):
         return auxdata
 
     def _modifications(self, pars):
-        factor_mods = ['normsys', 'staterror', 'shapesys', 'normfactor', 'shapefactor']
-        delta_mods = ['histosys']
+        factor_mods = [
+            modtype
+            for modtype, mod in modifiers.uncombined.items()
+            if mod.op_code == 'multiplication'
+        ]
+        delta_mods = [
+            modtype
+            for modtype, mod in modifiers.uncombined.items()
+            if mod.op_code == 'addition'
+        ]
 
         deltas = list(
             filter(

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -58,9 +58,7 @@ class _ModelConfig(object):
                             modifier_def['type']
                         ].required_parset(
                             len(sample['data']),
-                            default=self.parameter_configs.get(
-                                modifier_def['name'], {}
-                            ),
+                            config=self.parameter_configs.get(modifier_def['name'], {}),
                         )
                     except KeyError:
                         log.exception(

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -58,7 +58,7 @@ class _ModelConfig(object):
                             modifier_def['type']
                         ].required_parset(
                             len(sample['data']),
-                            defaults=self.parameter_configs.get(param_name, {}),
+                            defaults=self.parameter_configs.get(modifier_def['name'], {}),
                         )
                     except KeyError:
                         log.exception(

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -179,6 +179,17 @@ class Model(object):
         self.constraints_gaussian = gaussian_constraint_combined(self.config)
         self.constraints_poisson = poisson_constraint_combined(self.config)
 
+        self._factor_mods = [
+            modtype
+            for modtype, mod in modifiers.uncombined.items()
+            if mod.op_code == 'multiplication'
+        ]
+        self._delta_mods = [
+            modtype
+            for modtype, mod in modifiers.uncombined.items()
+            if mod.op_code == 'addition'
+        ]
+
     def _create_nominal_and_modifiers(self):
         default_data_makers = {
             'histosys': lambda: {
@@ -330,27 +341,16 @@ class Model(object):
         return auxdata
 
     def _modifications(self, pars):
-        factor_mods = [
-            modtype
-            for modtype, mod in modifiers.uncombined.items()
-            if mod.op_code == 'multiplication'
-        ]
-        delta_mods = [
-            modtype
-            for modtype, mod in modifiers.uncombined.items()
-            if mod.op_code == 'addition'
-        ]
-
         deltas = list(
             filter(
                 lambda x: x is not None,
-                [self.modifiers_appliers[k].apply(pars) for k in delta_mods],
+                [self.modifiers_appliers[k].apply(pars) for k in self._delta_mods],
             )
         )
         factors = list(
             filter(
                 lambda x: x is not None,
-                [self.modifiers_appliers[k].apply(pars) for k in factor_mods],
+                [self.modifiers_appliers[k].apply(pars) for k in self._factor_mods],
             )
         )
 

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -49,16 +49,16 @@ class _ModelConfig(object):
             for sample in channel['samples']:
                 self.samples.append(sample['name'])
                 for modifier_def in sample['modifiers']:
-                    self.parameters.append(modifier_def['name'])
-
                     # get the paramset requirements for the given modifier. If
                     # modifier does not exist, we'll have a KeyError
+                    paramset_name = modifier_def['name']
+                    self.parameters.append(paramset_name)
                     try:
                         paramset_requirements = modifiers.registry[
                             modifier_def['type']
                         ].required_parset(
                             len(sample['data']),
-                            config=self.parameter_configs.get(modifier_def['name'], {}),
+                            config=self.parameter_configs.get(paramset_name, {}),
                         )
                     except KeyError:
                         log.exception(
@@ -71,7 +71,7 @@ class _ModelConfig(object):
                         (
                             modifier_def['name'],  # mod name
                             modifier_def['type'],  # mod type
-                            modifier_def['name'],  # parset name
+                            paramset_name,  # parset name
                         )
                     )
 

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -58,7 +58,7 @@ class _ModelConfig(object):
                             modifier_def['type']
                         ].required_parset(
                             len(sample['data']),
-                            defaults=self.parameter_configs.get(modifier_def['name'], {}),
+                            default=self.parameter_configs.get(modifier_def['name'], {}),
                         )
                     except KeyError:
                         log.exception(

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -58,7 +58,9 @@ class _ModelConfig(object):
                             modifier_def['type']
                         ].required_parset(
                             len(sample['data']),
-                            default=self.parameter_configs.get(modifier_def['name'], {}),
+                            default=self.parameter_configs.get(
+                                modifier_def['name'], {}
+                            ),
                         )
                     except KeyError:
                         log.exception(

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -6,7 +6,7 @@ from . import exceptions
 from . import modifiers
 from . import utils
 from .constraints import gaussian_constraint_combined, poisson_constraint_combined
-from .paramsets import reduce_paramset_requirements
+from .paramsets import reduce_paramsets_requirements
 
 log = logging.getLogger(__name__)
 
@@ -29,9 +29,7 @@ class _ModelConfig(object):
                         parameter['name']
                     )
                 )
-            _paramsets_user_configs[parameter['name']] = {
-                k: v for k, v in parameter.items() if k != 'name'
-            }
+            _paramsets_user_configs[parameter.pop('name')] = parameter
 
         self.channels = []
         self.samples = []
@@ -148,7 +146,7 @@ class _ModelConfig(object):
     def _create_and_register_paramsets(
         self, paramsets_requirements, paramsets_user_configs
     ):
-        for param_name, paramset_requirements in reduce_paramset_requirements(
+        for param_name, paramset_requirements in reduce_paramsets_requirements(
             paramsets_requirements, paramsets_user_configs
         ).items():
             paramset_type = paramset_requirements.get('paramset_type')

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -24,7 +24,7 @@ class _ModelConfig(object):
         self.parameter_configs = {}
         for parameter in spec.get('parameters', []):
             if parameter['name'] in self.parameter_configs:
-                raise exceptions.InvalidSpecification(
+                raise exceptions.InvalidModel(
                     'Multiple parameter configurations for {} were found.'.format(
                         parameter['name']
                     )

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -23,8 +23,8 @@ class _ModelConfig(object):
         # build up a dictionary of the parameter configurations provided by the user
         self.parameter_configs = {}
         for parameter in spec.get('parameters', []):
-            if parameter['name'] in self._parameter_configs:
-                raise exceptions.InvalidModel(
+            if parameter['name'] in self.parameter_configs:
+                raise exceptions.InvalidSpecification(
                     'Multiple parameter configurations for {} were found.'.format(
                         parameter['name']
                     )

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -155,7 +155,7 @@ def test_registry_name_clash():
 def test_override_modifier_defaults(modifier):
     m = getattr(pyhf.modifiers, modifier)
 
-    new_config = {'inits': [99], 'bounds': [95]}
-    parset_requirements = m.required_parset(1, new_config)
+    default = {'inits': [99], 'bounds': [95]}
+    parset_requirements = m.required_parset(1, default=default)
     assert parset_requirements['inits'] == [99]
     assert parset_requirements['bounds'] == [95]

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -155,7 +155,7 @@ def test_registry_name_clash():
 def test_override_modifier_defaults(modifier):
     m = getattr(pyhf.modifiers, modifier)
 
-    default = {'inits': [99], 'bounds': [95]}
-    parset_requirements = m.required_parset(1, default=default)
+    config = {'inits': [99], 'bounds': [95]}
+    parset_requirements = m.required_parset(1, config=config)
     assert parset_requirements['inits'] == [99]
     assert parset_requirements['bounds'] == [95]

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -149,3 +149,13 @@ def test_registry_name_clash():
                 pass
 
         pyhf.modifiers.add_to_registry(myCustomModifier, 'histosys')
+
+
+@pytest.mark.parametrize("modifier", modifiers_to_test)
+def test_override_modifier_defaults(modifier):
+    m = getattr(pyhf.modifiers, modifier)
+
+    new_config = {'inits': [99], 'bounds': [95]}
+    parset_requirements = m.required_parset(1, new_config)
+    assert parset_requirements['inits'] == [99]
+    assert parset_requirements['bounds'] == [95]

--- a/tests/test_modifiers.py
+++ b/tests/test_modifiers.py
@@ -149,13 +149,3 @@ def test_registry_name_clash():
                 pass
 
         pyhf.modifiers.add_to_registry(myCustomModifier, 'histosys')
-
-
-@pytest.mark.parametrize("modifier", modifiers_to_test)
-def test_override_modifier_defaults(modifier):
-    m = getattr(pyhf.modifiers, modifier)
-
-    config = {'inits': [99], 'bounds': [95]}
-    parset_requirements = m.required_parset(1, config=config)
-    assert parset_requirements['inits'] == [99]
-    assert parset_requirements['bounds'] == [95]

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -372,3 +372,66 @@ def test_invalid_modifier_name_resuse():
     }
     with pytest.raises(pyhf.exceptions.InvalidNameReuse):
         pyhf.Model(spec, poiname='reused_name')
+
+
+def test_override_paramset_defaults():
+    source = json.load(open('validation/data/2bin_histosys_example2.json'))
+    spec = {
+        'channels': [
+            {
+                'name': 'singlechannel',
+                'samples': [
+                    {
+                        'name': 'signal',
+                        'data': source['bindata']['sig'],
+                        'modifiers': [
+                            {'name': 'mu', 'type': 'normfactor', 'data': None}
+                        ],
+                    },
+                    {
+                        'name': 'background',
+                        'data': source['bindata']['bkg'],
+                        'modifiers': [
+                            {'name': 'bkg_norm', 'type': 'shapesys', 'data': [10, 10]}
+                        ],
+                    },
+                ],
+            }
+        ],
+        'parameters': [
+            {'name': 'bkg_norm', 'inits': [99, 99], 'bounds': [[95, 95], [95, 95]]}
+        ],
+    }
+    pdf = pyhf.Model(spec)
+    assert pdf.config.param_set('bkg_norm').suggested_bounds == [[95, 95], [95, 95]]
+    assert pdf.config.param_set('bkg_norm').suggested_init == [99, 99]
+
+
+def test_override_paramsets_incorrect_num_parameters():
+    source = json.load(open('validation/data/2bin_histosys_example2.json'))
+    spec = {
+        'channels': [
+            {
+                'name': 'singlechannel',
+                'samples': [
+                    {
+                        'name': 'signal',
+                        'data': source['bindata']['sig'],
+                        'modifiers': [
+                            {'name': 'mu', 'type': 'normfactor', 'data': None}
+                        ],
+                    },
+                    {
+                        'name': 'background',
+                        'data': source['bindata']['bkg'],
+                        'modifiers': [
+                            {'name': 'bkg_norm', 'type': 'shapesys', 'data': [10, 10]}
+                        ],
+                    },
+                ],
+            }
+        ],
+        'parameters': [{'name': 'bkg_norm', 'inits': [99, 99], 'bounds': [[95, 95]]}],
+    }
+    with pytest.raises(pyhf.exceptions.InvalidModel):
+        pyhf.Model(spec)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -157,3 +157,111 @@ def test_empty_histosys():
     }
     with pytest.raises(pyhf.exceptions.InvalidSpecification):
         pyhf.Model(spec)
+
+
+def test_additional_properties():
+    spec = {
+        'channels': [
+            {
+                'name': 'channel',
+                'samples': [
+                    {'name': 'sample', 'data': [10.0], 'modifiers': []},
+                    {
+                        'name': 'another_sample',
+                        'data': [5.0],
+                        'modifiers': [
+                            {'name': 'mypoi', 'type': 'normfactor', 'data': None}
+                        ],
+                    },
+                ],
+            }
+        ],
+        'fake_additional_property': 2,
+    }
+    with pytest.raises(pyhf.exceptions.InvalidSpecification):
+        pyhf.Model(spec)
+
+
+def test_parameters_definition():
+    spec = {
+        'channels': [
+            {
+                'name': 'channel',
+                'samples': [
+                    {'name': 'sample', 'data': [10.0], 'modifiers': []},
+                    {
+                        'name': 'another_sample',
+                        'data': [5.0],
+                        'modifiers': [
+                            {'name': 'mypoi', 'type': 'normfactor', 'data': None}
+                        ],
+                    },
+                ],
+            }
+        ],
+        'parameters': [{'name': 'mypoi'}],
+    }
+    pyhf.Model(spec, poiname='mypoi')
+
+
+def test_parameters_all_props():
+    spec = {
+        'channels': [
+            {
+                'name': 'channel',
+                'samples': [
+                    {'name': 'sample', 'data': [10.0], 'modifiers': []},
+                    {
+                        'name': 'another_sample',
+                        'data': [5.0],
+                        'modifiers': [
+                            {'name': 'mypoi', 'type': 'normfactor', 'data': None}
+                        ],
+                    },
+                ],
+            }
+        ],
+        'parameters': [
+            {
+                'name': 'mypoi',
+                'inits': [1],
+                'bounds': [[0, 1]],
+                'auxdata': [1],
+                'factors': [1],
+            }
+        ],
+    }
+    pyhf.Model(spec, poiname='mypoi')
+
+
+@pytest.mark.parametrize(
+    'bad_parameter',
+    [
+        {'name': 'mypoi', 'inits': ['a']},
+        {'name': 'mypoi', 'bounds': [0, 1]},
+        {'name': 'mypoi', 'auxdata': ['a']},
+        {'name': 'mypoi', 'factors': ['a']},
+    ],
+    ids=['inits', 'bounds', 'auxdata', 'factors'],
+)
+def test_parameters_bad_parameter(bad_parameter):
+    spec = {
+        'channels': [
+            {
+                'name': 'channel',
+                'samples': [
+                    {'name': 'sample', 'data': [10.0], 'modifiers': []},
+                    {
+                        'name': 'another_sample',
+                        'data': [5.0],
+                        'modifiers': [
+                            {'name': 'mypoi', 'type': 'normfactor', 'data': None}
+                        ],
+                    },
+                ],
+            }
+        ],
+        'parameters': [bad_parameter],
+    }
+    with pytest.raises(pyhf.exceptions.InvalidSpecification):
+        pyhf.Model(spec, poiname='mypoi')

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -204,6 +204,29 @@ def test_parameters_definition():
     pyhf.Model(spec, poiname='mypoi')
 
 
+def test_parameters_duplicated():
+    spec = {
+        'channels': [
+            {
+                'name': 'channel',
+                'samples': [
+                    {'name': 'sample', 'data': [10.0], 'modifiers': []},
+                    {
+                        'name': 'another_sample',
+                        'data': [5.0],
+                        'modifiers': [
+                            {'name': 'mypoi', 'type': 'normfactor', 'data': None}
+                        ],
+                    },
+                ],
+            }
+        ],
+        'parameters': [{'name': 'mypoi'}, {'name': 'mypoi'}],
+    }
+    with pytest.raises(pyhf.exceptions.InvalidSpecification):
+        pyhf.Model(spec, poiname='mypoi')
+
+
 def test_parameters_all_props():
     spec = {
         'channels': [

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -223,7 +223,7 @@ def test_parameters_duplicated():
         ],
         'parameters': [{'name': 'mypoi'}, {'name': 'mypoi'}],
     }
-    with pytest.raises(pyhf.exceptions.InvalidSpecification):
+    with pytest.raises(pyhf.exceptions.InvalidModel):
         pyhf.Model(spec, poiname='mypoi')
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -294,9 +294,7 @@ def test_parameters_bad_parameter(bad_parameter):
 
 
 @pytest.mark.parametrize(
-    'bad_parameter',
-    [{'name': 'mypoi', 'auxdata': [0.0]}, {'name': 'mypoi', 'factors': [0.0]}],
-    ids=['auxdata', 'factors'],
+    'bad_parameter', [{'name': 'mypoi', 'factors': [0.0]}], ids=['factors']
 )
 def test_parameters_normfactor_bad_attribute(bad_parameter):
     spec = {

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -244,15 +244,7 @@ def test_parameters_all_props():
                 ],
             }
         ],
-        'parameters': [
-            {
-                'name': 'mypoi',
-                'inits': [1],
-                'bounds': [[0, 1]],
-                'auxdata': [1],
-                'factors': [1],
-            }
-        ],
+        'parameters': [{'name': 'mypoi', 'inits': [1], 'bounds': [[0, 1]]}],
     }
     pyhf.Model(spec, poiname='mypoi')
 
@@ -268,7 +260,15 @@ def test_parameters_all_props():
         {'name': 'mypoi', 'n_parameters': 5},
         {'name': 'mypoi', 'op_code': 'fake_op_code'},
     ],
-    ids=['inits', 'bounds', 'auxdata', 'factors', 'paramset_type', 'n_parameters', 'op_code'],
+    ids=[
+        'inits',
+        'bounds',
+        'auxdata',
+        'factors',
+        'paramset_type',
+        'n_parameters',
+        'op_code',
+    ],
 )
 def test_parameters_bad_parameter(bad_parameter):
     spec = {
@@ -290,4 +290,32 @@ def test_parameters_bad_parameter(bad_parameter):
         'parameters': [bad_parameter],
     }
     with pytest.raises(pyhf.exceptions.InvalidSpecification):
+        pyhf.Model(spec, poiname='mypoi')
+
+
+@pytest.mark.parametrize(
+    'bad_parameter',
+    [{'name': 'mypoi', 'auxdata': [0.0]}, {'name': 'mypoi', 'factors': [0.0]}],
+    ids=['auxdata', 'factors'],
+)
+def test_parameters_normfactor_bad_attribute(bad_parameter):
+    spec = {
+        'channels': [
+            {
+                'name': 'channel',
+                'samples': [
+                    {'name': 'sample', 'data': [10.0], 'modifiers': []},
+                    {
+                        'name': 'another_sample',
+                        'data': [5.0],
+                        'modifiers': [
+                            {'name': 'mypoi', 'type': 'normfactor', 'data': None}
+                        ],
+                    },
+                ],
+            }
+        ],
+        'parameters': [bad_parameter],
+    }
+    with pytest.raises(pyhf.exceptions.InvalidModel):
         pyhf.Model(spec, poiname='mypoi')

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -264,8 +264,11 @@ def test_parameters_all_props():
         {'name': 'mypoi', 'bounds': [0, 1]},
         {'name': 'mypoi', 'auxdata': ['a']},
         {'name': 'mypoi', 'factors': ['a']},
+        {'name': 'mypoi', 'paramset_type': 'fake_paramset_type'},
+        {'name': 'mypoi', 'n_parameters': 5},
+        {'name': 'mypoi', 'op_code': 'fake_op_code'},
     ],
-    ids=['inits', 'bounds', 'auxdata', 'factors'],
+    ids=['inits', 'bounds', 'auxdata', 'factors', 'paramset_type', 'n_parameters', 'op_code'],
 )
 def test_parameters_bad_parameter(bad_parameter):
     spec = {


### PR DESCRIPTION
# Description

This expands the spec to allow for (optional) parameter configuration. This will not break existing specs, since if this isn't specified, we will defer to default configurations in all cases. The addition of a parameter configuration allows to override these defaults in the code.

This will get us closer to being able to do something like #355 and enables us to implement globally defined systematics such as luminosity uncertainty in #352 .

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
- Expand the spec to allow for optional parameter configuration
- Remove op_code from the paramset requirements
- Refactor to allow for op_code to be less hard-coded in pyhf/pdf::_modifications
```