### PR TITLE
Add SUSY 2019 conference talk

### DIFF
--- a/docs/bib/talks.bib
+++ b/docs/bib/talks.bib
@@ -1,5 +1,17 @@
 % NB: entries with same author-title-year are not picked up:
 %     https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/117
+
+@unpublished{Stark20190523,
+  title  = {{New techniques for use of public likelihoods for reinterpretation of search results}},
+  author = {Giordon Stark},
+  year   = {2019},
+  month  = {May},
+  day    = {23},
+  note   = {27th International Conference on Supersymmetry and Unification of Fundamental Interactions (SUSY2019)},
+  organization = {CERN},
+  url    = {https://indico.cern.ch/event/746178/contributions/3396797/},
+}
+
 @unpublished{Heinrich20190502,
   title  = {{pyhf: Full Run-2 ATLAS likelihoods}},
   author = {Lukas Heinrich},


### PR DESCRIPTION
# Description

Add the talk @kratsg [gave at the SUSY 2019 conference](https://indico.cern.ch/event/746178/contributions/3396797/) that focused on publication and reinterpretation of likelihoods in the docs.

c.f. https://indico.cern.ch/event/746178/contributions/3396797/

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
- Add SUSY 2019 conference talkk by Giordon that focused on publication and reinterpretation of likelihoods
c.f. https://indico.cern.ch/event/746178/contributions/3396797/
```
