### PR TITLE
Enforce consistent tensor shape for scalars

### DIFF
--- a/pyhf/tensor/mxnet_backend.py
+++ b/pyhf/tensor/mxnet_backend.py
@@ -108,6 +108,7 @@ class mxnet_backend(object):
         dtype = dtypemap[dtype]
         try:
             tensor = nd.array(tensor_in, dtype=dtype)
+            # Ensure non-empty tensor shape for consistency
             try:
                 tensor.shape[0]
             except IndexError:

--- a/pyhf/tensor/mxnet_backend.py
+++ b/pyhf/tensor/mxnet_backend.py
@@ -106,15 +106,12 @@ class mxnet_backend(object):
         """
         dtypemap = {'float': 'float32', 'int': 'int32', 'bool': 'uint8'}
         dtype = dtypemap[dtype]
-        try:
-            tensor = nd.array(tensor_in, dtype=dtype)
-            # Ensure non-empty tensor shape for consistency with mxnet v1.4.0+
-            try:
-                tensor.shape[0]
-            except IndexError:
-                tensor = tensor.broadcast_to((1,))
-        except ValueError:
+
+        if isinstance(tensor_in, (int, float)):
+            # Ensure non-empty tensor shape for consistency
             tensor = nd.array([tensor_in], dtype=dtype)
+        else:
+            tensor = nd.array(tensor_in, dtype=dtype)
         return tensor
 
     def sum(self, tensor_in, axis=None):

--- a/pyhf/tensor/mxnet_backend.py
+++ b/pyhf/tensor/mxnet_backend.py
@@ -111,11 +111,15 @@ class mxnet_backend(object):
             log.error('Invalid dtype: dtype must be float, int, or bool.')
             raise
 
-        if isinstance(tensor_in, (int, float)):
-            # Ensure non-empty tensor shape for consistency
-            tensor = nd.array([tensor_in], dtype=dtype)
-        else:
+        try:
             tensor = nd.array(tensor_in, dtype=dtype)
+            # Ensure non-empty tensor shape for consistency
+            try:
+                tensor.shape[0]
+            except IndexError:
+                tensor = tensor.broadcast_to((1,))
+        except ValueError:
+            tensor = nd.array([tensor_in], dtype=dtype)
         return tensor
 
     def sum(self, tensor_in, axis=None):

--- a/pyhf/tensor/mxnet_backend.py
+++ b/pyhf/tensor/mxnet_backend.py
@@ -108,11 +108,11 @@ class mxnet_backend(object):
         dtype = dtypemap[dtype]
         try:
             tensor = nd.array(tensor_in, dtype=dtype)
-            # Ensure non-empty tensor shape for consistency
+            # Ensure non-empty tensor shape for consistency with mxnet v1.4.0+
             try:
                 tensor.shape[0]
             except IndexError:
-                tensor = nd.array([tensor_in], dtype=dtype)
+                tensor = tensor.broadcast_to((1,))
         except ValueError:
             tensor = nd.array([tensor_in], dtype=dtype)
         return tensor

--- a/pyhf/tensor/mxnet_backend.py
+++ b/pyhf/tensor/mxnet_backend.py
@@ -105,7 +105,11 @@ class mxnet_backend(object):
             MXNet NDArray: A multi-dimensional, fixed-size homogenous array.
         """
         dtypemap = {'float': 'float32', 'int': 'int32', 'bool': 'uint8'}
-        dtype = dtypemap[dtype]
+        try:
+            dtype = dtypemap[dtype]
+        except KeyError:
+            log.error('Invalid dtype: dtype must be float, int, or bool.')
+            raise
 
         if isinstance(tensor_in, (int, float)):
             # Ensure non-empty tensor shape for consistency

--- a/pyhf/tensor/mxnet_backend.py
+++ b/pyhf/tensor/mxnet_backend.py
@@ -108,6 +108,10 @@ class mxnet_backend(object):
         dtype = dtypemap[dtype]
         try:
             tensor = nd.array(tensor_in, dtype=dtype)
+            try:
+                tensor.shape[0]
+            except IndexError:
+                tensor = nd.array([tensor_in], dtype=dtype)
         except ValueError:
             tensor = nd.array([tensor_in], dtype=dtype)
         return tensor

--- a/pyhf/tensor/numpy_backend.py
+++ b/pyhf/tensor/numpy_backend.py
@@ -73,11 +73,12 @@ class numpy_backend(object):
             log.error('Invalid dtype: dtype must be float, int, or bool.')
             raise
 
-        if isinstance(tensor_in, (int, float)):
-            # Ensure non-empty tensor shape for consistency
-            tensor = np.asarray([tensor_in], dtype=dtype)
-        else:
-            tensor = np.asarray(tensor_in, dtype=dtype)
+        tensor = np.asarray(tensor_in, dtype=dtype)
+        # Ensure non-empty tensor shape for consistency
+        try:
+            tensor.shape[0]
+        except IndexError:
+            tensor = tensor.reshape(1)
         return tensor
 
     def sum(self, tensor_in, axis=None):

--- a/pyhf/tensor/numpy_backend.py
+++ b/pyhf/tensor/numpy_backend.py
@@ -68,7 +68,12 @@ class numpy_backend(object):
         """
         dtypemap = {'float': np.float64, 'int': np.int64, 'bool': np.bool_}
         dtype = dtypemap[dtype]
-        return np.asarray(tensor_in, dtype=dtype)
+        tensor = np.asarray(tensor_in, dtype=dtype)
+        try:
+            tensor.shape[0]
+        except IndexError:
+            tensor = tensor.reshape(1)
+        return tensor
 
     def sum(self, tensor_in, axis=None):
         return np.sum(tensor_in, axis=axis)

--- a/pyhf/tensor/numpy_backend.py
+++ b/pyhf/tensor/numpy_backend.py
@@ -67,7 +67,11 @@ class numpy_backend(object):
             `numpy.ndarray`: A multi-dimensional, fixed-size homogenous array.
         """
         dtypemap = {'float': np.float64, 'int': np.int64, 'bool': np.bool_}
-        dtype = dtypemap[dtype]
+        try:
+            dtype = dtypemap[dtype]
+        except KeyError:
+            log.error('Invalid dtype: dtype must be float, int, or bool.')
+            raise
 
         if isinstance(tensor_in, (int, float)):
             # Ensure non-empty tensor shape for consistency

--- a/pyhf/tensor/numpy_backend.py
+++ b/pyhf/tensor/numpy_backend.py
@@ -68,11 +68,12 @@ class numpy_backend(object):
         """
         dtypemap = {'float': np.float64, 'int': np.int64, 'bool': np.bool_}
         dtype = dtypemap[dtype]
-        tensor = np.asarray(tensor_in, dtype=dtype)
-        try:
-            tensor.shape[0]
-        except IndexError:
-            tensor = tensor.reshape(1)
+
+        if isinstance(tensor_in, (int, float)):
+            # Ensure non-empty tensor shape for consistency
+            tensor = np.asarray([tensor_in], dtype=dtype)
+        else:
+            tensor = np.asarray(tensor_in, dtype=dtype)
         return tensor
 
     def sum(self, tensor_in, axis=None):

--- a/pyhf/tensor/pytorch_backend.py
+++ b/pyhf/tensor/pytorch_backend.py
@@ -58,7 +58,11 @@ class pytorch_backend(object):
             torch.Tensor: A multi-dimensional matrix containing elements of a single data type.
         """
         dtypemap = {'float': torch.float, 'int': torch.int, 'bool': torch.uint8}
-        dtype = dtypemap[dtype]
+        try:
+            dtype = dtypemap[dtype]
+        except KeyError:
+            log.error('Invalid dtype: dtype must be float, int, or bool.')
+            raise
 
         if isinstance(tensor_in, (int, float)):
             # Ensure non-empty tensor shape for consistency

--- a/pyhf/tensor/pytorch_backend.py
+++ b/pyhf/tensor/pytorch_backend.py
@@ -64,11 +64,12 @@ class pytorch_backend(object):
             log.error('Invalid dtype: dtype must be float, int, or bool.')
             raise
 
-        if isinstance(tensor_in, (int, float)):
-            # Ensure non-empty tensor shape for consistency
-            tensor = torch.as_tensor([tensor_in], dtype=dtype)
-        else:
-            tensor = torch.as_tensor(tensor_in, dtype=dtype)
+        tensor = torch.as_tensor(tensor_in, dtype=dtype)
+        # Ensure non-empty tensor shape for consistency
+        try:
+            tensor.shape[0]
+        except IndexError:
+            tensor = tensor.expand(1)
         return tensor
 
     def gather(self, tensor, indices):

--- a/pyhf/tensor/pytorch_backend.py
+++ b/pyhf/tensor/pytorch_backend.py
@@ -216,7 +216,7 @@ class pytorch_backend(object):
             >>> pyhf.tensorlib.poisson([5.], [6.])
             tensor([0.1606])
             >>> pyhf.tensorlib.poisson(5., 6.)
-            tensor(0.1606)
+            tensor([0.1606])
 
         Args:
             n (`tensor` or `float`): The value at which to evaluate the approximation to the Poisson distribution p.m.f.
@@ -251,7 +251,7 @@ class pytorch_backend(object):
             >>> pyhf.tensorlib.normal([0.5], [0.], [1.])
             tensor([0.3521])
             >>> pyhf.tensorlib.normal(0.5, 0., 1.)
-            tensor(0.3521)
+            tensor([0.3521])
 
         Args:
             x (`tensor` or `float`): The value at which to evaluate the Normal distribution p.d.f.

--- a/pyhf/tensor/pytorch_backend.py
+++ b/pyhf/tensor/pytorch_backend.py
@@ -59,11 +59,12 @@ class pytorch_backend(object):
         """
         dtypemap = {'float': torch.float, 'int': torch.int, 'bool': torch.uint8}
         dtype = dtypemap[dtype]
-        tensor = torch.as_tensor(tensor_in, dtype=dtype)
-        try:
-            tensor.shape[0]
-        except IndexError:
-            tensor = tensor.expand(1)
+
+        if isinstance(tensor_in, (int, float)):
+            # Ensure non-empty tensor shape for consistency
+            tensor = torch.as_tensor([tensor_in], dtype=dtype)
+        else:
+            tensor = torch.as_tensor(tensor_in, dtype=dtype)
         return tensor
 
     def gather(self, tensor, indices):

--- a/pyhf/tensor/tensorflow_backend.py
+++ b/pyhf/tensor/tensorflow_backend.py
@@ -108,14 +108,14 @@ class tensorflow_backend(object):
         dtype = dtypemap[dtype]
 
         if isinstance(tensor_in, tf.Tensor):
-            v = tensor_in
+            tensor = tensor_in
         else:
             if isinstance(tensor_in, (int, float)):
                 tensor_in = [tensor_in]
-            v = tf.convert_to_tensor(tensor_in)
-        if v.dtype is not dtype:
-            v = tf.cast(v, dtype)
-        return v
+            tensor = tf.convert_to_tensor(tensor_in)
+        if tensor.dtype is not dtype:
+            tensor = tf.cast(tensor, dtype)
+        return tensor
 
     def sum(self, tensor_in, axis=None):
         tensor_in = self.astensor(tensor_in)

--- a/pyhf/tensor/tensorflow_backend.py
+++ b/pyhf/tensor/tensorflow_backend.py
@@ -105,7 +105,11 @@ class tensorflow_backend(object):
             `tf.Tensor`: A symbolic handle to one of the outputs of a `tf.Operation`.
         """
         dtypemap = {'float': tf.float32, 'int': tf.int32, 'bool': tf.bool}
-        dtype = dtypemap[dtype]
+        try:
+            dtype = dtypemap[dtype]
+        except KeyError:
+            log.error('Invalid dtype: dtype must be float, int, or bool.')
+            raise
 
         if isinstance(tensor_in, tf.Tensor):
             tensor = tensor_in

--- a/pyhf/tensor/tensorflow_backend.py
+++ b/pyhf/tensor/tensorflow_backend.py
@@ -110,6 +110,7 @@ class tensorflow_backend(object):
         if isinstance(tensor_in, tf.Tensor):
             tensor = tensor_in
         else:
+            # Ensure non-empty tensor shape for consistency
             if isinstance(tensor_in, (int, float)):
                 tensor_in = [tensor_in]
             tensor = tf.convert_to_tensor(tensor_in)

--- a/pyhf/tensor/tensorflow_backend.py
+++ b/pyhf/tensor/tensorflow_backend.py
@@ -111,13 +111,17 @@ class tensorflow_backend(object):
             log.error('Invalid dtype: dtype must be float, int, or bool.')
             raise
 
-        if isinstance(tensor_in, tf.Tensor):
-            tensor = tensor_in
-        else:
-            # Ensure non-empty tensor shape for consistency
-            if isinstance(tensor_in, (int, float)):
-                tensor_in = [tensor_in]
+        tensor = tensor_in
+        # If already a tensor then done
+        try:
+            tensor.op
+        except AttributeError:
             tensor = tf.convert_to_tensor(tensor_in)
+            # Ensure non-empty tensor shape for consistency
+            try:
+                tensor.shape[0]
+            except IndexError:
+                tensor = tf.reshape(tensor, [1])
         if tensor.dtype is not dtype:
             tensor = tf.cast(tensor, dtype)
         return tensor

--- a/pyhf/tensor/tensorflow_backend.py
+++ b/pyhf/tensor/tensorflow_backend.py
@@ -215,20 +215,10 @@ class tensorflow_backend(object):
         Returns:
             list of Tensors: The sequence broadcast together.
         """
-
-        def generic_len(a):
-            try:
-                return len(a)
-            except TypeError:
-                if len(a.shape) < 1:
-                    return 0
-                else:
-                    return a.shape[0]
-
         args = [self.astensor(arg) for arg in args]
-        max_dim = max(map(generic_len, args))
+        max_dim = max(map(lambda arg: arg.shape[0], args))
         try:
-            assert len([arg for arg in args if 1 < generic_len(arg) < max_dim]) == 0
+            assert len([arg for arg in args if 1 < arg.shape[0] < max_dim]) == 0
         except AssertionError as error:
             log.error(
                 'ERROR: The arguments must be of compatible size: 1 or %i', max_dim
@@ -237,7 +227,7 @@ class tensorflow_backend(object):
 
         broadcast = [
             arg
-            if generic_len(arg) > 1
+            if arg.shape[0] > 1
             else tf.tile(tf.slice(arg, [0], [1]), tf.stack([max_dim]))
             for arg in args
         ]

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -84,6 +84,9 @@ def test_reshape(backend):
 def test_shape(backend):
     tb = pyhf.tensorlib
     assert tb.shape(tb.ones((1, 2, 3, 4, 5))) == (1, 2, 3, 4, 5)
+    assert tb.shape(tb.astensor([])) == (0,)
+    assert tb.shape(tb.astensor([1.0])) == (1,)
+    assert tb.shape(tb.astensor(1.0)) == tb.shape(tb.astensor([1.0]))
 
 
 def test_pdf_calculations(backend):

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -4,10 +4,10 @@ import pyhf
 from pyhf.simplemodels import hepdata_like
 
 
-@pytest.mark.xfail(raises=KeyError)
 def test_astensor_dtype(backend):
     tb = pyhf.tensorlib
-    assert tb.astensor([1, 2, 3], dtype='long')
+    with pytest.raises(KeyError):
+        assert tb.astensor([1, 2, 3], dtype='long')
 
 
 def test_simple_tensor_ops(backend):

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1,13 +1,16 @@
 import pytest
+import logging
 import numpy as np
 import pyhf
 from pyhf.simplemodels import hepdata_like
 
 
-def test_astensor_dtype(backend):
+def test_astensor_dtype(backend, caplog):
     tb = pyhf.tensorlib
-    with pytest.raises(KeyError):
-        assert tb.astensor([1, 2, 3], dtype='long')
+    with caplog.at_level(logging.INFO, 'pyhf.tensor'):
+        with pytest.raises(KeyError):
+            assert tb.astensor([1, 2, 3], dtype='long')
+            assert 'Invalid dtype' in caplog.text
 
 
 def test_simple_tensor_ops(backend):

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -4,10 +4,15 @@ import pyhf
 from pyhf.simplemodels import hepdata_like
 
 
-@pytest.mark.xfail
-def test_astensor(backend):
+@pytest.mark.xfail(raises=(TypeError, ValueError))
+def test_astensor_type(backend):
     tb = pyhf.tensorlib
     assert tb.astensor('Hello')
+
+
+@pytest.mark.xfail(raises=KeyError)
+def test_astensor_dtype(backend):
+    tb = pyhf.tensorlib
     assert tb.astensor([1, 2, 3], dtype='long')
 
 

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -4,6 +4,13 @@ import pyhf
 from pyhf.simplemodels import hepdata_like
 
 
+@pytest.mark.xfail
+def test_astensor(backend):
+    tb = pyhf.tensorlib
+    assert tb.astensor('Hello')
+    assert tb.astensor([1, 2, 3], dtype='long')
+
+
 def test_simple_tensor_ops(backend):
     tb = pyhf.tensorlib
     assert tb.tolist(tb.sum([[1, 2, 3], [4, 5, 6]], axis=0)) == [5, 7, 9]

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -4,12 +4,6 @@ import pyhf
 from pyhf.simplemodels import hepdata_like
 
 
-@pytest.mark.xfail(raises=(TypeError, ValueError))
-def test_astensor_type(backend):
-    tb = pyhf.tensorlib
-    assert tb.astensor('Hello')
-
-
 @pytest.mark.xfail(raises=KeyError)
 def test_astensor_dtype(backend):
     tb = pyhf.tensorlib


### PR DESCRIPTION
# Description

In `mxnet >= v1.4.0` the shape of a `NDArray` when a scalar has been passed to it is empty. As a result, this should be caught and forced to have a consistent shape by wrapping the scalar in a list. However, at this point it is probably worth enforcing a default shape on tensors made from scalars, as the different tensor libraries handle them differently and we should have a consistent form.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Ensure non-empty tensor shape for consistency
   - Do this by asking for forgiveness and attempting to access shape information, and if it fails modifying the tensor object such that it has the proper shape
* Remove generic_len function from backends as a consistent tensor shape makes it unnecessary
* Add error logging and raise KeyError if an unsupported dtype is used for the tensorlibs astensor method
* Add tests for tensor shape for scalars
* Add tests for bad tensor dtypes
```
