### PR TITLE
Add Python 3.7 to CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 # test matrix
-dist: xenial
+dist: trusty
 language: python
 cache: pip
 python:
   - '2.7'
   - '3.6'
-  - '3.7'
 before_install:
   - sudo apt-get install libtcmalloc-minimal4
   - export LD_PRELOAD="/usr/lib/libtcmalloc_minimal.so.4"
@@ -39,6 +38,8 @@ env:
 
 jobs:
   include:
+  - dist: xenial
+    python: '3.7'
   - name: "Python 2.7 Notebook Tests"
     python: '2.7'
     script:
@@ -50,6 +51,7 @@ jobs:
       - python -m pytest tests/test_notebooks.py
     after_success: skip
   - name: "Python 3.7 Notebook Tests"
+    dist: xenial
     python: '3.7'
     script:
       - python -m pytest tests/test_notebooks.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 # test matrix
+dist: xenial
 language: python
 cache: pip
 python:
   - '2.7'
   - '3.6'
+  - '3.7'
 before_install:
   - sudo apt-get install libtcmalloc-minimal4
   - export LD_PRELOAD="/usr/lib/libtcmalloc_minimal.so.4"
@@ -44,6 +46,11 @@ jobs:
     after_success: skip
   - name: "Python 3.6 Notebook Tests"
     python: '3.6'
+    script:
+      - python -m pytest tests/test_notebooks.py
+    after_success: skip
+  - name: "Python 3.7 Notebook Tests"
+    python: '3.7'
     script:
       - python -m pytest tests/test_notebooks.py
     after_success: skip

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
# Description

Now that [TensorFlow `v1.13.1` has been released](https://pypi.org/project/tensorflow/1.13.1/) which is compatible with Python 3.7, Python 3.7 should be added to the versions tested by the CI. To do this, the Travis CI Ubuntu Xenial images which have Python 3.7 are used.

Additionally, the Python 3.7 language tag is added to `setup.py` so that PyPI will know that future releases have been tested with Python 3.7.

The only downside to this addition is that Travis will only run 5 builds concurrently on a free version. As the notebook tests are split off into their own tests this results in 6 builds, and additional time being added to testing as the Python 3.7 notebook tests need to wait for one job to finish before it can start.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add Python 3.7 to Travis CI testing
* Add Python 3.7 PyPI language tag to setup.py
```
