### PR TITLE
Use curl to trigger Binder build API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ jobs:
     install: skip
     script:
       # Use Binder build API to trigger repo2docker to build image
-      - python -m webbrowser "https://mybinder.org/build/gh/diana-hep/pyhf/master"
+      - curl https://mybinder.org/build/gh/diana-hep/pyhf/master
     after_success: skip
   - stage: deploy
     python: '3.6'


### PR DESCRIPTION
# Description

As a follow up to PR #383, use `curl` to access the Binder build API instead of `python -m webbrowser`. The only thing that needs to be done is for the build API endpoint to receive the request and so the simpler the tool used the better. Along these lines, there were some instances in which `python -m webbrowser` would suffer a timeout error resulting in a failed Binder stage. This is not an issue with `curl`.

This PR requires PR #387 to be merged in first.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use curl to trigger the Binder build API instead of python -m webbrowser to avoid any potential timeout errors
```
