### PR TITLE
Ensure inputs to tensor backend einsum test are tensors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as readme_md
 
 extras_require = {
     'tensorflow': [
-        'tensorflow~=1.13',
+        'tensorflow~=1.14',
         'tensorflow-probability~=0.5',
         'numpy<=1.14.5,>=1.14.0',  # Lower of 1.14.0 instead of 1.13.3 to ensure doctest pass
         'setuptools<=39.1.0',

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -197,7 +197,9 @@ def test_einsum(backend):
         with pytest.raises(NotImplementedError):
             assert tb.einsum('ij->ji', [1, 2, 3])
     else:
-        assert np.all(tb.tolist(tb.einsum('ij->ji', x)) == np.asarray(x).T.tolist())
+        assert np.all(
+            tb.tolist(tb.einsum('ij->ji', tb.astensor(x))) == np.asarray(x).T.tolist()
+        )
         assert (
             tb.tolist(
                 tb.einsum('i,j->ij', tb.astensor([1, 1, 1]), tb.astensor([1, 2, 3]))


### PR DESCRIPTION
# Description

Resolves #482 

In TensorFlow `v1.14` [`tf.einsum`](https://www.tensorflow.org/api_docs/python/tf/einsum) is expecting Tensors. As such, ensure that in the `test_einsum` all inputs are in fact Tensors.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
- Ensure that all inputs to the test_einsum test are Tensors
- Update minimum compatible version of TensorFlow to v1.14 to avoid future compatibility issues
```
