### PR TITLE
Don't cache pip installs for Python 3.6 in Travis to avoid memory EnvironmentError

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - export LD_PRELOAD="/usr/lib/libtcmalloc_minimal.so.4"
   - pip install --upgrade pip setuptools wheel
 install:
-  - pip install --ignore-installed -U -q --no-use-pep517 -e .[complete]
+  - pip install --ignore-installed -U --no-use-pep517 -e .[complete]
   - pip freeze
 script:
   - pyflakes pyhf

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,11 @@ before_install:
   - export LD_PRELOAD="/usr/lib/libtcmalloc_minimal.so.4"
   - pip install --upgrade pip setuptools wheel
 install:
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then pip install --ignore-installed -U -q --no-use-pep517 --no-cache-dir -e .[complete]; else pip install --ignore-installed -U -q --no-use-pep517 -e .[complete]; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then
+      pip install --ignore-installed -U -q --no-use-pep517 --no-cache-dir -e .[complete];
+    else
+      pip install --ignore-installed -U -q --no-use-pep517 -e .[complete];
+    fi
   - pip freeze
 script:
   - pyflakes pyhf

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,7 @@ before_install:
   - export LD_PRELOAD="/usr/lib/libtcmalloc_minimal.so.4"
   - pip install --upgrade pip setuptools wheel
 install:
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install --ignore-installed -U -q --no-use-pep517 -e .[complete]; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then pip install --ignore-installed -U -q --no-use-pep517 --no-cache-dir -e .[complete]; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then pip install --ignore-installed -U -q --no-use-pep517 -e .[complete]; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then pip install --ignore-installed -U -q --no-use-pep517 --no-cache-dir -e .[complete]; else pip install --ignore-installed -U -q --no-use-pep517 -e .[complete]; fi
   - pip freeze
 script:
   - pyflakes pyhf

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ before_install:
   - export LD_PRELOAD="/usr/lib/libtcmalloc_minimal.so.4"
   - pip install --upgrade pip setuptools wheel
 install:
-  - pip install --ignore-installed -U --no-use-pep517 -e .[complete]
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then pip install --ignore-installed -U -q --no-use-pep517 --no-cache-dir -e .[complete]; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then pip install --ignore-installed -U -q --no-use-pep517 -e .[complete]; fi
   - pip freeze
 script:
   - pyflakes pyhf

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
   - export LD_PRELOAD="/usr/lib/libtcmalloc_minimal.so.4"
   - pip install --upgrade pip setuptools wheel
 install:
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install --ignore-installed -U -q --no-use-pep517 -e .[complete]; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then pip install --ignore-installed -U -q --no-use-pep517 --no-cache-dir -e .[complete]; fi
   - if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then pip install --ignore-installed -U -q --no-use-pep517 -e .[complete]; fi
   - pip freeze


### PR DESCRIPTION
# Description

For reasons unknown at this time, after PR #460 was successfully merged in PR #461 encountered a [memory error in Travis CI's Python 3.6 runtime environment in the Ubuntu Trusty dist](https://travis-ci.org/diana-hep/pyhf/jobs/527324500#L484-L486).

```
ERROR: python-coveralls 2.9.1 has requirement coverage==4.0.3, but you'll have coverage 4.5.3 which is incompatible.
    ERROR: Error [Errno 12] Cannot allocate memory while executing command /home/travis/virtualenv/python3.6.3/bin/python -c 'import setuptools, tokenize;__file__='"'"'/home/travis/build/diana-hep/pyhf/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' develop --no-deps
ERROR: Could not install packages due to an EnvironmentError: [Errno 12] Cannot allocate memory
```

It is unclear why this is happening, and this has been followed up with the Travis CI Support team. In the meantime @kratsg has found that if caching is disabled during the `pip install` for Python 3.6 (with --no-cache-dir`) then this problem is avoided at the cost of loosing caching of the `pip` dependencies making the CI slower.

Given the time constraints of the ATLAS PUB note for SUSY2019 this patch is being deemed as temporarily acceptable but will need to be revisited in the future for further follow up and hopefully resolved in a cleaner/better understood fashion with the help of Travis CI Support.

Follow up of the underlying problem is in Issue #468.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
- Remove caching of pip installed dependencies from the Python 3.6 runtime environment (using --no-cache-dir) for Travis CI Ubuntu Trusty dist to mitigate a memory allocation error in Travis CI.
- Follow up of the underlying problem is in Issue #468
```