### PR TITLE
only run coveralls after python3.6 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ script:
   - pyflakes pyhf
   - pytest -r sx --ignore tests/benchmarks/ --ignore tests/test_notebooks.py
   - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then black --check --diff --verbose .; fi
-after_success: coveralls
 
 # always test (on both 'push' and 'pr' builds in Travis)
 # test docs on 'pr' builds and 'push' builds on master
@@ -43,6 +42,7 @@ jobs:
     python: '3.6'
     script:
       - pytest tests/test_notebooks.py
+    after_success: coveralls
   - stage: benchmark
     python: '3.6'
     before_install:


### PR DESCRIPTION
# Description

Notice from time to time that the coverage of master goes awry. This is because every single success in our travis build matrix is sending its results to coveralls. Sometimes, like in doc-building, we don't cover everything (e.g. 50%) because it's just building documentation and not actually testing. And sometimes this gets sent to coveralls after the python tests run, and sometimes before. This is a race condition, but also explains why it shows up from time to time.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
