### PR TITLE
Fix URL in readme to point from lukasheinrich fork to main diana-hep repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,4 +104,4 @@ pip uninstall pyhf
 
 ## Authors
 
-Please check the [contribution statistics for a list of contributors](https://github.com/lukasheinrich/pyhf/graphs/contributors)
+Please check the [contribution statistics for a list of contributors](https://github.com/diana-hep/pyhf/graphs/contributors)


### PR DESCRIPTION
# Description

The README has a contributing URL pointing to @lukasheinrich 's fork instead of diana-hep's.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
- fix contributing URL in README
```