### PR TITLE
Add Bash script to guard max time return value for Binder build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ jobs:
     install: skip
     script:
       # Use Binder build API to trigger repo2docker to build image
-      - curl https://mybinder.org/build/gh/diana-hep/pyhf/master
+      - bash binder/trigger_binder.sh https://mybinder.org/build/gh/diana-hep/pyhf/"${TRAVIS_BRANCH}"
     after_success: skip
   - stage: deploy
     python: '3.6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ jobs:
     install: skip
     script:
       # Use Binder build API to trigger repo2docker to build image
-      - bash binder/trigger_binder.sh https://mybinder.org/build/gh/diana-hep/pyhf/"${TRAVIS_BRANCH}"
+      - ./binder/trigger_binder.sh https://mybinder.org/build/gh/diana-hep/pyhf/"${TRAVIS_BRANCH}"
     after_success: skip
   - stage: deploy
     python: '3.6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ jobs:
     install: skip
     script:
       # Use Binder build API to trigger repo2docker to build image
-      - ./binder/trigger_binder.sh https://mybinder.org/build/gh/diana-hep/pyhf/"${TRAVIS_BRANCH}"
+      - bash binder/trigger_binder.sh https://mybinder.org/build/gh/diana-hep/pyhf/"${TRAVIS_BRANCH}"
     after_success: skip
   - stage: deploy
     python: '3.6'

--- a/binder/trigger_binder.sh
+++ b/binder/trigger_binder.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+function trigger_binder() {
+    local URL="${1}"
+
+    curl --connect-timeout 10 --max-time 30 "${URL}"
+    curl_return=$?
+
+    # Return code 28 is when the --max-time is reached
+    if [ "${curl_return}" -eq 0 ] || [ "${curl_return}" -eq 28 ]; then
+        if [[ "${curl_return}" -eq 28 ]]; then
+            printf "\nBinder build started.\nCheck back soon.\n"
+        fi
+    else
+        return "${curl_return}"
+    fi
+
+    return 0
+}
+
+function main() {
+    # 1: the Binder build API URL to curl
+    trigger_binder $1
+}
+
+main "$@" || exit 1


### PR DESCRIPTION
# Description

Safeguards Binder build section of the CI from taking too long and causing a timeout error by Travis CI. The trigger function sets a time limit on curl and accepts `--max-time` exit return code, `28`, as valid and then returns success.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* The trigger function sets a time limit on curl and accepts --max-time exit return code, 28, as valid and then returns success.
```
