### PR TITLE
Use papermill versions compatible with v1.0 and add scrapbook

### DIFF
--- a/docs/examples/notebooks/multiBinPois.ipynb
+++ b/docs/examples/notebooks/multiBinPois.ipynb
@@ -57,7 +57,7 @@
     "from pyhf.simplemodels import hepdata_like\n",
     "\n",
     "from scipy.interpolate import griddata\n",
-    "import papermill as pm"
+    "import scrapbook as sb"
    ]
   },
   {
@@ -364,7 +364,7 @@
     }
    ],
    "source": [
-    "pm.record(\"number_2d_successpoints\", len(X))"
+    "sb.glue(\"number_2d_successpoints\", len(X))"
    ]
   }
  ],

--- a/docs/examples/notebooks/multiBinPois.ipynb
+++ b/docs/examples/notebooks/multiBinPois.ipynb
@@ -30,24 +30,7 @@
    "metadata": {
     "scrolled": false
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/jovyan/pyhf/lib/python3.6/site-packages/ansiwrap/core.py:11: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/jovyan/pyhf/lib/python3.6/site-packages/textwrap3.py' mode='r' encoding='utf-8'>\n",
-      "  a_textwrap = imp.load_module('a_textwrap', *imp.find_module('textwrap3'))\n",
-      "/home/jovyan/pyhf/lib/python3.6/site-packages/nbconvert/exporters/exporter_locator.py:28: DeprecationWarning: `nbconvert.exporters.exporter_locator` is deprecated in favor of `nbconvert.exporters.base` since nbconvert 5.0.\n",
-      "  DeprecationWarning)\n",
-      "/home/jovyan/pyhf/lib/python3.6/site-packages/nbconvert/preprocessors/regexremove.py:41: DeprecationWarning: Traits should be given as instances, not types (for example, `Int()`, not `Int`). Passing types is deprecated in traitlets 4.1.\n",
-      "  patterns = List(Unicode, default_value=[r'\\Z']).tag(config=True)\n",
-      "/home/jovyan/pyhf/lib/python3.6/site-packages/traitlets/traitlets.py:2367: DeprecationWarning: Traits should be given as instances, not types (for example, `Int()`, not `Int`). Passing types is deprecated in traitlets 4.1.\n",
-      "  super(Set, self).__init__(trait, default_value, minlen, maxlen, **kwargs)\n",
-      "/home/jovyan/pyhf/lib/python3.6/site-packages/tornado/web.py:1747: DeprecationWarning: @asynchronous is deprecated, use coroutines instead\n",
-      "  DeprecationWarning)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import logging\n",
     "import json\n",

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ extras_require = {
         'jupyter',
         'nbdime',
         'uproot~=3.3',
-        'papermill~=0.16',
+        'papermill~=1.0',
         'graphviz',
         'bumpversion',
         'sphinx',

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ extras_require = {
         'nbdime',
         'uproot~=3.3',
         'papermill~=1.0',
+        'nteract-scrapbook~=0.2',
         'graphviz',
         'bumpversion',
         'sphinx',

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -1,6 +1,7 @@
 import sys
 import os
 import papermill as pm
+import scrapbook as sb
 
 
 def test_notebooks(tmpdir):
@@ -39,5 +40,5 @@ def test_notebooks(tmpdir):
         **common_kwargs
     )
 
-    nb = pm.read_notebook(str(outputnb))
-    assert nb.data['number_2d_successpoints'] > 200
+    nb = sb.read_notebook(str(outputnb))
+    assert nb.scraps['number_2d_successpoints'].data > 200


### PR DESCRIPTION
# Description

Resolves #419 

This PR updates to use papermill releases compatible with the [`v1.0.0`](https://pypi.org/project/papermill/1.0.0/) API. As part of that it also adds [nteract's scrapbook](https://github.com/nteract/scrapbook) as a dependency to replace papermill's [deprecated `pm.record` API](https://github.com/nteract/papermill/blob/d554193bc458797b63af1f94964883d5dcca2418/README.md#recording-values-to-the-notebook) with the [`scrapbook.glue` API](https://github.com/nteract/scrapbook/blob/96eab395e68069d5e775f01d587e16ef7ce39e01/README.md#glue-to-persist-scraps).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Update papermill dependency to use releases compatible with v1.0
* Add scrapbook dependency to use the glue API to replace pm.record
   - https://github.com/nteract/scrapbook
   - https://github.com/nteract/papermill/blob/d554193bc458797b63af1f94964883d5dcca2418/README.md#recording-values-to-the-notebook
```