### PR TITLE
Add guard for Trusty build environments to prevent memory issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - export LD_PRELOAD="/usr/lib/libtcmalloc_minimal.so.4"
   - pip install --upgrade pip setuptools wheel
 install:
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then
+  - if [[ $TRAVIS_DIST == 'trusty' ]]; then
       pip install --ignore-installed -U -q --no-use-pep517 --no-cache-dir -e .[complete];
     else
       pip install --ignore-installed -U -q --no-use-pep517 -e .[complete];


### PR DESCRIPTION
# Description

In Travis CI's [Trusty build environment](https://docs.travis-ci.com/user/reference/trusty/) there is an [apparent (not always reproducible) memory error](https://travis-ci.org/diana-hep/pyhf/jobs/529417919#L483-L486).

>    ERROR: Error [Errno 12] Cannot allocate memory while executing command /home/travis/virtualenv/python2.7.14/bin/python -c 'import setuptools, tokenize;__file__='"'"'/home/travis/build/diana-hep/pyhf/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' develop --no-deps
ERROR: Could not install packages due to an EnvironmentError: [Errno 12] Cannot allocate memory

As this seems rather pathological the solution to ensure a CI that builds is to drop caching from all builds on Travis's Trusty build environment. @kratsg first encountered this problem in PR #464, and had added an explicit guard for Python 2.7 and Python 3.6, but as I had been able to get (by what now appears to be luck) the Python 2.7 runtime to pass by only guarding Python 3.6 it is only getting patched now.

The environment is not switched over to the [Xenial build environment](https://docs.travis-ci.com/user/reference/xenial/) as doing so for Python 2.7 and Python 3.6 causes there to be [compiler difference problems](https://travis-ci.org/diana-hep/pyhf/jobs/529397377#L441-L454) with `numpy` and `iminuit` during the `iminuit` build as [`iminuit` doesn't distribute wheels](https://github.com/scikit-hep/iminuit/issues/334):

```
ImportError while loading conftest '/home/travis/build/diana-hep/pyhf/tests/conftest.py'.
../../../virtualenv/python2.7.15/lib/python2.7/site-packages/six.py:709: in exec_
    exec("""exec _code_ in _globs_, _locs_""")
tests/conftest.py:51: in <module>
    pyhf.optimize.minuit_optimizer(),
pyhf/optimize/__init__.py:41: in __getattr__
    from .opt_minuit import minuit_optimizer
pyhf/optimize/opt_minuit.py:1: in <module>
    import iminuit
../../../virtualenv/python2.7.15/lib/python2.7/site-packages/iminuit/__init__.py:28: in <module>
    from ._libiminuit import Minuit
__init__.pxd:885: in init iminuit._libiminuit
    ???
E   ValueError: numpy.ufunc has the wrong size, try recompiling. Expected 192, got 216
```

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
- Remove caching of pip installed dependencies for all builds on Travis CI's Trusty environment (using --no-cache-dir) to mitigate a memory allocation error.
- Amends PR #464
```
