### PR TITLE
Remove use of --no-use-pep517 flag from pip install with pip v19.1.1+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ before_install:
   - pip install --upgrade pip setuptools wheel
 install:
   - if [[ $TRAVIS_DIST == 'trusty' ]]; then
-      pip install --ignore-installed -U -q --no-use-pep517 --no-cache-dir -e .[complete];
+      pip install --ignore-installed -U -q --no-cache-dir -e .[complete];
     else
-      pip install --ignore-installed -U -q --no-use-pep517 -e .[complete];
+      pip install --ignore-installed -U -q -e .[complete];
     fi
   - pip freeze
 script:
@@ -73,7 +73,7 @@ jobs:
       - export LD_PRELOAD="/usr/lib/libtcmalloc_minimal.so.4"
       - pip install --upgrade pip setuptools wheel
     install:
-      - pip install --ignore-installed -U -q --no-use-pep517 -e .[complete]
+      - pip install --ignore-installed -U -q -e .[complete]
       - pip freeze
     script: python -m pytest -r sx --benchmark-sort=mean tests/benchmarks/
     after_success: skip
@@ -86,7 +86,7 @@ jobs:
       - export LD_PRELOAD="/usr/lib/libtcmalloc_minimal.so.4"
       - pip install --upgrade pip setuptools wheel
     install:
-      - pip install --ignore-installed -U -q --no-use-pep517 -e .[complete]
+      - pip install --ignore-installed -U -q -e .[complete]
       - pip freeze
     script:
       - python -m doctest README.md

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -11,7 +11,7 @@ and install all necessary packages for development
 
 .. code-block:: console
 
-    pip install --ignore-installed -U --no-use-pep517 -e .[complete]
+    pip install --ignore-installed -U -e .[complete]
 
 Then setup the Git pre-commit hook for `Black <https://github.com/ambv/black>`__  by running
 


### PR DESCRIPTION
# Description

With the [release of `pip` `v19.1.1`](https://github.com/pypa/pip/releases/tag/19.1.1) the decision was made to

> Restore ``pyproject.toml`` handling to how it was with pip 19.0.3 to prevent the need to add ``--no-use-pep517`` when installing in editable mode.

As such, the content of PR #455 is no longer needed and can be reverted to reduce complexity.

c.f.
- https://twitter.com/llanga/status/1125832882038235136
- https://github.com/pypa/pip/releases/tag/19.1.1

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Remove use of --no-use-pep517 flag from pip install with pip v19.1.1+
   - https://twitter.com/llanga/status/1125832882038235136
   - https://github.com/pypa/pip/releases/tag/19.1.1
* This PR essentially reverts PR #455 
```
