### PR TITLE
fix test

### DIFF
--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -794,13 +794,13 @@ def test_import_roundtrip(tmpdir, toplvl, basedir):
 
     data_before = [
         binvalue
-        for k in pdf_before.spec['channels']
+        for k in pdf_before.config.channels
         for binvalue in parsed_xml_before['data'][k['name']]
     ] + pdf_before.config.auxdata
 
     data_after = [
         binvalue
-        for k in pdf_after.spec['channels']
+        for k in pdf_after.config.channels
         for binvalue in parsed_xml_after['data'][k['name']]
     ] + pdf_after.config.auxdata
 


### PR DESCRIPTION
# Description

The roundtrip test relied on the ordering of the channels in the spec instead of the ordering defined by `_ModelConfig`. 

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [ ] "WIP" removed from the title of the pull request
- [ ] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

```
* Fixes data construction in roundtrip test
```


- [ ] Summarize commit messages into a comprehensive review of the PR
