### PR TITLE
Remove redundant (repeated) param_set name

### DIFF
--- a/pyhf/modifiers/histosys.py
+++ b/pyhf/modifiers/histosys.py
@@ -28,9 +28,9 @@ class histosys_combined(object):
     def __init__(self, histosys_mods, pdfconfig, mega_mods):
         self._parindices = list(range(len(pdfconfig.suggested_init())))
 
-        pnames = [pname for _, _, pname in histosys_mods]
-        keys = ['{}/{}'.format(mtype, m) for m, mtype, _ in histosys_mods]
-        histosys_mods = [m for m, _, _ in histosys_mods]
+        pnames = [pname for pname, _ in histosys_mods]
+        keys = ['{}/{}'.format(mtype, m) for m, mtype in histosys_mods]
+        histosys_mods = [m for m, _ in histosys_mods]
         self._histo_indices = [self._parindices[pdfconfig.par_slice(p)] for p in pnames]
         self._histosys_histoset = [
             [

--- a/pyhf/modifiers/lumi.py
+++ b/pyhf/modifiers/lumi.py
@@ -29,9 +29,9 @@ class lumi_combined(object):
     def __init__(self, lumi_mods, pdfconfig, mega_mods):
         self._parindices = list(range(len(pdfconfig.suggested_init())))
 
-        pnames = [pname for _, _, pname in lumi_mods]
-        keys = ['{}/{}'.format(mtype, m) for m, mtype, _ in lumi_mods]
-        lumi_mods = [m for m, _, _ in lumi_mods]
+        pnames = [pname for pname, _ in lumi_mods]
+        keys = ['{}/{}'.format(mtype, m) for m, mtype in lumi_mods]
+        lumi_mods = [m for m, _ in lumi_mods]
         self._lumi_indices = [self._parindices[pdfconfig.par_slice(p)] for p in pnames]
 
         self._lumi_mask = [

--- a/pyhf/modifiers/normfactor.py
+++ b/pyhf/modifiers/normfactor.py
@@ -26,9 +26,9 @@ class normfactor_combined(object):
     def __init__(self, normfactor_mods, pdfconfig, mega_mods):
         self._parindices = list(range(len(pdfconfig.suggested_init())))
 
-        pnames = [pname for _, _, pname in normfactor_mods]
-        keys = ['{}/{}'.format(mtype, m) for m, mtype, _ in normfactor_mods]
-        normfactor_mods = [m for m, _, _ in normfactor_mods]
+        pnames = [pname for pname, _ in normfactor_mods]
+        keys = ['{}/{}'.format(mtype, m) for m, mtype in normfactor_mods]
+        normfactor_mods = [m for m, _ in normfactor_mods]
 
         self._normfactor_indices = [
             self._parindices[pdfconfig.par_slice(p)] for p in pnames

--- a/pyhf/modifiers/normsys.py
+++ b/pyhf/modifiers/normsys.py
@@ -28,9 +28,9 @@ class normsys_combined(object):
     def __init__(self, normsys_mods, pdfconfig, mega_mods):
         self._parindices = list(range(len(pdfconfig.suggested_init())))
 
-        pnames = [pname for _, _, pname in normsys_mods]
-        keys = ['{}/{}'.format(mtype, m) for m, mtype, _ in normsys_mods]
-        normsys_mods = [m for m, _, _ in normsys_mods]
+        pnames = [pname for pname, _ in normsys_mods]
+        keys = ['{}/{}'.format(mtype, m) for m, mtype in normsys_mods]
+        normsys_mods = [m for m, _ in normsys_mods]
 
         self._normsys_indices = [
             self._parindices[pdfconfig.par_slice(p)] for p in pnames

--- a/pyhf/modifiers/shapefactor.py
+++ b/pyhf/modifiers/shapefactor.py
@@ -62,9 +62,9 @@ class shapefactor_combined(object):
         and at that point can be used to compute the effect of shapefactor.
         """
 
-        pnames = [pname for _, _, pname in shapefactor_mods]
-        keys = ['{}/{}'.format(mtype, m) for m, mtype, _ in shapefactor_mods]
-        shapefactor_mods = [m for m, _, _ in shapefactor_mods]
+        pnames = [pname for pname, _ in shapefactor_mods]
+        keys = ['{}/{}'.format(mtype, m) for m, mtype in shapefactor_mods]
+        shapefactor_mods = [m for m, _ in shapefactor_mods]
 
         self._parindices = list(range(len(pdfconfig.suggested_init())))
         self._shapefactor_indices = [

--- a/pyhf/modifiers/shapesys.py
+++ b/pyhf/modifiers/shapesys.py
@@ -31,9 +31,9 @@ class shapesys(object):
 class shapesys_combined(object):
     def __init__(self, shapesys_mods, pdfconfig, mega_mods):
 
-        pnames = [pname for _, _, pname in shapesys_mods]
-        keys = ['{}/{}'.format(mtype, m) for m, mtype, _ in shapesys_mods]
-        shapesys_mods = [m for m, _, _ in shapesys_mods]
+        pnames = [pname for pname, _ in shapesys_mods]
+        keys = ['{}/{}'.format(mtype, m) for m, mtype in shapesys_mods]
+        shapesys_mods = [m for m, _ in shapesys_mods]
 
         self._shapesys_mods = shapesys_mods
         self._pnames = pnames

--- a/pyhf/modifiers/staterror.py
+++ b/pyhf/modifiers/staterror.py
@@ -27,9 +27,9 @@ class staterror_combined(object):
     def __init__(self, staterr_mods, pdfconfig, mega_mods):
         self._parindices = list(range(len(pdfconfig.suggested_init())))
 
-        pnames = [pname for _, _, pname in staterr_mods]
-        keys = ['{}/{}'.format(mtype, m) for m, mtype, _ in staterr_mods]
-        staterr_mods = [m for m, _, _ in staterr_mods]
+        pnames = [pname for pname, _ in staterr_mods]
+        keys = ['{}/{}'.format(mtype, m) for m, mtype in staterr_mods]
+        staterr_mods = [m for m, _ in staterr_mods]
 
         self._staterror_indices = [
             self._parindices[pdfconfig.par_slice(p)] for p in pnames

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -49,8 +49,7 @@ class _ModelConfig(object):
                 for modifier_def in sample['modifiers']:
                     # get the paramset requirements for the given modifier. If
                     # modifier does not exist, we'll have a KeyError
-                    paramset_name = modifier_def['name']
-                    self.parameters.append(paramset_name)
+                    self.parameters.append(modifier_def['name'])
                     try:
                         paramset_requirements = modifiers.registry[
                             modifier_def['type']
@@ -66,7 +65,6 @@ class _ModelConfig(object):
                         (
                             modifier_def['name'],  # mod name
                             modifier_def['type'],  # mod type
-                            paramset_name,  # parset name
                         )
                     )
 
@@ -120,7 +118,7 @@ class _ModelConfig(object):
         return self.par_map[name]['paramset']
 
     def set_poi(self, name):
-        if name not in [x for x, _, _ in self.modifiers]:
+        if name not in [x for x, _ in self.modifiers]:
             raise exceptions.InvalidModel(
                 "The parameter of interest '{0:s}' cannot be fit as it is not declared in the model specification.".format(
                     name
@@ -217,7 +215,7 @@ class Model(object):
         # We don't actually set up the modifier data here for no-ops, but we do
         # set up the entire structure
         mega_mods = {}
-        for m, mtype, _ in self.config.modifiers:
+        for m, mtype in self.config.modifiers:
             key = '{}/{}'.format(mtype, m)
             for s in self.config.samples:
                 mega_mods.setdefault(s, {})[key] = {
@@ -253,7 +251,7 @@ class Model(object):
                     if defined_samp
                     else {}
                 )
-                for m, mtype, _ in self.config.modifiers:
+                for m, mtype in self.config.modifiers:
                     key = '{}/{}'.format(mtype, m)
                     # this is None if modifier doesn't affect channel/sample.
                     thismod = defined_mods.get(key)


### PR DESCRIPTION
# Description

See #405 for more details. The short of it is that `param_set` name does not differ from the `modifier_def['name']` at all. If this is somehow a mistake, our tests should catch this (if there's a case where it differs). As the code is written, there's no difference. So this PR cleans up the code a bit given that assumption.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* remove redundant use of paramset_name everywhere as it does not differ from modifier_def['name'] anymore
* tuples of three elements passed around for each modifier is now a tuple of two elements
```