### PR TITLE
Lock TensorFlow to be below v1.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as readme_md
 
 extras_require = {
     'tensorflow': [
-        'tensorflow>=1.10.0',
+        'tensorflow<1.12.0,>=1.10.0',
         'tensorflow-probability==0.3.0',
         'numpy<=1.14.5,>=1.14.0',  # Lower of 1.14.0 instead of 1.13.3 to ensure doctest pass
         'setuptools<=39.1.0',


### PR DESCRIPTION
# Description

Resolve #360 

This is a temporary measure until Issue #361 can be implemented, which itself is waiting on Issue #330. So the release of TensorFlow Probability `v0.5.0` will be a big one for us.

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
- As TensorFlow probability 
```
