### PR TITLE
Add May 2019 Joint Machine Learning and Stats Fora Meeting talk

### DIFF
--- a/docs/bib/talks.bib
+++ b/docs/bib/talks.bib
@@ -1,7 +1,7 @@
 % NB: entries with same author-title-year are not picked up:
 %     https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/117
 @unpublished{Heinrich20190502,
-  title  = {{pyhf: Update on likelihood preservation and statistical reproduction of searches}},
+  title  = {{pyhf: Full Run-2 ATLAS likelihoods}},
   author = {Lukas Heinrich},
   year   = {2019},
   month  = {May},

--- a/docs/bib/talks.bib
+++ b/docs/bib/talks.bib
@@ -1,5 +1,16 @@
 % NB: entries with same author-title-year are not picked up:
 %     https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/117
+@unpublished{Heinrich20190502,
+  title  = {{pyhf: Update on likelihood preservation and statistical reproduction of searches}},
+  author = {Lukas Heinrich},
+  year   = {2019},
+  month  = {May},
+  day    = {2},
+  note   = {(Internal) Joint Machine Learning \& Statistics Fora Meeting},
+  organization = {CERN},
+  url    = {https://indico.cern.ch/event/817483/contributions/3412907/},
+}
+
 @unpublished{Heinrich20181205,
   title  = {{Gaussian Process Shape Estimation and Systematics}},
   author = {Lukas Heinrich},


### PR DESCRIPTION
# Description

Add the talk @lukasheinrich gave at the [May 2019 ATLAS Joint Machine Learning and Stats Fora Meeting](https://indico.cern.ch/event/817483/contributions/3412907/) that focused on likelihood preservation and statistical reproduction to the listed presentations in the docs.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
- Add May 2019 ATLAS Joint Machine Learning and Stats Fora Meeting given by Lukas that focused on likelihood preservation and statistical reproduction. The talk is ATLAS internal.
c.f. https://indico.cern.ch/event/817483/contributions/3412907/
```