### PR TITLE
fix divide to only divide non-zero pieces.

### DIFF
--- a/pyhf/writexml.py
+++ b/pyhf/writexml.py
@@ -132,6 +132,7 @@ def build_modifier(modifierspec, channelname, samplename, sampledata):
                 sampledata,
                 out=np.zeros_like(sampledata),
                 where=np.asarray(sampledata) != 0,
+                dtype='float',
             ).tolist(),
         )
     elif modifierspec['type'] == 'shapesys':
@@ -143,7 +144,9 @@ def build_modifier(modifierspec, channelname, samplename, sampledata):
         _export_root_histogram(
             attrs['HistoName'],
             [
-                np.divide(a, b, out=np.zeros_like(a), where=np.asarray(b) != 0)
+                np.divide(
+                    a, b, out=np.zeros_like(a), where=np.asarray(b) != 0, dtype='float'
+                )
                 for a, b in np.array((modifierspec['data'], sampledata)).T
             ],
         )

--- a/pyhf/writexml.py
+++ b/pyhf/writexml.py
@@ -126,7 +126,13 @@ def build_modifier(modifierspec, channelname, samplename, sampledata):
         del attrs['Name']
         # need to make this a relative uncertainty stored in ROOT file
         _export_root_histogram(
-            attrs['HistoName'], np.divide(modifierspec['data'], sampledata).tolist()
+            attrs['HistoName'],
+            np.divide(
+                modifierspec['data'],
+                sampledata,
+                out=np.zeros_like(sampledata),
+                where=np.asarray(sampledata) != 0,
+            ).tolist(),
         )
     elif modifierspec['type'] == 'shapesys':
         attrs['ConstraintType'] = 'Poisson'
@@ -136,7 +142,10 @@ def build_modifier(modifierspec, channelname, samplename, sampledata):
         # need to make this a relative uncertainty stored in ROOT file
         _export_root_histogram(
             attrs['HistoName'],
-            [np.divide(a, b) for a, b in zip(modifierspec['data'], sampledata)],
+            [
+                np.divide(a, b, out=np.zeros_like(a), where=np.asarray(b) != 0)
+                for a, b in zip(modifierspec['data'], sampledata)
+            ],
         )
     else:
         log.warning(

--- a/pyhf/writexml.py
+++ b/pyhf/writexml.py
@@ -144,7 +144,7 @@ def build_modifier(modifierspec, channelname, samplename, sampledata):
             attrs['HistoName'],
             [
                 np.divide(a, b, out=np.zeros_like(a), where=np.asarray(b) != 0)
-                for a, b in zip(modifierspec['data'], sampledata)
+                for a, b in np.array((modifierspec['data'], sampledata)).T
             ],
         )
     else:

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -228,6 +228,26 @@ def test_export_sample(mocker, spec):
 
 
 @pytest.mark.parametrize(
+    "spec", [spec_staterror(), spec_shapesys()], ids=['staterror', 'shapesys']
+)
+def test_export_sample_zerodata(mocker, spec):
+    channelspec = spec['channels'][0]
+    channelname = channelspec['name']
+    samplespec = channelspec['samples'][1]
+    samplename = samplespec['name']
+    sampledata = [0.0] * len(samplespec['data'])
+
+    mocker.patch('pyhf.writexml._ROOT_DATA_FILE')
+    # make sure no RuntimeWarning, https://stackoverflow.com/a/45671804
+    with pytest.warns(None) as record:
+        for modifierspec in samplespec['modifiers']:
+            modifier = pyhf.writexml.build_modifier(
+                modifierspec, channelname, samplename, sampledata
+            )
+    assert not record.list
+
+
+@pytest.mark.parametrize(
     "spec",
     [spec_staterror(), spec_histosys(), spec_normsys(), spec_shapesys()],
     ids=['staterror', 'histosys', 'normsys', 'shapesys'],


### PR DESCRIPTION
# Description

In situations where, for example, sample-data is zero - this causes a runtime warning about divide (and returns a undefined instead of zero) when we need to convert from absolute uncertainties back to relative uncertainties. This is a slight drawback in the translation, but should not affect the end-results whether or not we choose to return undefined or zero if it's treated identically in both cases.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
- only divide out sample data in cases where sample data is non-zero when exporting to XML
- this only affects modifiers that convert from absolute uncertainties back to relative uncertainties
```