### PR TITLE
Use python -m pytest to avoid segfault in Python 2.7 Travis notebook tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   - pip freeze
 script:
   - pyflakes pyhf
-  - pytest -r sx --ignore tests/benchmarks/ --ignore tests/test_notebooks.py
+  - python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/test_notebooks.py
   - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then black --check --diff --verbose .; fi
 after_success: coveralls
 
@@ -40,12 +40,12 @@ jobs:
   - name: "Python 2.7 Notebook Tests"
     python: '2.7'
     script:
-      - pytest tests/test_notebooks.py
+      - python -m pytest tests/test_notebooks.py
     after_success: skip
   - name: "Python 3.6 Notebook Tests"
     python: '3.6'
     script:
-      - pytest tests/test_notebooks.py
+      - python -m pytest tests/test_notebooks.py
     after_success: skip
   - stage: benchmark
     python: '3.6'
@@ -56,7 +56,7 @@ jobs:
     install:
       - pip install --ignore-installed -U -q -e .[complete]
       - pip freeze
-    script: pytest -r sx --benchmark-sort=mean tests/benchmarks/
+    script: python -m pytest -r sx --benchmark-sort=mean tests/benchmarks/
     after_success: skip
   - stage: docs
     python: '3.6'


### PR DESCRIPTION
# Description

Related to Issue #385 (it _fixes_ it, but doesn't _resolve_ it)

Issues with calling `pytest` vs. `python -m pytest` are known as in the [pytest docs it is mentioned that](https://docs.pytest.org/en/latest/pythonpath.html#invoking-pytest-versus-python-m-pytest)

> Running `pytest` with `python -m pytest [...]` instead of `pytest [...]` yields nearly equivalent behaviour, except that the former call will add the current directory to `sys.path`. See also [Calling pytest through python -m pytest](https://docs.pytest.org/en/latest/usage.html#cmdline).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
Use python -m pytest to call pytest. This is done as it has been empirically observed that a segfault only noticed in the Python 2.7 version of the notebook tests on Travis CI doesn't occur if python -m pytest is called while it does occur if only pytest is called.
```