### PR TITLE
Remove editable flag for Binder to avoid PEP 517 issue with pip

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,1 +1,1 @@
-pip install --upgrade -e .[complete]
+pip install --upgrade .[complete]


### PR DESCRIPTION
# Description

The `postBuild` file for Binder is breaking given the issues from pip v19.1 and PEP 517 that happened in PR #455. As Binder doesn't need to have an editable install of pyhf in it this can be resolved by not installing in editable mode, as there is no need for Binder.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
- Follow up to PR #455
- Remove -e flag from pip install in postBuild to have Binder avoid issues with PEP 517 and pip
```
