### PR TITLE
Require PyTorch v1.0 or newer and fix static TLS load error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ extras_require = {
         'numpy<=1.14.5,>=1.14.0',  # Lower of 1.14.0 instead of 1.13.3 to ensure doctest pass
         'setuptools<=39.1.0',
     ],
-    'torch': ['torch<1.0.0,>=0.4.0'],
+    'torch': ['torch>=1.0.0'],
     'mxnet': [
         'mxnet>=1.0.0',
         'requests<2.19.0,>=2.18.4',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import torch  # Solves "cannot load any more object with static TLS" (thread local storage) error
 import pytest
 import pyhf
 import tensorflow as tf


### PR DESCRIPTION
# Description

- Together with PR #379 fixes the CI for 2018 going into 2019.
- This PR needs to be rebased against `master` after PR #379 is accepted.
- This PR is also affecting PR #377 and PR #378.
- One reoccurring problem seems to be(?) that the `v1.0` release of PyTorch is [causing issues with memory allocation in Travis](https://travis-ci.org/diana-hep/pyhf/jobs/473431783#L481-L483) resulting in errors or segfault 11.

In requiring the latest version of PyTorch (v1.0) the loading of it after other imports in `tests/conftest.py` causes there to be an [error during setup of the pytest fixtures](https://travis-ci.org/diana-hep/pyhf/jobs/473509231#L650-L655)

```
ImportError while loading conftest '/home/travis/build/diana-hep/pyhf/tests/conftest.py'.
tests/conftest.py:45: in <module>
    (pyhf.tensor.pytorch_backend(), None),
pyhf/tensor/__init__.py:24: in __getattr__
    e,
E   pyhf.exceptions.ImportBackendError: ('There was a problem importing PyTorch. The pytorch backend cannot be used.', ImportError('dlopen: cannot load any more object with static TLS',))
```

TLS appears to stand for thread local storage

* https://stackoverflow.com/questions/19268293/matlab-error-cannot-open-with-static-tls

and seems to be a reoccurring issue with PyTorch. The advice for how to deal with it from PyTorch [Issue 2083](https://github.com/pytorch/pytorch/issues/2083) and [Issue 2575](https://github.com/pytorch/pytorch/issues/2575) seems to be to simply change the import order so that

`import torch`

is always the first import in the files that are causing the issue. The rational for this fix is not understood to me, other then it just makes sure that libraries that (presumably) require a large amount of static TLS are dealt with first.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Require PyTorch v1.0 or newer
* Make torch the first import in tests/conftest.py to solve the "cannot load any more object with static TLS" (thread local storage) error that is common when using PyTorch along with other large libraries. c.f. PyTorch Issue 2083.
```
