### PR TITLE
Use GitHub hosted images as src target to support PyPI render

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ results obtained from this package are validated against output computed from Hi
 nobs = 55, b = 50, db = 7, nom_sig = 10.
 ```
 
-<img src="docs/_static/img/manual_1bin_55_50_7.png" alt="manual" width="500"/>
-<img src="docs/_static/img/hfh_1bin_55_50_7.png" alt="manual" width="500"/>
+<img src="https://raw.githubusercontent.com/diana-hep/pyhf/master/docs/_static/img/manual_1bin_55_50_7.png" alt="manual" width="500"/>
+<img src="https://raw.githubusercontent.com/diana-hep/pyhf/master/docs/_static/img/hfh_1bin_55_50_7.png" alt="manual" width="500"/>
 
 
 ## A two bin example
@@ -82,8 +82,8 @@ bin 1: nobs = 100, b = 100, db = 15., nom_sig = 30.
 bin 2: nobs = 145, b = 150, db = 20., nom_sig = 45.
 ```
 
-<img src="docs/_static/img/manual_2_bin_100.0_145.0_100.0_150.0_15.0_20.0_30.0_45.0.png" alt="manual" width="500"/>
-<img src="docs/_static/img/hfh_2_bin_100.0_145.0_100.0_150.0_15.0_20.0_30.0_45.0.png" alt="manual" width="500"/>
+<img src="https://raw.githubusercontent.com/diana-hep/pyhf/master/docs/_static/img/manual_2_bin_100.0_145.0_100.0_150.0_15.0_20.0_30.0_45.0.png" alt="manual" width="500"/>
+<img src="https://raw.githubusercontent.com/diana-hep/pyhf/master/docs/_static/img/hfh_2_bin_100.0_145.0_100.0_150.0_15.0_20.0_30.0_45.0.png" alt="manual" width="500"/>
 
 ## Installation
 


### PR DESCRIPTION
# Description

Resolves #410

For images in the README have their src target be the URL of their raw GitHub hosted versions and not a relative path inside the repo. The [reason for this is that](https://github.com/pypa/warehouse/issues/5246#issuecomment-451142432)

> PyPI does not support rendering from the package path itself, as it is not an image host.

and so without this the PyPI render will fail.

A working version of this can be seen on [TestPyPI release `0.0.17.dev22`](https://test.pypi.org/project/pyhf/0.0.17.dev22/) (note that this is `0.0.17.dev22` and not something expected like `0.0.18.dev1` as this PR branch was started before release `v0.0.17` of pyhf was cut and then rebased).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
- Use GitHub hosted image URL as src targets for images in README to support PyPI render. PyPI does not support rendering from the package path itself, as it is not an image host.
```
