### PR TITLE
Use Xenial and Python 3.7 as defaults in Travis CI for speed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: xenial
 language: python
 cache: pip
 python:
+  - '3.6'
   - '3.7'
 before_install:
   - sudo apt-get install libtcmalloc-minimal4
@@ -16,6 +17,10 @@ script:
   - python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/test_notebooks.py
   - if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then black --check --diff --verbose .; fi
 after_success: if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then coveralls; fi
+# Include to force matrix expansion but use trusty for Python 3.6 instead
+matrix:
+  exclude:
+    - python: '3.6'
 
 # always test (on both 'push' and 'pr' builds in Travis)
 # test docs on 'pr' builds and 'push' builds on master
@@ -42,14 +47,14 @@ jobs:
   - dist: trusty
     python: '3.6'
   - name: "Python 2.7 Notebook Tests"
-    dist: trusty
     python: '2.7'
+    dist: trusty
     script:
       - python -m pytest tests/test_notebooks.py
     after_success: skip
   - name: "Python 3.6 Notebook Tests"
-    dist: trusty
     python: '3.6'
+    dist: trusty
     script:
       - python -m pytest tests/test_notebooks.py
     after_success: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 # test matrix
-dist: trusty
+dist: xenial
 language: python
 cache: pip
 python:
-  - '2.7'
-  - '3.6'
+  - '3.7'
 before_install:
   - sudo apt-get install libtcmalloc-minimal4
   - export LD_PRELOAD="/usr/lib/libtcmalloc_minimal.so.4"
@@ -15,8 +14,8 @@ install:
 script:
   - pyflakes pyhf
   - python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/test_notebooks.py
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then black --check --diff --verbose .; fi
-after_success: if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then coveralls; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then black --check --diff --verbose .; fi
+after_success: if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then coveralls; fi
 
 # always test (on both 'push' and 'pr' builds in Travis)
 # test docs on 'pr' builds and 'push' builds on master
@@ -38,26 +37,29 @@ env:
 
 jobs:
   include:
-  - dist: xenial
-    python: '3.7'
+  - dist: trusty
+    python: '2.7'
+  - dist: trusty
+    python: '3.6'
   - name: "Python 2.7 Notebook Tests"
+    dist: trusty
     python: '2.7'
     script:
       - python -m pytest tests/test_notebooks.py
     after_success: skip
   - name: "Python 3.6 Notebook Tests"
+    dist: trusty
     python: '3.6'
     script:
       - python -m pytest tests/test_notebooks.py
     after_success: skip
   - name: "Python 3.7 Notebook Tests"
-    dist: xenial
     python: '3.7'
     script:
       - python -m pytest tests/test_notebooks.py
     after_success: skip
   - stage: benchmark
-    python: '3.6'
+    python: '3.7'
     before_install:
       - sudo apt-get install libtcmalloc-minimal4
       - export LD_PRELOAD="/usr/lib/libtcmalloc_minimal.so.4"
@@ -68,7 +70,7 @@ jobs:
     script: python -m pytest -r sx --benchmark-sort=mean tests/benchmarks/
     after_success: skip
   - stage: docs
-    python: '3.6'
+    python: '3.7'
     before_install:
       - sudo apt-get update
       - sudo apt-get -qq install pandoc
@@ -91,7 +93,7 @@ jobs:
       on:
         branch: master
   - stage: binder
-    python: '3.6'
+    python: '3.7'
     before_install: skip
     install: skip
     script:
@@ -99,7 +101,7 @@ jobs:
       - bash binder/trigger_binder.sh https://mybinder.org/build/gh/diana-hep/pyhf/"${TRAVIS_BRANCH}"
     after_success: skip
   - stage: deploy
-    python: '3.6'
+    python: '3.7'
     install: skip
     script: skip
     after_success: echo "Skipping after_success"


### PR DESCRIPTION
# Description

Resolves #417 

As shown in Issue #417, if Xenial and Python 3.7 are used as the default OS and Python runtime in Travis CI there is a speed boost in running tests, resulting in test suites that are few minutes faster.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use Xenial Xerus as the default OS and use Python 3.7 as the default Python runtime in Travis CI for shorter tests
* Use Trusty Tahr as the Travis CI OS for testing with Python 2.7 and Python 3.6 runtimes
```
