### PR TITLE
Remove --ignore-installed pip install option flag in binder/postBuild

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,1 +1,1 @@
-pip install --ignore-installed -U -e .[complete]
+pip install --upgrade -e .[complete]


### PR DESCRIPTION
# Description

Resolves #389 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
At minrk's suggestion the --ignore-installed flag is removed from the pip install in binder/postBuild
c.f. https://gitter.im/jupyterhub/binder?at=5c38af3e2e25e453d7662b05
```