### PR TITLE
Remove print function in CLI

### DIFF
--- a/pyhf/commandline.py
+++ b/pyhf/commandline.py
@@ -252,7 +252,7 @@ def cls(
     result = {'CLs_obs': result[0].tolist()[0], 'CLs_exp': result[-1].ravel().tolist()}
 
     if output_file is None:
-        print(json.dumps(result, indent=4, sort_keys=True))
+        click.echo(json.dumps(result, indent=4, sort_keys=True))
     else:
         with open(output_file, 'w+') as out_file:
             json.dump(result, out_file, indent=4, sort_keys=True)


### PR DESCRIPTION
# Description

This fixes a bug introduced in #403, no `print` functions in the CLI. Only use `click.echo`.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
This fixes a bug introduced in #403, no `print` functions in the CLI. Only use `click.echo`.
```