### PR TITLE
Use --no-use-pep517 flag for editable mode with pyproject.toml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - export LD_PRELOAD="/usr/lib/libtcmalloc_minimal.so.4"
   - pip install --upgrade pip setuptools wheel
 install:
-  - pip install --ignore-installed -U -q -e .[complete]
+  - pip install --ignore-installed -U -q --no-use-pep517 -e .[complete]
   - pip freeze
 script:
   - pyflakes pyhf
@@ -69,7 +69,7 @@ jobs:
       - export LD_PRELOAD="/usr/lib/libtcmalloc_minimal.so.4"
       - pip install --upgrade pip setuptools wheel
     install:
-      - pip install --ignore-installed -U -q -e .[complete]
+      - pip install --ignore-installed -U -q --no-use-pep517 -e .[complete]
       - pip freeze
     script: python -m pytest -r sx --benchmark-sort=mean tests/benchmarks/
     after_success: skip
@@ -82,7 +82,7 @@ jobs:
       - export LD_PRELOAD="/usr/lib/libtcmalloc_minimal.so.4"
       - pip install --upgrade pip setuptools wheel
     install:
-      - pip install --ignore-installed -U -q -e .[complete]
+      - pip install --ignore-installed -U -q --no-use-pep517 -e .[complete]
       - pip freeze
     script:
       - python -m doctest README.md

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -11,7 +11,7 @@ and install all necessary packages for development
 
 .. code-block:: console
 
-    pip install --ignore-installed -U -e .[complete]
+    pip install --ignore-installed -U --no-use-pep517 -e .[complete]
 
 Then setup the Git pre-commit hook for `Black <https://github.com/ambv/black>`__  by running
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ include = '\.pyi?$'
 exclude = '''
 /(
     \.git
+  | .eggs
   | build
 )/
 '''


### PR DESCRIPTION
# Description

The reasons for this are probably best given in [`pip` Issue 6434](https://github.com/pypa/pip/issues/6434) and [PR 6442](https://github.com/pypa/pip/pull/6442). In short, though, with `pip` `v19.1` enforces [PEP 517 which does not allow for editable mode installations](https://www.python.org/dev/peps/pep-0517/#get-requires-for-build-sdist)

> Editable installs
>
>This PEP originally specified another hook, install_editable, to do an editable install (as with pip install -e). It was removed due to the complexity of the topic, but may be specified in a later PEP.

As pyhf has a [`pyproject.toml` file for Black](https://github.com/diana-hep/pyhf/blob/f7d27c7c18c131c51b990dcc1b38ce0da577469d/pyproject.toml) this breaks the setup as there is no PEP yet to specify editable installations for developers with `pyproject.toml`. `pip` [PR 6442](https://github.com/pypa/pip/pull/6442) fixes this with `--no-use-pep517` for the time being. This PR adopts `--no-use-pep517` for all installations.

This will also need to get addressed later in Issue #399 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use --no-use-pep517 flag for editable mode during installation and update docs to reflect this
   - https://github.com/pypa/pip/issues/6434
   - https://github.com/pypa/pip/pull/6442
* Add .eggs to Black exclude list
```
