### PR TITLE
Remove --qualify-names option from the CLI

### DIFF
--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -72,8 +72,7 @@ def json2xml(workspace, xmlfile, specroot, dataroot):
 )
 @click.option('--measurement', default=None)
 @click.option('-p', '--patch', multiple=True)
-@click.option('--qualify-names/--no-qualify-names', default=False)
-def cls(workspace, output_file, measurement, qualify_names, patch):
+def cls(workspace, output_file, measurement, patch):
     with click.open_file(workspace, 'r') as specstream:
         d = json.load(specstream)
     measurements = d['toplvl']['measurements']
@@ -105,11 +104,7 @@ def cls(workspace, output_file, measurement, qualify_names, patch):
             with click.open_file(p, 'r') as read_file:
                 p = jsonpatch.JsonPatch(json.loads(read_file.read()))
             spec = p.apply(spec)
-        p = Model(
-            spec,
-            poiname=measurements[measurement_index]['config']['poi'],
-            qualify_names=qualify_names,
-        )
+        p = Model(spec, poiname=measurements[measurement_index]['config']['poi'])
         observed = sum((d['data'][c] for c in p.config.channels), []) + p.config.auxdata
         result = hypotest(1.0, observed, p, return_expected_set=True)
         result = {

--- a/pyhf/paramsets.py
+++ b/pyhf/paramsets.py
@@ -62,7 +62,7 @@ def reduce_paramset_requirements(paramset_requirements):
         for k in param_keys:
             if len(combined_param[k]) != 1 and k != 'op_code':
                 raise exceptions.InvalidNameReuse(
-                    "Multiple values for '{}' ({}) were found for {}. Use unique modifier names or use qualify_names=True when constructing the pdf.".format(
+                    "Multiple values for '{}' ({}) were found for {}. Use unique modifier names when constructing the pdf.".format(
                         k, list(combined_param[k]), param_name
                     )
                 )

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 
 
 class _ModelConfig(object):
-    def __init__(self, spec, poiname='mu', qualify_names=False):
+    def __init__(self, spec, poiname='mu'):
         self.poi_index = None
         self.par_map = {}
         self.par_order = []
@@ -37,13 +37,6 @@ class _ModelConfig(object):
                 self.samples.append(sample['name'])
                 for modifier_def in sample['modifiers']:
                     self.parameters.append(modifier_def['name'])
-                    if qualify_names:
-                        fullname = '{}/{}'.format(
-                            modifier_def['type'], modifier_def['name']
-                        )
-                        if modifier_def['name'] == poiname:
-                            poiname = fullname
-                        modifier_def['name'] = fullname
 
                     # get the paramset requirements for the given modifier. If
                     # modifier does not exist, we'll have a KeyError
@@ -62,8 +55,8 @@ class _ModelConfig(object):
                         (
                             modifier_def['name'],  # mod name
                             modifier_def['type'],  # mod type
-                            modifier_def['name'],
-                        )  # parset name
+                            modifier_def['name'],  # parset name
+                        )
                     )
 
                     # check the shareability (e.g. for shapesys for example)

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -372,6 +372,4 @@ def test_invalid_modifier_name_resuse():
         ]
     }
     with pytest.raises(pyhf.exceptions.InvalidNameReuse):
-        pdf = pyhf.Model(spec, poiname='reused_name')
-
-    pdf = pyhf.Model(spec, poiname='reused_name')
+        pyhf.Model(spec, poiname='reused_name')

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -374,4 +374,4 @@ def test_invalid_modifier_name_resuse():
     with pytest.raises(pyhf.exceptions.InvalidNameReuse):
         pdf = pyhf.Model(spec, poiname='reused_name')
 
-    pdf = pyhf.Model(spec, poiname='reused_name', qualify_names=True)
+    pdf = pyhf.Model(spec, poiname='reused_name')


### PR DESCRIPTION
# Description

Resolves #357 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
- Remove obsolete --qualify-names CLI option
- Effectively revert PR #233
- Remove corresponding qualify_names arg from _ModelConfig and logic to remove the functionality of that keyword arg from Model. Additionally remove it from use in tests and from exception hints.
```
