### PR TITLE
 Use PEP 440/508 compatible version syntax in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as readme_md
 
 extras_require = {
     'tensorflow': [
-        'tensorflow~=1.12.0',
+        'tensorflow~=1.13.1',
         'tensorflow-probability~=0.5.0',
         'numpy<=1.14.5,>=1.14.0',  # Lower of 1.14.0 instead of 1.13.3 to ensure doctest pass
         'setuptools<=39.1.0',

--- a/setup.py
+++ b/setup.py
@@ -18,12 +18,7 @@ extras_require = {
         'setuptools<=39.1.0',
     ],
     'torch': ['torch~=1.0'],
-    'mxnet': [
-        'mxnet~=1.0',
-        'requests<2.19.0,>=2.18.4',
-        'numpy<1.15.0,>=1.8.2',
-        'requests<2.19.0,>=2.18.4',
-    ],
+    'mxnet': ['mxnet~=1.0', 'requests~=2.18.4', 'numpy<1.15.0,>=1.8.2'],
     # 'dask': [
     #     'dask[array]'
     # ],

--- a/setup.py
+++ b/setup.py
@@ -12,14 +12,14 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as readme_md
 
 extras_require = {
     'tensorflow': [
-        'tensorflow~=1.13.1',
-        'tensorflow-probability~=0.5.0',
+        'tensorflow~=1.13',
+        'tensorflow-probability~=0.5',
         'numpy<=1.14.5,>=1.14.0',  # Lower of 1.14.0 instead of 1.13.3 to ensure doctest pass
         'setuptools<=39.1.0',
     ],
-    'torch': ['torch~=1.0.0'],
+    'torch': ['torch~=1.0'],
     'mxnet': [
-        'mxnet~=1.0.0',
+        'mxnet~=1.0',
         'requests<2.19.0,>=2.18.4',
         'numpy<1.15.0,>=1.8.2',
         'requests<2.19.0,>=2.18.4',
@@ -31,7 +31,7 @@ extras_require = {
     'minuit': ['iminuit'],
     'develop': [
         'pyflakes',
-        'pytest~=3.5.1',
+        'pytest~=3.5',
         'pytest-cov>=2.5.1',
         'pytest-mock',
         'pytest-benchmark[histogram]',
@@ -41,8 +41,8 @@ extras_require = {
         'matplotlib',
         'jupyter',
         'nbdime',
-        'uproot~=3.3.0',
-        'papermill~=0.16.0',
+        'uproot~=3.3',
+        'papermill~=0.16',
         'graphviz',
         'bumpversion',
         'sphinx',

--- a/setup.py
+++ b/setup.py
@@ -12,14 +12,14 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as readme_md
 
 extras_require = {
     'tensorflow': [
-        'tensorflow>=1.12.0',
-        'tensorflow-probability>=0.5.0',
+        'tensorflow~=1.12.0',
+        'tensorflow-probability~=0.5.0',
         'numpy<=1.14.5,>=1.14.0',  # Lower of 1.14.0 instead of 1.13.3 to ensure doctest pass
         'setuptools<=39.1.0',
     ],
-    'torch': ['torch>=1.0.0'],
+    'torch': ['torch~=1.0.0'],
     'mxnet': [
-        'mxnet>=1.0.0',
+        'mxnet~=1.0.0',
         'requests<2.19.0,>=2.18.4',
         'numpy<1.15.0,>=1.8.2',
         'requests<2.19.0,>=2.18.4',
@@ -31,7 +31,7 @@ extras_require = {
     'minuit': ['iminuit'],
     'develop': [
         'pyflakes',
-        'pytest<4.0.0,>=3.5.1',
+        'pytest~=3.5.1',
         'pytest-cov>=2.5.1',
         'pytest-mock',
         'pytest-benchmark[histogram]',
@@ -41,8 +41,8 @@ extras_require = {
         'matplotlib',
         'jupyter',
         'nbdime',
-        'uproot>=3.3.0',
-        'papermill>=0.16.0',
+        'uproot~=3.3.0',
+        'papermill~=0.16.0',
         'graphviz',
         'bumpversion',
         'sphinx',


### PR DESCRIPTION
# Description

Resolves #397

To ensure stable APIs for the computational backends while not pinning at specific versions &mdash; to keep pyhf acting like a proper library and not an application &mdash; use PEP 440/508's compatible version syntax for the backend releases to pin them at their current major release version while allowing for minor version updates. This is also done for pytest, uproot, and papermill.

This also has the nice feature of being able to intentionally choose when to update to a newer backend API even if the backend has had a new major release with API breaking changes for a long time.

Noting that if the release is specified down to the bug fix release (`X.Y.Z`) then it will be pinned down to the minor release (`X.Y`). c.f. [PEP 404](https://www.python.org/dev/peps/pep-0440/#compatible-release):

>  the following groups of version clauses are equivalent:
> ```
> ~= 1.4.5
> >= 1.4.5, == 1.4.*
> ```

so as updates from other libraries are desirable, as long as there is no API breaking changes, then all dependencies should be specified as

```
~= X.Y
```

unless, like requests, they need to be specified all the way down to `X.Y.*`

As TensorFlow `v1.13.1` was the first release to support Python 3.7 it must be the lowest version number specified in `setup.py` to use compatible version syntax.

c.f.
- https://www.python.org/dev/peps/pep-0440/#compatible-release
- https://www.python.org/dev/peps/pep-0508

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use PEP 440/508's compatible version syntax
   - https://www.python.org/dev/peps/pep-0440/#compatible-release
   - https://www.python.org/dev/peps/pep-0508
* Specify down only to the minor release in most cases to allow for non-API breaking updates
* Require a TensorFlow release compatible with v1.13 to support Python 3.7
* Remove redundant install of requests
```
