### PR TITLE
Fix location of lumi uncertainty completion in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ Implemented variations:
 - [x] Import from XML + ROOT via [uproot](https://github.com/scikit-hep/uproot)
 - [x] ShapeFactor
 - [x] StatError
+- [x] Lumi Uncertainty
 
 Computational Backends:
 - [x] NumPy
 - [x] PyTorch
 - [x] TensorFlow
 - [x] MXNet
-- [x] Lumi Uncertainty
 
 Available Optimizers
 


### PR DESCRIPTION
# Description

This fixes #371. Documentation change only. Updates location of lumi uncertainty completion checkbox in readme.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR