### PR TITLE
Fix minor bugs with the xml exporting in the real world

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include pyhf/data/spec.json
+include pyhf/data/HistFactorySchema.dtd
 

--- a/pyhf/data/HistFactorySchema.dtd
+++ b/pyhf/data/HistFactorySchema.dtd
@@ -1,0 +1,160 @@
+
+<!-- The top level combination spec -->
+<!-- OutputFilePrefix: Prefix to the output root file to be created (inspection histograms) -->
+<!-- Mode: Type of the analysis -->
+<!ELEMENT Combination (Function*,Input+,Measurement*)>
+<!ATTLIST Combination
+        OutputFilePrefix         CDATA            #REQUIRED
+        Mode                     CDATA            #IMPLIED
+> 
+
+<!-- Input files detailing the channels. One channel per file -->
+<!ELEMENT Function  EMPTY>
+<!ATTLIST Function 
+	  Name                 CDATA         #REQUIRED
+	  Expression           CDATA         #REQUIRED
+	  Dependents           CDATA         #REQUIRED
+>
+
+<!-- Input files detailing the channels. One channel per file -->
+<!ELEMENT Input (#PCDATA) >
+
+<!-- Configuration for each measurement -->
+<!-- Name: to be used as the heading in the table -->
+<!-- Lumi: the luminosity of the measurement -->
+<!-- LumiRelErr: the relative error known for the lumi -->
+<!-- BinLow: the lowest bin number used for the measurement (inclusive) -->
+<!-- BinHigh: the highest bin number used for the measurement (exclusive) -->
+<!-- Mode: type of the measurement (a closed list of ...) -->
+<!-- ExportOnly: if "True" skip fit, only export model -->
+<!ELEMENT Measurement (POI,ParamSetting*,ConstraintTerm*) >
+<!ATTLIST Measurement 
+        Name              CDATA            #REQUIRED
+        Lumi              CDATA            #REQUIRED
+        LumiRelErr        CDATA            #REQUIRED
+        BinLow            CDATA            #IMPLIED
+        BinHigh           CDATA            #IMPLIED
+        Mode              CDATA            #IMPLIED
+        ExportOnly        CDATA            #IMPLIED
+>
+
+<!-- Specify what you are measuring. Corresponds to the name specified in the construction
+of the model in the channel setup. Typically the NormFactor for xsec measurements -->
+<!ELEMENT POI (#PCDATA) >
+
+<!-- Specify what parameters are fixed, or have particular value -->
+<!-- Val: set the value of the parameter -->
+<!-- Const: set this parameter constant -->
+<!ELEMENT ParamSetting (#PCDATA)>
+<!ATTLIST ParamSetting 
+        Val               CDATA           #IMPLIED
+        Const             CDATA           #IMPLIED        
+>
+
+<!-- Specify an alternative shape to use for given constraint terms (Gaussian is used if this is not specified) -->
+<!-- Type: can be Gamma or Uniform -->
+<!-- RelativeUncertainty: relative uncertainty on the shape -->
+<!ELEMENT ConstraintTerm (#PCDATA)>
+<!ATTLIST ConstraintTerm 
+        Type                  CDATA       #REQUIRED
+        RelativeUncertainty   CDATA       #IMPLIED
+>
+
+<!-- Top element for channels. InputFile, HistoName and HistoPath
+can be set at this level in which case they will become defaul to
+all subsequent elements. Otherwise they can be set in individual 
+subelements -->
+<!ELEMENT Channel (Data*,StatErrorConfig*,Sample+)>
+<!-- InputFile: input file where the input histogram can be found (use abs path) -->
+<!-- HistoPath: the path (within the root file) where the histogram can be found -->
+<!-- HistoName: the name of the histogram to be used for this (and following in not overridden) item -->
+<!ATTLIST Channel
+        Name              CDATA            #REQUIRED
+        InputFile         CDATA            #IMPLIED
+        HistoPath         CDATA            #IMPLIED
+        HistoName         CDATA            #IMPLIED
+>
+
+<!-- Data to be fit. If you don't provide it, Asimov data will be created -->
+<!-- InputFile: any item set here will override the configuration for the subelements. 
+For this element there is no sublemenents so the setting will only have local effects -->
+<!ELEMENT Data EMPTY>
+<!ATTLIST Data
+        InputFile         CDATA            #IMPLIED
+        HistoPath         CDATA            #IMPLIED
+        HistoName         CDATA            #IMPLIED
+>
+
+<!ELEMENT StatErrorConfig EMPTY>
+<!ATTLIST StatErrorConfig
+        RelErrorThreshold      CDATA            #IMPLIED
+        ConstraintType         CDATA            #IMPLIED
+>
+
+
+<!-- Sample elements are made up of systematic variations -->
+<!ELEMENT Sample (StatError | HistoSys | OverallSys | ShapeSys | NormFactor | ShapeFactor)*>
+<!ATTLIST Sample
+        Name              CDATA            #REQUIRED
+        InputFile         CDATA            #IMPLIED
+        HistoName         CDATA            #IMPLIED
+        HistoPath         CDATA            #IMPLIED
+        NormalizeByTheory      CDATA       #IMPLIED
+> 
+
+<!-- Systematics for which the variation is provided by histograms -->
+<!ELEMENT StatError EMPTY>
+<!ATTLIST StatError
+	  Activate          CDATA            #REQUIRED
+          HistoName         CDATA            #IMPLIED
+          InputFile         CDATA            #IMPLIED
+          HistoPath         CDATA            #IMPLIED
+> 
+
+<!ELEMENT HistoSys EMPTY>
+<!ATTLIST HistoSys
+        Name              CDATA            #REQUIRED
+        InputFile         CDATA            #IMPLIED
+        HistoFileHigh     CDATA            #IMPLIED
+        HistoPathHigh     CDATA            #IMPLIED
+        HistoNameHigh     CDATA            #IMPLIED
+        HistoFileLow      CDATA            #IMPLIED
+        HistoPathLow      CDATA            #IMPLIED
+        HistoNameLow      CDATA            #IMPLIED
+> 
+
+<!-- Systematics for which the variation is provided by simple overall scaling -->
+<!ELEMENT OverallSys EMPTY>
+<!ATTLIST OverallSys
+        Name              CDATA            #REQUIRED
+        High              CDATA            #REQUIRED
+        Low               CDATA            #REQUIRED
+> 
+
+<!-- Systematics for which the variation is provided by simple overall scaling -->
+<!ELEMENT ShapeSys EMPTY>
+<!ATTLIST ShapeSys
+          Name              CDATA            #REQUIRED
+          HistoName         CDATA            #REQUIRED
+          HistoPath         CDATA            #IMPLIED
+          InputFile         CDATA            #IMPLIED
+          ConstraintType    CDATA            #IMPLIED
+> 
+
+<!-- Scaling factor, which may be the parameter of interest for cross section measurements-->
+<!ELEMENT NormFactor EMPTY>
+<!ATTLIST NormFactor
+        Name              CDATA            #REQUIRED
+        Val               CDATA            #REQUIRED
+        High              CDATA            #REQUIRED
+        Low               CDATA            #REQUIRED
+        Const             CDATA            #IMPLIED
+> 
+
+
+<!-- Systematics for which the variation is provided by simple overall scaling -->
+<!ELEMENT ShapeFactor EMPTY>
+<!ATTLIST ShapeFactor
+          Name              CDATA            #REQUIRED
+> 
+

--- a/pyhf/writexml.py
+++ b/pyhf/writexml.py
@@ -70,7 +70,13 @@ def build_measurement(measurementspec):
             lumierr = parameter['sigmas'][0]
 
     # define measurement
-    meas = ET.Element("Measurement", Name=name, Lumi=str(lumi), LumiRelErr=str(lumierr))
+    meas = ET.Element(
+        "Measurement",
+        Name=name,
+        Lumi=str(lumi),
+        LumiRelErr=str(lumierr),
+        ExportOnly=str(True),
+    )
     poiel = ET.Element('POI')
     poiel.text = poi
     meas.append(poiel)

--- a/pyhf/writexml.py
+++ b/pyhf/writexml.py
@@ -115,6 +115,7 @@ def build_modifier(modifierspec, channelname, samplename, sampledata):
         attrs['HistoName'] = _make_hist_name(
             channelname, samplename, modifierspec['name']
         )
+        del attrs['Name']
         # need to make this a relative uncertainty stored in ROOT file
         _export_root_histogram(
             attrs['HistoName'], np.divide(modifierspec['data'], sampledata).tolist()

--- a/pyhf/writexml.py
+++ b/pyhf/writexml.py
@@ -189,7 +189,7 @@ def writexml(spec, specdir, data_rootdir, resultprefix):
 
     shutil.copyfile(
         pkg_resources.resource_filename(__name__, 'data/HistFactorySchema.dtd'),
-        os.path.dirname(specdir),
+        os.path.join(os.path.dirname(specdir), 'HistFactorySchema.dtd'),
     )
     combination = ET.Element(
         "Combination", OutputFilePrefix=os.path.join('.', specdir, resultprefix)

--- a/pyhf/writexml.py
+++ b/pyhf/writexml.py
@@ -197,6 +197,9 @@ def writexml(spec, specdir, data_rootdir, resultprefix):
                 channel = build_channel(channelspec, spec.get('data'))
                 indent(channel)
                 channelfile.write(
+                    "<!DOCTYPE Channel SYSTEM '../HistFactorySchema.dtd'>\n\n"
+                )
+                channelfile.write(
                     ET.tostring(channel, encoding='utf-8').decode('utf-8')
                 )
 
@@ -207,4 +210,6 @@ def writexml(spec, specdir, data_rootdir, resultprefix):
     for measurement in spec['toplvl']['measurements']:
         combination.append(build_measurement(measurement))
     indent(combination)
-    return ET.tostring(combination, encoding='utf-8')
+    return "<!DOCTYPE Combination  SYSTEM 'HistFactorySchema.dtd'>\n\n".encode(
+        "utf-8"
+    ) + ET.tostring(combination, encoding='utf-8')

--- a/pyhf/writexml.py
+++ b/pyhf/writexml.py
@@ -1,6 +1,8 @@
 import logging
 
 import os
+import shutil
+import pkg_resources
 import xml.etree.cElementTree as ET
 import numpy as np
 import uproot
@@ -185,6 +187,10 @@ def build_channel(channelspec, dataspec):
 def writexml(spec, specdir, data_rootdir, resultprefix):
     global _ROOT_DATA_FILE
 
+    shutil.copyfile(
+        pkg_resources.resource_filename(__name__, 'data/HistFactorySchema.dtd'),
+        os.path.dirname(specdir),
+    )
     combination = ET.Element(
         "Combination", OutputFilePrefix=os.path.join('.', specdir, resultprefix)
     )

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -197,7 +197,9 @@ def test_export_modifier(mocker, spec, has_root_data, attrs):
     modifier = pyhf.writexml.build_modifier(
         modifierspec, channelname, samplename, sampledata
     )
-    assert modifier.attrib['Name'] == modifierspec['name']
+    # if the modifier is a staterror, it has no Name
+    if 'Name' in modifier.attrib:
+        assert modifier.attrib['Name'] == modifierspec['name']
     assert all(attr in modifier.attrib for attr in attrs)
     assert pyhf.writexml._ROOT_DATA_FILE.__setitem__.called == has_root_data
 


### PR DESCRIPTION
# Description

This resolves #433.

The XML exporting functionality `json2xml` was only validated in the context of passing it back through `xml2json` and checking that things worked. However, in the _scary_ *real* world where `hist2workspace` exists, it wasn't working. This was for a few reasons:
- HistFactorySchema.dtd was not included anywhere, so doctypes were added to the XML outputs as appropriate
- HistFactorySchema.dtd is now copied over into the output directory from `json2xml` and as such is added as `pyhf` data and will be shipped with future versions of the package
- ExportOnly is added to the measurement object since we don't want `hist2workspace` to actually run fits


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
- HistFactorySchema.dtd was not included anywhere, so doctypes were added to the XML outputs as appropriate
- HistFactorySchema.dtd is now copied over into the output directory from `json2xml` and as such is added as `pyhf` data and will be shipped with future versions of the package
- ExportOnly is added to the measurement object since we don't want `hist2workspace` to actually run fits
```