### PR TITLE
Move writexml into the json2xml as uproot not required for pyhf usage

### DIFF
--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -4,7 +4,6 @@ import click
 import json
 import os
 
-from . import writexml
 from .utils import hypotest
 from .pdf import Workspace
 from .version import __version__
@@ -71,6 +70,8 @@ def xml2json(entrypoint_xml, basedir, output_file, track_progress):
 @click.option('--dataroot', default='data')
 @click.option('--resultprefix', default='FitConfig')
 def json2xml(workspace, output_dir, specroot, dataroot, resultprefix):
+    from . import writexml
+
     try:
         import uproot
 

--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -70,8 +70,6 @@ def xml2json(entrypoint_xml, basedir, output_file, track_progress):
 @click.option('--dataroot', default='data')
 @click.option('--resultprefix', default='FitConfig')
 def json2xml(workspace, output_dir, specroot, dataroot, resultprefix):
-    from . import writexml
-
     try:
         import uproot
 
@@ -82,6 +80,7 @@ def json2xml(workspace, output_dir, specroot, dataroot, resultprefix):
             "xmlio extra: pip install pyhf[xmlio] or install uproot "
             "manually: pip install uproot"
         )
+    from . import writexml
 
     ensure_dirs(output_dir)
     with click.open_file(workspace, 'r') as specstream:


### PR DESCRIPTION
# Description

This resolves #441. Uproot should not be required to use `pyhf`.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
- writexml import is moved into the `json2xml` function.
```