### PR TITLE
Add assertion and check for sample size consistency

### DIFF
--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -55,6 +55,15 @@ class _ModelConfig(object):
             self.channels.append(channel['name'])
             self.channel_nbins[channel['name']] = len(channel['samples'][0]['data'])
             for sample in channel['samples']:
+                if len(sample['data']) != self.channel_nbins[channel['name']]:
+                    raise exceptions.InvalidModel(
+                        'The sample {0:s} has {1:d} bins, but the channel it belongs to ({2:s}) has {3:d} bins.'.format(
+                            sample['name'],
+                            len(sample['data']),
+                            channel['name'],
+                            self.channel_nbins[channel['name']],
+                        )
+                    )
                 self.samples.append(sample['name'])
                 for modifier_def in sample['modifiers']:
                     # get the paramset requirements for the given modifier. If

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -512,3 +512,19 @@ def test_lumi_np_scaling():
         110.0 * alpha_lumi,
         1.0 * alpha_lumi,
     ]
+
+
+def test_sample_wrong_bins():
+    spec = {
+        'channels': [
+            {
+                'name': 'channel',
+                'samples': [
+                    {'name': 'goodsample', 'data': [1.0, 2.0], 'modifiers': []},
+                    {'name': 'badsample', 'data': [3.0, 4.0, 5.0], 'modifiers': []},
+                ],
+            }
+        ]
+    }
+    with pytest.raises(pyhf.exceptions.InvalidModel):
+        pdf = pyhf.Model(spec)


### PR DESCRIPTION
# Description

This adds a check and test to ensure we catch sample-channel size inconsistency.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
- every sample in a given channel should have the same number of bins so we add a check for it
- additionally add a test to ensure that we're catching this appropriately
```