### PR TITLE
Add pyhf inspect

### DIFF
--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -143,12 +143,11 @@ def inspect(workspace, output_file, measurement):
 
     result['measurements'] = [
         (
-            ('(*) ' if measurement['name'] == default_measurement['name'] else '')
-            + measurement['name'],
-            measurement['config']['poi'],
-            [p['name'] for p in measurement['config']['parameters']],
+            ('(*) ' if m['name'] == default_measurement['name'] else '') + m['name'],
+            m['config']['poi'],
+            [p['name'] for p in m['config']['parameters']],
         )
-        for measurement in w.spec.get('measurements')
+        for m in w.spec.get('measurements')
     ]
 
     maxlen_channels = max(map(len, default_model.config.channels))

--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -147,16 +147,22 @@ def inspect(workspace, output_file, measurement):
 
     result = {}
     result['samples'] = p.config.samples
-    result['channels'] = [(channel, p.config.channel_nbins[channel]) for channel in p.config.channels]
+    result['channels'] = [
+        (channel, p.config.channel_nbins[channel]) for channel in p.config.channels
+    ]
     result['parameters'] = sorted(
-        (
-            parname,
-            p.config.par_map[parname]['paramset'].__class__.__name__
-        )
+        (parname, p.config.par_map[parname]['paramset'].__class__.__name__)
         for parname in p.config.parameters
     )
     result['systematics'] = [
-        (*parameter, [modifier[1] for modifier in p.config.modifiers if modifier[2] == parameter[0]])
+        (
+            *parameter,
+            [
+                modifier[1]
+                for modifier in p.config.modifiers
+                if modifier[2] == parameter[0]
+            ],
+        )
         for parameter in result['parameters']
     ]
     result['modifiers'] = p.config.modifiers
@@ -166,24 +172,25 @@ def inspect(workspace, output_file, measurement):
     maxlen = max([maxlen_channels, maxlen_samples, maxlen_parameters])
 
     # summary statistics
-    fmtStr = '{{0: >{0:d}s}}  {{1:s}}'.format(maxlen+len('Summary'))
-    print(fmtStr.format('Summary Statistics',''))
-    print(fmtStr.format('-'*18, ''))
+    fmtStr = '{{0: >{0:d}s}}  {{1:s}}'.format(maxlen + len('Summary'))
+    print(fmtStr.format('Summary Statistics', ''))
+    print(fmtStr.format('-' * 18, ''))
     fmtStr = '{{0: >{0:d}s}}  {{1:s}}'.format(maxlen)
     for key in ['channels', 'samples', 'parameters', 'modifiers']:
         print(fmtStr.format(key, str(len(result[key]))))
+    print(fmtStr.format('poi', measurements[measurement_index]['config']['poi']))
     print()
 
     fmtStr = '{{0: >{0:d}s}}  {{1: ^5s}}'.format(maxlen)
     print(fmtStr.format('channels', 'nbins'))
-    print(fmtStr.format('-'*10, '-'*5))
+    print(fmtStr.format('-' * 10, '-' * 5))
     for channel, nbins in result['channels']:
         print(fmtStr.format(channel, str(nbins)))
     print()
 
     fmtStr = '{{0: >{0:d}s}}'.format(maxlen)
     print(fmtStr.format('samples'))
-    print(fmtStr.format('-'*10))
+    print(fmtStr.format('-' * 10))
     for sample in result['samples']:
         print(fmtStr.format(sample))
     print()
@@ -191,7 +198,7 @@ def inspect(workspace, output_file, measurement):
     # print parameters, constraints, modifiers
     fmtStr = '{{0: >{0:d}s}}  {{1: <22s}}  {{2:s}}'.format(maxlen)
     print(fmtStr.format('parameters', 'constraint', 'modifiers'))
-    print(fmtStr.format('-'*10, '-'*10, '-'*10))
+    print(fmtStr.format('-' * 10, '-' * 10, '-' * 10))
     for parname, constraint, modtypes in result['systematics']:
         print(fmtStr.format(parname, constraint, ','.join(sorted(modtypes))))
     print()

--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -142,11 +142,7 @@ def inspect(workspace, output_file, measurement):
     result['modifiers'] = default_model.config.modifiers
 
     result['measurements'] = [
-        (
-            ('(*) ' if m['name'] == default_measurement['name'] else '') + m['name'],
-            m['config']['poi'],
-            [p['name'] for p in m['config']['parameters']],
-        )
+        (m['name'], m['config']['poi'], [p['name'] for p in m['config']['parameters']])
         for m in w.spec.get('measurements')
     ]
 
@@ -197,7 +193,8 @@ def inspect(workspace, output_file, measurement):
     ]:
         print(
             fmtStr.format(
-                measurement_name,
+                ('(*) ' if measurement_name == default_measurement['name'] else '')
+                + measurement_name,
                 measurement_poi,
                 ','.join(measurement_parameters)
                 if measurement_parameters

--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -158,9 +158,9 @@ def inspect(workspace, output_file, measurement):
         [maxlen_channels, maxlen_samples, maxlen_parameters, maxlen_measurements]
     )
 
-    # summary statistics
+    # summary
     fmtStr = '{{0: >{0:d}s}}  {{1:s}}'.format(maxlen + len('Summary'))
-    print(fmtStr.format('Summary Statistics', ''))
+    print(fmtStr.format('     Summary     ', ''))
     print(fmtStr.format('-' * 18, ''))
     fmtStr = '{{0: >{0:d}s}}  {{1:s}}'.format(maxlen)
     for key in ['channels', 'samples', 'parameters', 'modifiers']:

--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -57,7 +57,7 @@ def xml2json(entrypoint_xml, basedir, output_file, track_progress):
 
     spec = readxml.parse(entrypoint_xml, basedir, track_progress=track_progress)
     if output_file is None:
-        print(json.dumps(spec, indent=4, sort_keys=True))
+        click.echo(json.dumps(spec, indent=4, sort_keys=True))
     else:
         with open(output_file, 'w+') as out_file:
             json.dump(spec, out_file, indent=4, sort_keys=True)
@@ -156,42 +156,42 @@ def inspect(workspace, output_file, measurement):
 
     # summary
     fmtStr = '{{0: >{0:d}s}}  {{1:s}}'.format(maxlen + len('Summary'))
-    print(fmtStr.format('     Summary     ', ''))
-    print(fmtStr.format('-' * 18, ''))
+    click.echo(fmtStr.format('     Summary     ', ''))
+    click.echo(fmtStr.format('-' * 18, ''))
     fmtStr = '{{0: >{0:d}s}}  {{1:s}}'.format(maxlen)
     for key in ['channels', 'samples', 'parameters', 'modifiers']:
-        print(fmtStr.format(key, str(len(result[key]))))
-    print()
+        click.echo(fmtStr.format(key, str(len(result[key]))))
+    click.echo()
 
     fmtStr = '{{0: >{0:d}s}}  {{1: ^5s}}'.format(maxlen)
-    print(fmtStr.format('channels', 'nbins'))
-    print(fmtStr.format('-' * 10, '-' * 5))
+    click.echo(fmtStr.format('channels', 'nbins'))
+    click.echo(fmtStr.format('-' * 10, '-' * 5))
     for channel, nbins in result['channels']:
-        print(fmtStr.format(channel, str(nbins)))
-    print()
+        click.echo(fmtStr.format(channel, str(nbins)))
+    click.echo()
 
     fmtStr = '{{0: >{0:d}s}}'.format(maxlen)
-    print(fmtStr.format('samples'))
-    print(fmtStr.format('-' * 10))
+    click.echo(fmtStr.format('samples'))
+    click.echo(fmtStr.format('-' * 10))
     for sample in result['samples']:
-        print(fmtStr.format(sample))
-    print()
+        click.echo(fmtStr.format(sample))
+    click.echo()
 
     # print parameters, constraints, modifiers
     fmtStr = '{{0: >{0:d}s}}  {{1: <22s}}  {{2:s}}'.format(maxlen)
-    print(fmtStr.format('parameters', 'constraint', 'modifiers'))
-    print(fmtStr.format('-' * 10, '-' * 10, '-' * 10))
+    click.echo(fmtStr.format('parameters', 'constraint', 'modifiers'))
+    click.echo(fmtStr.format('-' * 10, '-' * 10, '-' * 10))
     for parname, constraint, modtypes in result['systematics']:
-        print(fmtStr.format(parname, constraint, ','.join(sorted(set(modtypes)))))
-    print()
+        click.echo(fmtStr.format(parname, constraint, ','.join(sorted(set(modtypes)))))
+    click.echo()
 
     fmtStr = '{{0: >{0:d}s}}  {{1: ^22s}}  {{2:s}}'.format(maxlen)
-    print(fmtStr.format('measurement', 'poi', 'parameters'))
-    print(fmtStr.format('-' * 10, '-' * 10, '-' * 10))
+    click.echo(fmtStr.format('measurement', 'poi', 'parameters'))
+    click.echo(fmtStr.format('-' * 10, '-' * 10, '-' * 10))
     for measurement_name, measurement_poi, measurement_parameters in result[
         'measurements'
     ]:
-        print(
+        click.echo(
             fmtStr.format(
                 ('(*) ' if measurement_name == default_measurement['name'] else '')
                 + measurement_name,
@@ -201,7 +201,7 @@ def inspect(workspace, output_file, measurement):
                 else '(none)',
             )
         )
-    print()
+    click.echo()
 
     if output_file:
         with open(output_file, 'w+') as out_file:
@@ -230,7 +230,7 @@ def cls(workspace, output_file, measurement, patch, testpoi):
     result = hypotest(testpoi, w.data(p), p, return_expected_set=True)
     result = {'CLs_obs': result[0].tolist()[0], 'CLs_exp': result[-1].ravel().tolist()}
     if output_file is None:
-        print(json.dumps(result, indent=4, sort_keys=True))
+        click.echo(json.dumps(result, indent=4, sort_keys=True))
     else:
         with open(output_file, 'w+') as out_file:
             json.dump(result, out_file, indent=4, sort_keys=True)

--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -108,6 +108,110 @@ def json2xml(workspace, output_dir, specroot, dataroot, resultprefix):
     default=None,
 )
 @click.option('--measurement', default=None)
+def inspect(workspace, output_file, measurement):
+    with click.open_file(workspace, 'r') as specstream:
+        d = json.load(specstream)
+    measurements = d['toplvl']['measurements']
+    measurement_names = [m['name'] for m in measurements]
+    measurement_index = 0
+
+    log.debug('measurements defined:\n\t{0:s}'.format('\n\t'.join(measurement_names)))
+    if measurement and measurement not in measurement_names:
+        log.error(
+            'no measurement by name \'{0:s}\' exists, pick from one of the valid ones above'.format(
+                measurement
+            )
+        )
+        sys.exit(1)
+    else:
+        if not measurement and len(measurements) > 1:
+            log.warning('multiple measurements defined. Taking the first measurement.')
+            measurement_index = 0
+        elif measurement:
+            measurement_index = measurement_names.index(measurement)
+
+        log.debug(
+            'calculating CLs for measurement {0:s}'.format(
+                measurements[measurement_index]['name']
+            )
+        )
+
+    spec = {
+        'channels': d['channels'],
+        'parameters': d['toplvl']['measurements'][measurement_index]['config'].get(
+            'parameters', []
+        ),
+    }
+
+    p = Model(spec, poiname=measurements[measurement_index]['config']['poi'])
+
+    result = {}
+    result['samples'] = p.config.samples
+    result['channels'] = [(channel, p.config.channel_nbins[channel]) for channel in p.config.channels]
+    result['parameters'] = sorted(
+        (
+            parname,
+            p.config.par_map[parname]['paramset'].__class__.__name__
+        )
+        for parname in p.config.parameters
+    )
+    result['systematics'] = [
+        (*parameter, [modifier[1] for modifier in p.config.modifiers if modifier[2] == parameter[0]])
+        for parameter in result['parameters']
+    ]
+    result['modifiers'] = p.config.modifiers
+    maxlen_channels = max(map(len, p.config.channels))
+    maxlen_samples = max(map(len, p.config.samples))
+    maxlen_parameters = max(map(len, p.config.parameters))
+    maxlen = max([maxlen_channels, maxlen_samples, maxlen_parameters])
+
+    # summary statistics
+    fmtStr = '{{0: >{0:d}s}}  {{1:s}}'.format(maxlen+len('Summary'))
+    print(fmtStr.format('Summary Statistics',''))
+    print(fmtStr.format('-'*18, ''))
+    fmtStr = '{{0: >{0:d}s}}  {{1:s}}'.format(maxlen)
+    for key in ['channels', 'samples', 'parameters', 'modifiers']:
+        print(fmtStr.format(key, str(len(result[key]))))
+    print()
+
+    fmtStr = '{{0: >{0:d}s}}  {{1: ^5s}}'.format(maxlen)
+    print(fmtStr.format('channels', 'nbins'))
+    print(fmtStr.format('-'*10, '-'*5))
+    for channel, nbins in result['channels']:
+        print(fmtStr.format(channel, str(nbins)))
+    print()
+
+    fmtStr = '{{0: >{0:d}s}}'.format(maxlen)
+    print(fmtStr.format('samples'))
+    print(fmtStr.format('-'*10))
+    for sample in result['samples']:
+        print(fmtStr.format(sample))
+    print()
+
+    # print parameters, constraints, modifiers
+    fmtStr = '{{0: >{0:d}s}}  {{1: <22s}}  {{2:s}}'.format(maxlen)
+    print(fmtStr.format('parameters', 'constraint', 'modifiers'))
+    print(fmtStr.format('-'*10, '-'*10, '-'*10))
+    for parname, constraint, modtypes in result['systematics']:
+        print(fmtStr.format(parname, constraint, ','.join(sorted(modtypes))))
+    print()
+
+    if output_file:
+        with open(output_file, 'w+') as out_file:
+            json.dump(result, out_file, indent=4, sort_keys=True)
+        log.debug("Written to {0:s}".format(output_file))
+
+    sys.exit(0)
+
+
+@pyhf.command()
+@click.argument('workspace', default='-')
+@click.option(
+    '--output-file',
+    help='The location of the output json file. If not specified, prints to screen.',
+    default=None,
+)
+@click.option('--measurement', default=None)
 @click.option('-p', '--patch', multiple=True)
 @click.option('--testpoi', default=1.0)
 def cls(workspace, output_file, measurement, patch, testpoi):

--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -128,7 +128,8 @@ def inspect(workspace, output_file, measurement):
     )
     result['systematics'] = [
         (
-            *parameter,
+            parameter[0],
+            parameter[1],
             [
                 modifier[1]
                 for modifier in default_model.config.modifiers

--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -160,7 +160,7 @@ def inspect(workspace, output_file, measurement):
             [
                 modifier[1]
                 for modifier in p.config.modifiers
-                if modifier[2] == parameter[0]
+                if modifier[0] == parameter[0]
             ],
         )
         for parameter in result['parameters']
@@ -200,7 +200,7 @@ def inspect(workspace, output_file, measurement):
     print(fmtStr.format('parameters', 'constraint', 'modifiers'))
     print(fmtStr.format('-' * 10, '-' * 10, '-' * 10))
     for parname, constraint, modtypes in result['systematics']:
-        print(fmtStr.format(parname, constraint, ','.join(sorted(modtypes))))
+        print(fmtStr.format(parname, constraint, ','.join(sorted(set(modtypes)))))
     print()
 
     if output_file:

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -17,6 +17,7 @@ class _ModelConfig(object):
         self.par_map = {}
         self.par_order = []
         self.next_index = 0
+        self.poi_name = None
         self.poi_index = None
         self.auxdata = []
         self.auxdata_order = []
@@ -127,6 +128,7 @@ class _ModelConfig(object):
             )
         s = self.par_slice(name)
         assert s.stop - s.start == 1
+        self.poi_name = name
         self.poi_index = s.start
 
     def _register_paramset(self, param_name, paramset):

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -216,40 +216,6 @@ def test_inspect(tmpdir, script_runner):
     command = 'pyhf inspect {0:s}'.format(temp.strpath)
     ret = script_runner.run(*shlex.split(command))
     assert ret.success
-    output = """Summary Statistics
-       ------------------
-          channels  1
-           samples  3
-        parameters  6
-         modifiers  6
-
-          channels  nbins
-        ----------  -----
-          channel1    2
-
-           samples
-        ----------
-       background1
-       background2
-            signal
-
-        parameters  constraint              modifiers
-        ----------  ----------              ----------
-     SigXsecOverSM  unconstrained           normfactor
-              lumi  constrained_by_normal   lumi
-staterror_channel1  constrained_by_normal   staterror
-             syst1  constrained_by_normal   normsys
-             syst2  constrained_by_normal   normsys
-             syst3  constrained_by_normal   normsys
-
-       measurement           poi            parameters
-        ----------        ----------        ----------
-  (*) GaussExample      SigXsecOverSM       lumi,alpha_syst1
-      GammaExample      SigXsecOverSM       lumi,alpha_syst1
-    LogNormExample      SigXsecOverSM       lumi,alpha_syst1
-      ConstExample      SigXsecOverSM       lumi,alpha_syst1
-    """
-    assert output.split() == ret.stdout.split()
 
 
 def test_inspect_outfile(tmpdir, script_runner):
@@ -265,3 +231,19 @@ def test_inspect_outfile(tmpdir, script_runner):
     )
     ret = script_runner.run(*shlex.split(command))
     assert ret.success
+
+    summary = json.loads(tempout.read())
+    assert [
+        'channels',
+        'measurements',
+        'modifiers',
+        'parameters',
+        'samples',
+        'systematics',
+    ] == sorted(summary.keys())
+    assert len(summary['channels']) == 1
+    assert len(summary['measurements']) == 4
+    assert len(summary['modifiers']) == 6
+    assert len(summary['parameters']) == 6
+    assert len(summary['samples']) == 3
+    assert len(summary['systematics']) == 6

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -250,3 +250,18 @@ staterror_channel1  constrained_by_normal   staterror
       ConstExample      SigXsecOverSM       lumi,alpha_syst1
     """
     assert output.split() == ret.stdout.split()
+
+
+def test_inspect_outfile(tmpdir, script_runner):
+    temp = tmpdir.join("parsed_output.json")
+    command = 'pyhf xml2json validation/xmlimport_input/config/example.xml --basedir validation/xmlimport_input/ --output-file {0:s} --hide-progress'.format(
+        temp.strpath
+    )
+    ret = script_runner.run(*shlex.split(command))
+
+    tempout = tmpdir.join("inspect_output.json")
+    command = 'pyhf inspect {0:s} --output-file {1:s}'.format(
+        temp.strpath, tempout.strpath
+    )
+    ret = script_runner.run(*shlex.split(command))
+    assert ret.success

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -204,3 +204,49 @@ def test_testpoi(tmpdir, script_runner):
         assert not np.array_equal(*pair)
 
     assert len(list(set(results_obs))) == len(pois)
+
+
+def test_inspect(tmpdir, script_runner):
+    temp = tmpdir.join("parsed_output.json")
+    command = 'pyhf xml2json validation/xmlimport_input/config/example.xml --basedir validation/xmlimport_input/ --output-file {0:s} --hide-progress'.format(
+        temp.strpath
+    )
+    ret = script_runner.run(*shlex.split(command))
+
+    command = 'pyhf inspect {0:s}'.format(temp.strpath)
+    ret = script_runner.run(*shlex.split(command))
+    assert ret.success
+    output = """Summary Statistics
+       ------------------
+          channels  1
+           samples  3
+        parameters  6
+         modifiers  6
+
+          channels  nbins
+        ----------  -----
+          channel1    2
+
+           samples
+        ----------
+       background1
+       background2
+            signal
+
+        parameters  constraint              modifiers
+        ----------  ----------              ----------
+     SigXsecOverSM  unconstrained           normfactor
+              lumi  constrained_by_normal   lumi
+staterror_channel1  constrained_by_normal   staterror
+             syst1  constrained_by_normal   normsys
+             syst2  constrained_by_normal   normsys
+             syst3  constrained_by_normal   normsys
+
+       measurement           poi            parameters
+        ----------        ----------        ----------
+  (*) GaussExample      SigXsecOverSM       lumi,alpha_syst1
+      GammaExample      SigXsecOverSM       lumi,alpha_syst1
+    LogNormExample      SigXsecOverSM       lumi,alpha_syst1
+      ConstExample      SigXsecOverSM       lumi,alpha_syst1
+    """
+    assert output.split() == ret.stdout.split()


### PR DESCRIPTION
# Description

An idea to inspect a given JSON and provide some summary information. Currently, output is as follows:

```
(pyhf) Lord Stark:~/pyhf (feature/inspect)$ pyhf inspect ~/Downloads/Excl-fit/Sig_MGPy8EG_A14N23LO_SM_Higgsino_130_100_2L2MET75_MadSpin_pruned.json 
                                                  Summary Statistics  
                                                  ------------------  
                                                     channels  22
                                                      samples  7
                                                   parameters  88
                                                    modifiers  122
                                                          poi  mu_SIG

                                                     channels  nbins
                                                   ----------  -----
                                          CRtau_hghmet_met_Et    1  
                                       SRee_eMLLf_hghmet_cuts    1  
                            SRee_eMLLd_lowmet_deltaM_low_cuts    1  
                           SRee_eMLLg_lowmet_deltaM_high_cuts    1  
                                           CRVV_hghmet_met_Et    1  
                            SRee_eMLLf_lowmet_deltaM_low_cuts    1  
                           SRee_eMLLc_lowmet_deltaM_high_cuts    1  
                            SRee_eMLLc_lowmet_deltaM_low_cuts    1  
                           SRee_eMLLh_lowmet_deltaM_high_cuts    1  
                                          CRtau_lowmet_met_Et    1  
                                       SRee_eMLLg_hghmet_cuts    1  
                                           CRVV_lowmet_met_Et    1  
                                       SRee_eMLLe_hghmet_cuts    1  
                                       SRee_eMLLh_hghmet_cuts    1  
                           SRee_eMLLe_lowmet_deltaM_high_cuts    1  
                            SRee_eMLLe_lowmet_deltaM_low_cuts    1  
                                          CRtop_hghmet_met_Et    1  
                           SRee_eMLLd_lowmet_deltaM_high_cuts    1  
                                          CRtop_lowmet_met_Et    1  
                                       SRee_eMLLd_hghmet_cuts    1  
                           SRee_eMLLf_lowmet_deltaM_high_cuts    1  
                                       SRee_eMLLc_hghmet_cuts    1  

                                                      samples
                                                   ----------
                                                        fakes
                                                      diboson
        MGPy8EG_A14N23LO_SM_Higgsino_130_100_2L2MET75_MadSpin
                                                        Zjets
                                                        other
                                                      Zttjets
                                                          top

                                                   parameters  constraint              modifiers
                                                   ----------  ----------              ----------
                                                       EG_Eff  constrained_by_normal   histosys,normsys
                                                       EG_Iso  constrained_by_normal   histosys,normsys
                                            EG_RESOLUTION_ALL  constrained_by_normal   histosys,normsys
                                                      EG_Reco  constrained_by_normal   histosys,normsys
                                                 EG_SCALE_AF2  constrained_by_normal   histosys,normsys
                                                 EG_SCALE_ALL  constrained_by_normal   histosys,normsys
                    JET_EtaIntercalibration_NonClosure_negEta  constrained_by_normal   histosys,normsys
                    JET_EtaIntercalibration_NonClosure_posEta  constrained_by_normal   histosys,normsys
                                          JET_Flavor_Response  constrained_by_normal   histosys,normsys
                                              JET_GroupedNP_1  constrained_by_normal   histosys,normsys
                                              JET_GroupedNP_2  constrained_by_normal   histosys,normsys
                                              JET_GroupedNP_3  constrained_by_normal   histosys,normsys
                                             JET_JER_DataVsMC  constrained_by_normal   histosys,normsys
                                        JET_JER_EffectiveNP_1  constrained_by_normal   histosys,normsys
                                        JET_JER_EffectiveNP_2  constrained_by_normal   histosys,normsys
                                        JET_JER_EffectiveNP_3  constrained_by_normal   histosys,normsys
                                        JET_JER_EffectiveNP_4  constrained_by_normal   histosys,normsys
                                        JET_JER_EffectiveNP_5  constrained_by_normal   histosys,normsys
                                        JET_JER_EffectiveNP_6  constrained_by_normal   histosys,normsys
                                JET_JER_EffectiveNP_7restTerm  constrained_by_normal   histosys,normsys
                                                          JVT  constrained_by_normal   normsys
                                         MET_SoftTrk_ResoPara  constrained_by_normal   histosys,normsys
                                         MET_SoftTrk_ResoPerp  constrained_by_normal   histosys,normsys
                                            MET_SoftTrk_Scale  constrained_by_normal   histosys,normsys
                                                 MUON_Eff_sys  constrained_by_normal   histosys,normsys
                                           MUON_Eff_sys_lowpt  constrained_by_normal   histosys,normsys
                                                      MUON_ID  constrained_by_normal   histosys,normsys
                                                      MUON_MS  constrained_by_normal   histosys,normsys
                                                   MUON_SCALE  constrained_by_normal   histosys,normsys
                                                   Norm_other  constrained_by_normal   normsys
                                               SigModelAndPDF  constrained_by_normal   normsys
                                                      SigXSec  constrained_by_normal   histosys,normsys
                                                      btag_BT  constrained_by_normal   histosys,normsys
                                                      btag_CT  constrained_by_normal   histosys,normsys
                                                   btag_Extra  constrained_by_normal   histosys,normsys
                                                  btag_LightT  constrained_by_normal   histosys,normsys
                                              fakes_flatSys20  constrained_by_normal   normsys
                                                         lumi  constrained_by_normal   lumi
                                                       mu_SIG  unconstrained           normfactor
                                                 mu_VV_hghmet  unconstrained           normfactor
                                                 mu_VV_lowmet  unconstrained           normfactor
                                                mu_Ztt_hghmet  unconstrained           normfactor
                                                mu_Ztt_lowmet  unconstrained           normfactor
                                                mu_top_hghmet  unconstrained           normfactor
                                                mu_top_lowmet  unconstrained           normfactor
                                                       pileup  constrained_by_normal   histosys,normsys
                shape_fakes_stat_fakes_CRVV_hghmet_obs_met_Et  constrained_by_poisson  shapesys
                shape_fakes_stat_fakes_CRVV_lowmet_obs_met_Et  constrained_by_poisson  shapesys
               shape_fakes_stat_fakes_CRtau_hghmet_obs_met_Et  constrained_by_poisson  shapesys
               shape_fakes_stat_fakes_CRtau_lowmet_obs_met_Et  constrained_by_poisson  shapesys
               shape_fakes_stat_fakes_CRtop_hghmet_obs_met_Et  constrained_by_poisson  shapesys
               shape_fakes_stat_fakes_CRtop_lowmet_obs_met_Et  constrained_by_poisson  shapesys
shape_fakes_stat_fakes_SRee_eMLLc_lowmet_deltaM_high_obs_cuts  constrained_by_poisson  shapesys
            shape_fakes_stat_fakes_SRee_eMLLd_hghmet_obs_cuts  constrained_by_poisson  shapesys
shape_fakes_stat_fakes_SRee_eMLLd_lowmet_deltaM_high_obs_cuts  constrained_by_poisson  shapesys
 shape_fakes_stat_fakes_SRee_eMLLd_lowmet_deltaM_low_obs_cuts  constrained_by_poisson  shapesys
            shape_fakes_stat_fakes_SRee_eMLLe_hghmet_obs_cuts  constrained_by_poisson  shapesys
shape_fakes_stat_fakes_SRee_eMLLe_lowmet_deltaM_high_obs_cuts  constrained_by_poisson  shapesys
 shape_fakes_stat_fakes_SRee_eMLLe_lowmet_deltaM_low_obs_cuts  constrained_by_poisson  shapesys
            shape_fakes_stat_fakes_SRee_eMLLf_hghmet_obs_cuts  constrained_by_poisson  shapesys
shape_fakes_stat_fakes_SRee_eMLLf_lowmet_deltaM_high_obs_cuts  constrained_by_poisson  shapesys
 shape_fakes_stat_fakes_SRee_eMLLf_lowmet_deltaM_low_obs_cuts  constrained_by_poisson  shapesys
            shape_fakes_stat_fakes_SRee_eMLLg_hghmet_obs_cuts  constrained_by_poisson  shapesys
shape_fakes_stat_fakes_SRee_eMLLg_lowmet_deltaM_high_obs_cuts  constrained_by_poisson  shapesys
            shape_fakes_stat_fakes_SRee_eMLLh_hghmet_obs_cuts  constrained_by_poisson  shapesys
shape_fakes_stat_fakes_SRee_eMLLh_lowmet_deltaM_high_obs_cuts  constrained_by_poisson  shapesys
                                 staterror_CRVV_hghmet_met_Et  constrained_by_normal   staterror
                                 staterror_CRVV_lowmet_met_Et  constrained_by_normal   staterror
                                staterror_CRtau_hghmet_met_Et  constrained_by_normal   staterror
                                staterror_CRtau_lowmet_met_Et  constrained_by_normal   staterror
                                staterror_CRtop_hghmet_met_Et  constrained_by_normal   staterror
                                staterror_CRtop_lowmet_met_Et  constrained_by_normal   staterror
                             staterror_SRee_eMLLc_hghmet_cuts  constrained_by_normal   staterror
                 staterror_SRee_eMLLc_lowmet_deltaM_high_cuts  constrained_by_normal   staterror
                  staterror_SRee_eMLLc_lowmet_deltaM_low_cuts  constrained_by_normal   staterror
                             staterror_SRee_eMLLd_hghmet_cuts  constrained_by_normal   staterror
                 staterror_SRee_eMLLd_lowmet_deltaM_high_cuts  constrained_by_normal   staterror
                  staterror_SRee_eMLLd_lowmet_deltaM_low_cuts  constrained_by_normal   staterror
                             staterror_SRee_eMLLe_hghmet_cuts  constrained_by_normal   staterror
                 staterror_SRee_eMLLe_lowmet_deltaM_high_cuts  constrained_by_normal   staterror
                  staterror_SRee_eMLLe_lowmet_deltaM_low_cuts  constrained_by_normal   staterror
                             staterror_SRee_eMLLf_hghmet_cuts  constrained_by_normal   staterror
                 staterror_SRee_eMLLf_lowmet_deltaM_high_cuts  constrained_by_normal   staterror
                  staterror_SRee_eMLLf_lowmet_deltaM_low_cuts  constrained_by_normal   staterror
                             staterror_SRee_eMLLg_hghmet_cuts  constrained_by_normal   staterror
                 staterror_SRee_eMLLg_lowmet_deltaM_high_cuts  constrained_by_normal   staterror
                             staterror_SRee_eMLLh_hghmet_cuts  constrained_by_normal   staterror
                 staterror_SRee_eMLLh_lowmet_deltaM_high_cuts  constrained_by_normal   staterror

```

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
- adds a CLI utility for inspecting information about the provided workspace object on an as-best basis
- testing for pyhf inspect is done by checking if the output is as expected for a provided xmlimport example
```