### PR TITLE
Fix corrupted size vs. prev_size memory error in CI benchmark stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ after_success: coveralls
 stages:
   - test
   - name: benchmark
-    # if: (branch = master) AND (NOT (type IN (pull_request)))
+    if: (branch = master) AND (NOT (type IN (pull_request)))
   - name: docs
     if: (branch = master)
   - name: deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ after_success: coveralls
 stages:
   - test
   - name: benchmark
-    if: (branch = master) AND (NOT (type IN (pull_request)))
+    # if: (branch = master) AND (NOT (type IN (pull_request)))
   - name: docs
     if: (branch = master)
   - name: deploy
@@ -48,6 +48,8 @@ jobs:
   - stage: benchmark
     python: '3.6'
     before_install:
+      - sudo apt-get install libtcmalloc-minimal4
+      - export LD_PRELOAD="/usr/lib/libtcmalloc_minimal.so.4"
       - pip install --upgrade pip setuptools wheel
     install:
       - pip install --ignore-installed -U -q -e .[complete]


### PR DESCRIPTION
# Description

In the merge of PR #379 into `master` it was seen that the [benchmark CI stage failed with the memory error of](https://travis-ci.org/diana-hep/pyhf/jobs/474501916#L859-L861)

```
*** Error in `/home/travis/virtualenv/python3.6.3/bin/python': corrupted size vs. prev_size: 0x0000000000c2de00 ***
/home/travis/.travis/job_stages: line 104:  4633 Aborted                 (core dumped) pytest -r sx --benchmark-sort=mean tests/benchmarks/
The command "pytest -r sx --benchmark-sort=mean tests/benchmarks/" exited with 134.
```

This error had been [seen before in Issue #67](https://github.com/diana-hep/pyhf/issues/67#issuecomment-378529720) and @kratsg provided a [fix for a relevant similar memory issue in PR #296](https://github.com/diana-hep/pyhf/pull/296#issuecomment-427536326). Applying that same fix, of installing and exporting the path for `libtcmalloc-minimal4` during `before_install` has provided a [passing build with the benchmark CI stage in a test](https://travis-ci.org/diana-hep/pyhf/builds/474967137), so it seems that this should revolve the issue here as well.

# Checklist Before Requesting Reviewer 

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Install and export the path for libtcmalloc-minimal4 during before_install for the benchmark stage of Travis CI to avoid a corrupted size vs. prev_size memory error. c.f. PR 296 for additional reference.
```
