### PR TITLE
Add configurable optimizer (and options) through pyhf cls CLI

### DIFF
--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -4,7 +4,7 @@ import click
 import json
 import os
 
-from .utils import hypotest
+from .utils import hypotest, EqDelimStringParamType
 from .pdf import Workspace
 from .version import __version__
 
@@ -222,6 +222,7 @@ def inspect(workspace, output_file, measurement):
 @click.option('--testpoi', default=1.0)
 @click.option('--teststat', type=click.Choice(['q', 'qtilde']), default='qtilde')
 @click.option('--optimizer')
+@click.option('--optconf', type=EqDelimStringParamType(), multiple=True)
 @click.option('-n', '--max-iterations', default=1000)
 def cls(
     workspace,
@@ -231,6 +232,7 @@ def cls(
     testpoi,
     teststat,
     optimizer,
+    optconf,
     max_iterations,
 ):
     with click.open_file(workspace, 'r') as specstream:
@@ -246,6 +248,8 @@ def cls(
         patches=patches,
         modifier_settings={'normsys': {'interpcode': 'code4'}},
     )
+
+    optconf = {k: v for item in optconf for k, v in item.items()}
 
     # set the new optimizer
     if optimizer:

--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -221,7 +221,7 @@ def inspect(workspace, output_file, measurement):
 @click.option('-p', '--patch', multiple=True)
 @click.option('--testpoi', default=1.0)
 @click.option('--teststat', type=click.Choice(['q', 'qtilde']), default='qtilde')
-@click.option('--optimizer', default='scipy_optimizer')
+@click.option('--optimizer')
 @click.option('-n', '--max-iterations', default=1000)
 def cls(
     workspace,
@@ -248,7 +248,7 @@ def cls(
     )
 
     # set the new optimizer
-    if optimizer != 'scipy_optimizer':
+    if optimizer:
         new_optimizer = None
         try:
             new_optimizer = getattr(pyhf.optimize, optimizer)(maxiter=max_iterations)

--- a/pyhf/exceptions/__init__.py
+++ b/pyhf/exceptions/__init__.py
@@ -70,3 +70,9 @@ class ImportBackendError(Exception):
     """
 
     pass
+
+
+class InvalidOptimizer(Exception):
+    """
+    InvalidOptimizer is raised when trying to set using an optimizer that does not exist.
+    """

--- a/pyhf/optimize/__init__.py
+++ b/pyhf/optimize/__init__.py
@@ -49,6 +49,8 @@ class _OptimizerRetriever(object):
                     "There was a problem importing Minuit. The minuit optimizer cannot be used.",
                     e,
                 )
+        elif name == '__wrapped__':  # doctest
+            pass
         else:
             raise exceptions.InvalidOptimizer(
                 "The requested optimizer \"{0:s}\" does not exist.".format(name)

--- a/pyhf/optimize/__init__.py
+++ b/pyhf/optimize/__init__.py
@@ -49,6 +49,10 @@ class _OptimizerRetriever(object):
                     "There was a problem importing Minuit. The minuit optimizer cannot be used.",
                     e,
                 )
+        else:
+            raise exceptions.InvalidOptimizer(
+                "The requested optimizer \"{0:s}\" does not exist.".format(name)
+            )
 
 
 OptimizerRetriever = _OptimizerRetriever()

--- a/pyhf/optimize/opt_scipy.py
+++ b/pyhf/optimize/opt_scipy.py
@@ -5,8 +5,8 @@ log = logging.getLogger(__name__)
 
 
 class scipy_optimizer(object):
-    def __init__(self):
-        pass
+    def __init__(self, **kwargs):
+        self.maxiter = kwargs.get('maxiter', 100000)
 
     def unconstrained_bestfit(self, objective, data, pdf, init_pars, par_bounds):
         # The Global Fit
@@ -16,7 +16,7 @@ class scipy_optimizer(object):
             method='SLSQP',
             args=(data, pdf),
             bounds=par_bounds,
-            options=dict(maxiter=100000),
+            options=dict(maxiter=self.maxiter),
         )
         try:
             assert result.success
@@ -37,7 +37,7 @@ class scipy_optimizer(object):
             method='SLSQP',
             args=(data, pdf),
             bounds=par_bounds,
-            options=dict(maxiter=100000),
+            options=dict(maxiter=self.maxiter),
         )
         try:
             assert result.success

--- a/pyhf/optimize/opt_tflow.py
+++ b/pyhf/optimize/opt_tflow.py
@@ -6,11 +6,11 @@ log = logging.getLogger(__name__)
 
 
 class tflow_optimizer(object):
-    def __init__(self, tensorlib):
+    def __init__(self, tensorlib, **kwargs):
         self.tb = tensorlib
-        self.relax = 0.1
-        self.maxit = 1000
-        self.eps = 1e-4
+        self.relax = kwargs.get('relax', 0.1)
+        self.maxiter = kwargs.get('maxiter', 100000)
+        self.eps = kwargs.get('eps', 1e-4)
 
     def unconstrained_bestfit(self, objective, data, pdf, init_pars, par_bounds):
         # the graph
@@ -26,7 +26,7 @@ class tflow_optimizer(object):
 
         # run newton's method
         best_fit = init_pars
-        for i in range(self.maxit):
+        for i in range(self.maxiter):
             up = self.tb.session.run(update, feed_dict={pars: best_fit})
             best_fit = best_fit - self.relax * up
             if np.abs(np.max(up)) < self.eps:
@@ -65,7 +65,7 @@ class tflow_optimizer(object):
         best_fit_nuis = [
             x for i, x in enumerate(init_pars) if i != pdf.config.poi_index
         ]
-        for i in range(self.maxit):
+        for i in range(self.maxiter):
             up = self.tb.session.run(update, feed_dict={nuis_cat: best_fit_nuis})
             best_fit_nuis = best_fit_nuis - self.relax * up
             if np.abs(np.max(up)) < self.eps:

--- a/pyhf/utils.py
+++ b/pyhf/utils.py
@@ -48,7 +48,7 @@ def validate(spec, schema_name):
 
 
 def options_from_eqdelimstring(opts):
-    document = '\n'.join('{0}: {1}'.format(*opt.split('=')) for opt in opts)
+    document = '\n'.join('{0}: {1}'.format(*opt.split('=', 1)) for opt in opts)
     return yaml.full_load(document)
 
 

--- a/pyhf/utils.py
+++ b/pyhf/utils.py
@@ -2,6 +2,7 @@ import json
 import jsonschema
 import pkg_resources
 import os
+import yaml
 
 from .exceptions import InvalidSpecification
 from . import get_backend
@@ -44,6 +45,11 @@ def validate(spec, schema_name):
         return validator.validate(spec)
     except jsonschema.ValidationError as err:
         raise InvalidSpecification(err)
+
+
+def options_from_eqdelimstring(opts):
+    document = '\n'.join('{0}: {1}'.format(*opt.split('=')) for opt in opts)
+    return yaml.full_load(document)
 
 
 def loglambdav(pars, data, pdf):

--- a/pyhf/utils.py
+++ b/pyhf/utils.py
@@ -3,6 +3,7 @@ import jsonschema
 import pkg_resources
 import os
 import yaml
+import click
 
 from .exceptions import InvalidSpecification
 from . import get_backend
@@ -50,6 +51,18 @@ def validate(spec, schema_name):
 def options_from_eqdelimstring(opts):
     document = '\n'.join('{0}: {1}'.format(*opt.split('=', 1)) for opt in opts)
     return yaml.full_load(document)
+
+
+class EqDelimStringParamType(click.ParamType):
+    name = 'equal-delimited option'
+
+    def convert(self, value, param, ctx):
+        try:
+            return options_from_eqdelimstring([value])
+        except IndexError:
+            self.fail(
+                '{0:s} is not a valid equal-delimited string'.format(value), param, ctx
+            )
 
 
 def loglambdav(pars, data, pdf):

--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,7 @@ setup(
         'six',  # for modifiers
         'jsonschema>=v3.0.0a2',  # for utils, alpha-release for draft 6
         'jsonpatch',
+        'pyyaml',  # for parsing CLI equal-delimited options
     ],
     extras_require=extras_require,
     entry_points={'console_scripts': ['pyhf=pyhf.commandline:pyhf']},

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -2,6 +2,11 @@ import pyhf
 import pytest
 
 
+def test_get_invalid_optimizer():
+    with pytest.raises(pyhf.exceptions.InvalidOptimizer):
+        assert pyhf.optimize.scipy
+
+
 @pytest.fixture(scope='module')
 def source():
     source = {

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -2,6 +2,7 @@ import json
 import shlex
 import pyhf
 import time
+import pytest
 
 
 def test_version(script_runner):
@@ -204,6 +205,25 @@ def test_testpoi(tmpdir, script_runner):
         assert not np.array_equal(*pair)
 
     assert len(list(set(results_obs))) == len(pois)
+
+
+@pytest.mark.parametrize(
+    'opts,success',
+    [(['maxiter=1000'], True), (['maxiter=100'], True), (['maxiter=10'], False)],
+)
+def test_cls_optimizer(tmpdir, script_runner, opts, success):
+    temp = tmpdir.join("parsed_output.json")
+    command = 'pyhf xml2json validation/xmlimport_input/config/example.xml --basedir validation/xmlimport_input/ --output-file {0:s}'.format(
+        temp.strpath
+    )
+    ret = script_runner.run(*shlex.split(command))
+
+    command = 'pyhf cls {0:s} --optimizer scipy_optimizer {1:s}'.format(
+        temp.strpath, ' '.join('--optconf {0:s}'.format(opt) for opt in opts)
+    )
+    ret = script_runner.run(*shlex.split(command))
+
+    assert ret.success == success
 
 
 def test_inspect(tmpdir, script_runner):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,22 +17,20 @@ def test_load_missing_schema():
 
 
 @pytest.mark.parametrize(
-    'opt,obj',
+    'opts,obj',
     [
-        ('a=10', {'a': 10}),
-        ('b=test', {'b': 'test'}),
-        ('c=1.0e-8', {'c': 1.0e-8}),
-        ('d=3.14', {'d': 3.14}),
-        ('e=True', {'e': True}),
-        ('f=false', {'f': False}),
+        (['a=10'], {'a': 10}),
+        (['b=test'], {'b': 'test'}),
+        (['c=1.0e-8'], {'c': 1.0e-8}),
+        (['d=3.14'], {'d': 3.14}),
+        (['e=True'], {'e': True}),
+        (['f=false'], {'f': False}),
+        (['a=b', 'c=d'], {'a': 'b', 'c': 'd'}),
+        (['g=h=i'], {'g': 'h=i'}),
     ],
 )
-def test_options_from_eqdelimstring(opt, obj):
-    assert pyhf.utils.options_from_eqdelimstring([opt]) == obj
-
-
-def test_options_from_eqdelimstrings():
-    assert pyhf.utils.options_from_eqdelimstring(['a=b', 'c=d']) == {'a': 'b', 'c': 'd'}
+def test_options_from_eqdelimstring(opts, obj):
+    assert pyhf.utils.options_from_eqdelimstring(opts) == obj
 
 
 @pytest.fixture(scope='module')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,6 +16,25 @@ def test_load_missing_schema():
         pyhf.utils.load_schema('fake_schema.json')
 
 
+@pytest.mark.parametrize(
+    'opt,obj',
+    [
+        ('a=10', {'a': 10}),
+        ('b=test', {'b': 'test'}),
+        ('c=1.0e-8', {'c': 1.0e-8}),
+        ('d=3.14', {'d': 3.14}),
+        ('e=True', {'e': True}),
+        ('f=false', {'f': False}),
+    ],
+)
+def test_options_from_eqdelimstring(opt, obj):
+    assert pyhf.utils.options_from_eqdelimstring([opt]) == obj
+
+
+def test_options_from_eqdelimstrings():
+    assert pyhf.utils.options_from_eqdelimstring(['a=b', 'c=d']) == {'a': 'b', 'c': 'd'}
+
+
 @pytest.fixture(scope='module')
 def hypotest_args():
     pdf = pyhf.simplemodels.hepdata_like(


### PR DESCRIPTION
# Description

This updates the other optimizers to accept `maxiter` as a keyword argument for configuration. We should just keep this pretty consistent. This makes it easier for us to configure from the command line now for CLs. This might not be the best option, since we might want to support something like a `dotenv` to load default backend/optimizer instead...? Unclear.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
- raise an exception (InvalidOptimizer) if an optimizer is requested that does not exist
- allow for **kwargs for all optimizer initializations so we can extract out the additional options for configuration
- create click.ParamType (EqDelimStringParamType) to parse CLI options for configuring optimizer using equal-delimited key-value pairs, inspired by yadage
```