### PR TITLE
Update MANIFEST.in with correct schema paths

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,10 +4,8 @@ repos:
     hooks:
     - id: black
       language_version: python3.6
-
-repos:
-  - repo: https://github.com/mgedmin/check-manifest
+- repo: https://github.com/mgedmin/check-manifest
     rev: stable
     hooks:
-      - id: check-manifest
-        language_version: python3.6
+    - id: check-manifest
+      language_version: python3.6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     - id: black
       language_version: python3.6
 - repo: https://github.com/mgedmin/check-manifest
-    rev: stable
+    rev: "0.39"
     hooks:
     - id: check-manifest
       language_version: python3.6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,3 @@ repos:
     hooks:
     - id: black
       language_version: python3.6
-- repo: https://github.com/mgedmin/check-manifest
-    rev: "0.39"
-    hooks:
-    - id: check-manifest
-      language_version: python3.6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,10 @@ repos:
     hooks:
     - id: black
       language_version: python3.6
+
+repos:
+  - repo: https://github.com/mgedmin/check-manifest
+    rev: stable
+    hooks:
+      - id: check-manifest
+        language_version: python3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
   - pip freeze
 script:
   - pyflakes pyhf
+  - check-manifest
   - python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/test_notebooks.py
   - if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then black --check --diff --verbose .; fi
 after_success: if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then coveralls; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   - pip freeze
 script:
   - pyflakes pyhf
-  - check-manifest
+  - check-manifest || travis_terminate 1
   - python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/test_notebooks.py
   - if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then black --check --diff --verbose .; fi
 after_success: if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then coveralls; fi

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
-include pyhf/schemas/defs.json
-include pyhf/schemas/measurement.json
-include pyhf/schemas/model.json
-include pyhf/schemas/workspace.json
+include pyhf/schemas/1.0.0/defs.json
+include pyhf/schemas/1.0.0/measurement.json
+include pyhf/schemas/1.0.0/model.json
+include pyhf/schemas/1.0.0/workspace.json
 include pyhf/schemas/HistFactorySchema.dtd
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,4 @@ include pyhf/schemas/1.0.0/measurement.json
 include pyhf/schemas/1.0.0/model.json
 include pyhf/schemas/1.0.0/workspace.json
 include pyhf/schemas/HistFactorySchema.dtd
-
+include LICENSE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,18 @@ exclude = '''
   | build
 )/
 '''
+
+[tool.check-manifest]
+ignore = [
+    'docs*',
+    'validation*',
+    'examples*',
+    'tests*',
+    'docker*',
+    'binder*',
+    '.*',
+    'pyproject.toml',
+    'pytest.ini',
+    'CODE_OF_CONDUCT.md',
+    'CONTRIBUTING.md',
+]

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ extras_require = {
         'pre-commit',
         'black;python_version>="3.6"',  # Black is Python3 only
         'twine',
+        'check-manifest',
     ],
 }
 extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))


### PR DESCRIPTION
# Description

This fixes a bug in the MANIFEST file where the schema paths were not updated.

I wonder why our tests did not catch this before, strangely.. but it doesn't error out.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Update manifest to point to schemas/1.0.0 instead of just schemas/
* Add license to manifest
* Add check-manifest as dependency of develop option
* Add manifest check as test to Travis
```