### PR TITLE
Make extract_error compliant with uproot-methods v0.3.0 API

### DIFF
--- a/pyhf/readxml.py
+++ b/pyhf/readxml.py
@@ -20,12 +20,12 @@ def extract_error(h):
     bin uncertainties are then Poisson, and so the `sqrt(entries)`.
 
     Args:
-        h: The histogram
+        h (uproot.rootio.TH1 object): The histogram
 
     Returns:
         list: The uncertainty for each bin in the histogram
     """
-    err = h.variances if h.variances else h.numpy()[0]
+    err = h.variances if h.variances.any() else h.numpy()[0]
     return np.sqrt(err).tolist()
 
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ extras_require = {
         'numpy<=1.14.5,>=1.14.0',  # Lower of 1.14.0 instead of 1.13.3 to ensure doctest pass
         'setuptools<=39.1.0',
     ],
-    'torch': ['torch<1.0.0,>=0.4.0'],
+    'torch': ['torch>=1.0.0'],
     'mxnet': [
         'mxnet>=1.0.0',
         'requests<2.19.0,>=2.18.4',

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ extras_require = {
         'matplotlib',
         'jupyter',
         'nbdime',
-        'uproot>=3.0.0',
+        'uproot>=3.3.0',
         'papermill>=0.16.0',
         'graphviz',
         'bumpversion',

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ extras_require = {
         'numpy<=1.14.5,>=1.14.0',  # Lower of 1.14.0 instead of 1.13.3 to ensure doctest pass
         'setuptools<=39.1.0',
     ],
-    'torch': ['torch<1.0.0'],
+    'torch': ['torch<1.0.0,>=0.4.0'],
     'mxnet': [
         'mxnet>=1.0.0',
         'requests<2.19.0,>=2.18.4',

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ extras_require = {
         'numpy<=1.14.5,>=1.14.0',  # Lower of 1.14.0 instead of 1.13.3 to ensure doctest pass
         'setuptools<=39.1.0',
     ],
-    'torch': ['torch>=0.4.0'],
+    'torch': ['torch<1.0.0'],
     'mxnet': [
         'mxnet>=1.0.0',
         'requests<2.19.0,>=2.18.4',

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ extras_require = {
         'numpy<=1.14.5,>=1.14.0',  # Lower of 1.14.0 instead of 1.13.3 to ensure doctest pass
         'setuptools<=39.1.0',
     ],
-    'torch': ['torch>=1.0.0'],
+    'torch': ['torch<1.0.0,>=0.4.0'],
     'mxnet': [
         'mxnet>=1.0.0',
         'requests<2.19.0,>=2.18.4',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import torch  # Solves "cannot load any more object with static TLS" (thread local storage) error
 import pytest
 import pyhf
 import tensorflow as tf

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import torch  # Solves "cannot load any more object with static TLS" (thread local storage) error
 import pytest
 import pyhf
 import tensorflow as tf


### PR DESCRIPTION
# Description

`tests/test_import.py` give an error of

```
E       ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

in `extract_error` due to a change in the return structure of `uproot-methods` `TH1.variances` return structure in [`uproot_methods` PR 21](https://github.com/scikit-hep/uproot-methods/pull/21) where the returned value [changed from a list to a `numpy.array`](https://github.com/scikit-hep/uproot-methods/commit/c2a78e4e05eb710c74d5c6ec5d017f70af28566b#diff-67fbe39413c91feb6ad80acd70f76d47).

This change was introduced in [`uproot-methods` release `v0.3.0`](https://github.com/scikit-hep/uproot-methods/releases/tag/0.3.0)

This necessitated a change in the query of `h.variances` on the pyhf side.

This PR is also affecting PR #377 and PR #378 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use h.variances.any() to match the numpy.array return structure of the variances property of uproot-methods TH1 objects introduced in uproot-methods v0.3.0
* Require uproot v3.3.0 or newer, which requires uproot-methods v0.3.0 or newer
* Temporarily pin PyTorch to be below v1.0 for the following PR to fix
```
