### PR TITLE
adding cache dictionary to open root files only once in readxml

### DIFF
--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -39,6 +39,7 @@ def xml2json(entrypoint_xml, basedir, output_file, track_progress):
     """ Entrypoint XML: The top-level XML file for the PDF definition. """
     try:
         import uproot
+        assert uproot
     except ImportError:
         log.error(
             "xml2json requires uproot, please install pyhf using the "

--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -46,6 +46,7 @@ def xml2json(entrypoint_xml, basedir, output_file, track_progress):
             "manually: pip install uproot"
         )
     from . import readxml
+
     spec = readxml.parse(entrypoint_xml, basedir, track_progress=track_progress)
     if output_file is None:
         print(json.dumps(spec, indent=4, sort_keys=True))

--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -6,10 +6,6 @@ import os
 import jsonpatch
 import sys
 
-try:
-    from . import readxml
-except ImportError:
-    pass # readxml not needed with json input
 from . import writexml
 from .utils import hypotest
 from .pdf import Model
@@ -41,6 +37,15 @@ def pyhf():
 @click.option('--track-progress/--hide-progress', default=True)
 def xml2json(entrypoint_xml, basedir, output_file, track_progress):
     """ Entrypoint XML: The top-level XML file for the PDF definition. """
+    try:
+        import uproot
+    except ImportError:
+        log.error(
+            "xml2json requires uproot, please install pyhf using the "
+            "xmlimport extra: pip install pyhf[xmlimport] or install uproot "
+            "manually: pip install uproot"
+        )
+    from . import readxml
     spec = readxml.parse(entrypoint_xml, basedir, track_progress=track_progress)
     if output_file is None:
         print(json.dumps(spec, indent=4, sort_keys=True))

--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -6,7 +6,10 @@ import os
 import jsonpatch
 import sys
 
-from . import readxml
+try:
+    from . import readxml
+except ImportError:
+    pass # readxml not needed with json input
 from . import writexml
 from .utils import hypotest
 from .pdf import Model

--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -39,6 +39,7 @@ def xml2json(entrypoint_xml, basedir, output_file, track_progress):
     """ Entrypoint XML: The top-level XML file for the PDF definition. """
     try:
         import uproot
+
         assert uproot
     except ImportError:
         log.error(

--- a/pyhf/readxml.py
+++ b/pyhf/readxml.py
@@ -10,6 +10,7 @@ log = logging.getLogger(__name__)
 
 __FILECACHE__ = {}
 
+
 def extract_error(h):
     """
     Determine the bin uncertainties for a histogram.

--- a/pyhf/readxml.py
+++ b/pyhf/readxml.py
@@ -26,13 +26,18 @@ def extract_error(h):
     return np.sqrt(err).tolist()
 
 
-def import_root_histogram(rootdir, filename, path, name):
+def import_root_histogram(rootdir, filename, path, name, filecache={}):
     import uproot
 
     # strip leading slashes as uproot doesn't use "/" for top-level
     path = path or ''
     path = path.strip('/')
-    f = uproot.open(os.path.join(rootdir, filename))
+    fullpath = os.path.join(rootdir, filename)
+    if not fullpath in filecache:
+        f = uproot.open(fullpath)
+        filecache[fullpath] = f
+    else:
+        f = filecache[fullpath]
     try:
         h = f[name]
     except KeyError:

--- a/pyhf/readxml.py
+++ b/pyhf/readxml.py
@@ -7,6 +7,7 @@ import tqdm
 
 log = logging.getLogger(__name__)
 
+__FILECACHE__ = {}
 
 def extract_error(h):
     """
@@ -26,7 +27,10 @@ def extract_error(h):
     return np.sqrt(err).tolist()
 
 
-def import_root_histogram(rootdir, filename, path, name, filecache={}):
+def import_root_histogram(rootdir, filename, path, name, filecache=None):
+    global __FILECACHE__
+    filecache = filecache or __FILECACHE__
+
     import uproot
 
     # strip leading slashes as uproot doesn't use "/" for top-level
@@ -204,3 +208,7 @@ def parse(configfile, rootdir, track_progress=False):
         'channels': [{'name': k, 'samples': v['samples']} for k, v in channels.items()],
         'data': {k: v['data'] for k, v in channels.items()},
     }
+
+
+def clear_filecache():
+    __FILECACHE__ = {}

--- a/pyhf/readxml.py
+++ b/pyhf/readxml.py
@@ -4,6 +4,7 @@ import os
 import xml.etree.ElementTree as ET
 import numpy as np
 import tqdm
+import uproot
 
 log = logging.getLogger(__name__)
 
@@ -30,8 +31,6 @@ def extract_error(h):
 def import_root_histogram(rootdir, filename, path, name, filecache=None):
     global __FILECACHE__
     filecache = filecache or __FILECACHE__
-
-    import uproot
 
     # strip leading slashes as uproot doesn't use "/" for top-level
     path = path or ''

--- a/pyhf/readxml.py
+++ b/pyhf/readxml.py
@@ -211,4 +211,5 @@ def parse(configfile, rootdir, track_progress=False):
 
 
 def clear_filecache():
+    global __FILECACHE__
     __FILECACHE__ = {}

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ extras_require = {
         'pyflakes',
         'pytest>=3.5.1',
         'pytest-cov>=2.5.1',
+        'pytest-mock',
         'pytest-benchmark[histogram]',
         'pytest-console-scripts',
         'python-coveralls',

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -113,6 +113,8 @@ def test_import_filecache(mocker):
     )
 
     # check if uproot.open was only called once with the expected root file
-    pyhf.readxml.uproot.open.assert_called_once_with(os.path.join("validation/xmlimport_input", "./data/example.root"))
+    pyhf.readxml.uproot.open.assert_called_once_with(
+        os.path.join("validation/xmlimport_input", "./data/example.root")
+    )
 
     assert_equal_dictionary(parsed_xml, parsed_xml2)

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -99,9 +99,6 @@ def test_import_histosys():
 
 def test_import_filecache(mocker):
 
-    # uproot is dynamically imported in readxml, so to wrap it we need to set it now
-    pyhf.readxml.uproot = uproot
-
     mocker.patch("pyhf.readxml.uproot.open", wraps=uproot.open)
 
     pyhf.readxml.clear_filecache()

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -8,7 +8,7 @@ import os
 def assert_equal_dictionary(d1, d2):
     "recursively compare 2 dictionaries"
     for k in d1.keys():
-        assert d2.has_key(k) == True
+        assert k in d2
         if type(d1[k]) is dict:
             assert_equal_dictionary(d1[k], d2[k])
         else:


### PR DESCRIPTION
# Description
Hi,

The xml parser (re-)opens the histogram rootfiles for each histogram. This can slow down the process extremely when there are many histograms in one rootfile (as is the case if one creates the xml and histograms with HistFitter). This might be easily avoided by adding a dictionary somewhere that tracks which files have already been opened.
My current solution is probably not the cleanest way  to do this (no way clean up of the dictionary), but it shows that the approach is effective. I tried it for an example with ~100k Histograms in one rootfile which seemed to take forever without that fix (i aborted it after 2 hours). With the cache dictionary it took a few minutes to generate the json file.
Maybe somebody has a good idea on how to incorporate this.

(remark: HistFactory's hist2workspace has the same issue, but there it is probably more involved to fix it)

Cheers,
Nikolai

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [ ] "WIP" removed from the title of the pull request
- [ ] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [ ] Summarize commit messages into a comprehensive review of the PR
