### PR TITLE
Use sorted() to maintain ordering of channel/samples/modifiers/parameters

### DIFF
--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -89,10 +89,10 @@ class _ModelConfig(object):
                         paramset_requirements
                     )
 
-        self.channels = list(set(self.channels))
-        self.samples = list(set(self.samples))
-        self.parameters = list(set(self.parameters))
-        self.modifiers = list(set(self.modifiers))
+        self.channels = sorted(list(set(self.channels)))
+        self.samples = sorted(list(set(self.samples)))
+        self.parameters = sorted(list(set(self.parameters)))
+        self.modifiers = sorted(list(set(self.modifiers)))
         self.channel_nbins = self.channel_nbins
         self._create_and_register_paramsets(
             _paramsets_requirements, _paramsets_user_configs


### PR DESCRIPTION
# Description

This resolves #414.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
- we use list(set(...)) to generate the metadata of a given spec but set() does not guarantee order
```