### PR TITLE
Finish adding deploy testing with TestPyPI

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,1 @@
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ stages:
   - name: binder
     if: (branch = master) AND (NOT (type IN (pull_request)))
   - name: deploy
-    if: (tag =~ v[0-9\.]*)
+    # if: (tag =~ v[0-9\.]*)
 
 env:
   global:
@@ -122,6 +122,7 @@ jobs:
         secure: CqHxAg2GWY+7ogMKJYCqH8Eynmc1Xhh+WocntEfsJXOgsqksmHF5q9dp6IxGwrrts1ZWbxOs80mici2LSAxtHnVBAXfiqWm5cZ6nEv6+hvAzidvGO7Q2OVs3CIVKU4jCDg2BJIBo84Whqwe6T5S+DKUDo6PYQUtIvHqnO4PmDyB2Y2rLquavMqMkh8wIfFaDj51J5zm2aNdXx4349LvlMcW2yn0/Mh1t6yP1LUCkirCPjdIAljmqmrkxscEdCepR3sXjgYggpW/RLTXtMaUc/6Pz1Ax5uU3Y/mtuXT19lC+9PiFpciuLBvM6h0RjRz87tVE4US7DfbjZIIZFdrd97eog9Jqh0cDsD+lymgzTpeEaisXtDwBlI+osUtjB5d1rWCtsIu39fBRi368SLgBH3yrbYEIuNBzczeQ1wxMmJlWflQ/6nbPEaRxKpMZVjMRngdd8rccNj0vAJxsMlzqJZ99RbUjyMQ5n1JO1GU/9mnu1NH/+gZrvoGCLBaqKQDewrTkVKAMTmm/lti9hIEpgXr+U5KyAM0dtvU3ncLCEhIV6H9KujHx8S52hz/C1OJAXwh4otC2rnuiS21XhFfADJbVtXE9lBX0ANgc/pWs11Yu38ZbfoXnx5GkALuUnw2jZ2ZeEiugu5/dqlPTmleBgkxcRsVNx8/fft3raIscIYjM=
       distributions: "sdist bdist_wheel"
   - stage: deploy
+    if: (tag =~ v[0-9\.]*)
     python: '3.7'
     install: skip
     script: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,7 +107,7 @@ jobs:
   - stage: deploy
     # Tests deployment to PyPI for all commits to master
     name: "TestPyPI deploy"
-    if: (branch = master) AND (NOT (type IN (pull_request)))
+    if: (branch = master) AND type = push
     env:
       # Signal that setup.py should use use_scm_version with local_scheme
       TESTPYPI_UPLOAD: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,6 @@ stages:
     if: (branch = master)
   - name: binder
     if: (branch = master) AND (NOT (type IN (pull_request)))
-  - name: test_deploy
-    # if: (branch = master) AND (NOT (type IN (pull_request)))
   - name: deploy
     if: (tag =~ v[0-9\.]*)
 
@@ -107,7 +105,9 @@ jobs:
       # Use Binder build API to trigger repo2docker to build image
       - bash binder/trigger_binder.sh https://mybinder.org/build/gh/diana-hep/pyhf/"${TRAVIS_BRANCH}"
     after_success: skip
-  - stage: test_deploy
+  - stage: deploy
+    # Tests deployment to PyPI for all tags
+    if: type NOT IN (pull_request)  # Always run, except if PR
     name: "TestPyPI deploy"
     python: '3.7'
     install: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -109,6 +109,9 @@ jobs:
     # Tests deployment to PyPI for all tags
     if: type NOT IN (pull_request)  # Always run, except if PR
     name: "TestPyPI deploy"
+    # Signal that setup.py should use use_scm_version=True
+    env:
+      TESTPYPI_UPLOAD: true
     python: '3.7'
     install: skip
     script: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -118,9 +118,6 @@ jobs:
     deploy:
       provider: pypi
       server: https://test.pypi.org/legacy/
-      # This test case only
-      on:
-        all_branches: true
       username:
         secure: KDi40+7LVX2E/tWtVhGB/jWrNDqNiO+dKzqkbOTP7ZvGrMu3VIVA1KbfDiWxygd5rgC7UAQcqTFbUHnwuyFAmooIhH3fDwpzpugz5zzW4Hia0eBUanarw40DHlBS0wVzw+zZoLP/wltR8Dg75vp2awPTqrvFyq444Jgzzah+xhHwTYx4VB9oeMAoiS0OSLn561pR1N+nzSRMe3R1Sl8AZtPLTCgOZ5tZARZjqiqtYXfTEaMQPj/BNmVYatsaUkCkljZjiLv/uiL6Ushz/Y0dhPdVF63dKDTM6NvDxT+pBA/+58U6RqcRmMdlYmCurgKTJ5W4VAXckHXaYwu5pvrd1pxqPJ7oNvdpDZ9JktHsQog8IxVjoij8Je5T4iE3hjEH/Jm8yKUL2WlPeyLxV0S9xmSdhTIeTZgAtbPQgP0KN7SC1ZB/S7irstJ68PilHc/ZxBbYthGu0tPOmHHye+lzVyV6qAhZkbRFarro0MgWjJR9U8vM5JHFsEvBm7ghHaKDGd75wE9MDHqxftxXGKJbZ19OlRCqnte8LA8a1Wa0E5Iw3QPaG7eq2cBp3TwwECw0ipMBBXfOz4ZIIcDRC/vcnW03zf6ziWaZ152QAVsmiJqXnzFBV7thPA28vqQtv0vAdzXO8e2lROYz18z8m2LTdvG4DiNxkNlN7KHjK1i+VEg=
       password:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ stages:
   - name: binder
     if: (branch = master) AND (NOT (type IN (pull_request)))
   - name: deploy
-    # if: (tag =~ v[0-9\.]*)
 
 env:
   global:
@@ -106,11 +105,11 @@ jobs:
       - bash binder/trigger_binder.sh https://mybinder.org/build/gh/diana-hep/pyhf/"${TRAVIS_BRANCH}"
     after_success: skip
   - stage: deploy
-    # Tests deployment to PyPI for all tags
-    if: type NOT IN (pull_request)  # Always run, except if PR
+    # Tests deployment to PyPI for all commits to master
     name: "TestPyPI deploy"
-    # Signal that setup.py should use use_scm_version=True
+    if: (branch = master) AND (NOT (type IN (pull_request)))
     env:
+      # Signal that setup.py should use use_scm_version with local_scheme
       TESTPYPI_UPLOAD: true
     python: '3.7'
     install: skip
@@ -128,8 +127,8 @@ jobs:
         secure: CqHxAg2GWY+7ogMKJYCqH8Eynmc1Xhh+WocntEfsJXOgsqksmHF5q9dp6IxGwrrts1ZWbxOs80mici2LSAxtHnVBAXfiqWm5cZ6nEv6+hvAzidvGO7Q2OVs3CIVKU4jCDg2BJIBo84Whqwe6T5S+DKUDo6PYQUtIvHqnO4PmDyB2Y2rLquavMqMkh8wIfFaDj51J5zm2aNdXx4349LvlMcW2yn0/Mh1t6yP1LUCkirCPjdIAljmqmrkxscEdCepR3sXjgYggpW/RLTXtMaUc/6Pz1Ax5uU3Y/mtuXT19lC+9PiFpciuLBvM6h0RjRz87tVE4US7DfbjZIIZFdrd97eog9Jqh0cDsD+lymgzTpeEaisXtDwBlI+osUtjB5d1rWCtsIu39fBRi368SLgBH3yrbYEIuNBzczeQ1wxMmJlWflQ/6nbPEaRxKpMZVjMRngdd8rccNj0vAJxsMlzqJZ99RbUjyMQ5n1JO1GU/9mnu1NH/+gZrvoGCLBaqKQDewrTkVKAMTmm/lti9hIEpgXr+U5KyAM0dtvU3ncLCEhIV6H9KujHx8S52hz/C1OJAXwh4otC2rnuiS21XhFfADJbVtXE9lBX0ANgc/pWs11Yu38ZbfoXnx5GkALuUnw2jZ2ZeEiugu5/dqlPTmleBgkxcRsVNx8/fft3raIscIYjM=
       distributions: "sdist bdist_wheel"
   - stage: deploy
-    if: (tag =~ v[0-9\.]*)
     name: "PyPI deploy"
+    if: (tag =~ v[0-9\.]*)
     python: '3.7'
     install: skip
     script: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,6 +116,9 @@ jobs:
     deploy:
       provider: pypi
       server: https://test.pypi.org/legacy/
+      # This test case only
+      on:
+        all_branches: true
       username:
         secure: KDi40+7LVX2E/tWtVhGB/jWrNDqNiO+dKzqkbOTP7ZvGrMu3VIVA1KbfDiWxygd5rgC7UAQcqTFbUHnwuyFAmooIhH3fDwpzpugz5zzW4Hia0eBUanarw40DHlBS0wVzw+zZoLP/wltR8Dg75vp2awPTqrvFyq444Jgzzah+xhHwTYx4VB9oeMAoiS0OSLn561pR1N+nzSRMe3R1Sl8AZtPLTCgOZ5tZARZjqiqtYXfTEaMQPj/BNmVYatsaUkCkljZjiLv/uiL6Ushz/Y0dhPdVF63dKDTM6NvDxT+pBA/+58U6RqcRmMdlYmCurgKTJ5W4VAXckHXaYwu5pvrd1pxqPJ7oNvdpDZ9JktHsQog8IxVjoij8Je5T4iE3hjEH/Jm8yKUL2WlPeyLxV0S9xmSdhTIeTZgAtbPQgP0KN7SC1ZB/S7irstJ68PilHc/ZxBbYthGu0tPOmHHye+lzVyV6qAhZkbRFarro0MgWjJR9U8vM5JHFsEvBm7ghHaKDGd75wE9MDHqxftxXGKJbZ19OlRCqnte8LA8a1Wa0E5Iw3QPaG7eq2cBp3TwwECw0ipMBBXfOz4ZIIcDRC/vcnW03zf6ziWaZ152QAVsmiJqXnzFBV7thPA28vqQtv0vAdzXO8e2lROYz18z8m2LTdvG4DiNxkNlN7KHjK1i+VEg=
       password:
@@ -123,6 +126,7 @@ jobs:
       distributions: "sdist bdist_wheel"
   - stage: deploy
     if: (tag =~ v[0-9\.]*)
+    name: "PyPI deploy"
     python: '3.7'
     install: skip
     script: skip

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,8 @@ universal = 1
 
 [metadata]
 license_file = LICENSE
+
+[options]
+setup_requires =
+    setuptools_scm>=1.15.0
+    setuptools_scm_git_archive>=1.0

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ def _is_test_pypi():
     set to true (c.f. .travis.yml)
 
     The use_scm_version kwarg accepts a callable for the local_scheme
-    configuration paramter with argument "version". This can be replaced
+    configuration parameter with argument "version". This can be replaced
     with a lambda as the desired version structure is {next_version}.dev{distance}
     c.f. https://github.com/pypa/setuptools_scm/#importing-in-setuppy
     """

--- a/setup.py
+++ b/setup.py
@@ -88,4 +88,5 @@ setup(
     extras_require=extras_require,
     entry_points={'console_scripts': ['pyhf=pyhf.commandline:pyhf']},
     dependency_links=[],
+    use_scm_version=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,26 @@ extras_require = {
 }
 extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 
+
+def _is_test_pypi():
+    """
+    Determine if the Travis CI environment has TESTPYPI_UPLOAD defined and
+    set to true (c.f. .travis.yml)
+
+    The use_scm_version kwarg accepts a callable for the local_scheme
+    configuration paramter with argument "version". This can be replaced
+    with a lambda as the desired version structure is {next_version}.dev{distance}
+    c.f. https://github.com/pypa/setuptools_scm/#importing-in-setuppy
+    """
+    from os import getenv
+
+    return (
+        {'local_scheme': lambda version: ''}
+        if getenv('TESTPYPI_UPLOAD') == 'true'
+        else False
+    )
+
+
 setup(
     name='pyhf',
     version='0.0.16',
@@ -88,5 +108,5 @@ setup(
     extras_require=extras_require,
     entry_points={'console_scripts': ['pyhf=pyhf.commandline:pyhf']},
     dependency_links=[],
-    use_scm_version=True,
+    use_scm_version=_is_test_pypi(),
 )

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,9 @@ def _is_test_pypi():
     configuration parameter with argument "version". This can be replaced
     with a lambda as the desired version structure is {next_version}.dev{distance}
     c.f. https://github.com/pypa/setuptools_scm/#importing-in-setuppy
+
+    As the scm versioning is only desired for TestPyPI, for depolyment to PyPI the version
+    controlled through bumpversion is used.
     """
     from os import getenv
 


### PR DESCRIPTION
# Description

Completes PR #429 (which was merged early by accident) and resolves #425 and resolves #432.

Inspired by Issue #410 and @webknjaz's tweet which inspired Issue #425 to have more robust deployment to PyPI this PR implements PR level deployments to [TestPyPI](https://test.pypi.org/) that are versioned with version structure of `{next_version}.dev{distance}` through use of [`setuptools-scm`](https://github.com/pypa/setuptools_scm/) and [`setuptools-scm-git-archive`](https://github.com/Changaco/setuptools_scm_git_archive/) and heavy copying of [`ansible-lint`'s approach](https://github.com/ansible/ansible-lint/blob/d27451783dbc4f408cef04096a139f6be61f7611/setup.py).

The level of deployment is set to push commits on `master` as we commit frequently enough that there isn't a need to pollute the area with a huge number of deployed versions.

As an example of the system working, by turning on deployment from all branches this PR [deployed](https://travis-ci.org/diana-hep/pyhf/jobs/518643360) [`pyhf 0.0.17.dev23`](https://test.pypi.org/project/pyhf/0.0.17.dev23/) on TestPyPI.

This PR also sets up the path to then complete Issues #410 and #399.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
- Add deployment of push commits to master to TestPyPI for deploy testing. This uses a TESTPYPI_UPLOAD environment variable to signal to setuptools-scm through setup.py.
- Add setup_requires of setuptools-scm and setuptools-scm-git-archive through setup.cfg
- Add .git_archival.txt and .gitattributes as required for setuptools-scm-git-archive
- For TestPyPI deploy job use type=push to avoid triggering on unintended builds
```
