### PR TITLE
Fix schema publishing to docs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -55,6 +55,7 @@ html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	#mkdir -p $(BUILDDIR)/html/docs && ln -sfn ../_static $(BUILDDIR)/html/docs/_static
 	mkdir -p $(BUILDDIR)/html/docs && rsync -r $(BUILDDIR)/html/_static $(BUILDDIR)/html/docs/
+	rsync -r ../pyhf/schemas/ $(BUILDDIR)/html/schemas
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -181,7 +181,7 @@ html_theme_path = []
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static', 'schemas']
+html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/schemas
+++ b/docs/schemas
@@ -1,1 +1,0 @@
-../pyhf/schemas


### PR DESCRIPTION
# Description

Amends PR #452

The docs were not publishing the schemas correctly because of how static files are actually treated. This fixes it with an explicit `rsync` into the folder we want. This is necessary to provide a public machine API for the time being.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
- explicit rsync the pyhf/schemas folder into the build-directory to publish correctly. Amends PR #452.
```