### PR TITLE
Use updated TensorFlow names for math operations

### DIFF
--- a/pyhf/tensor/tensorflow_backend.py
+++ b/pyhf/tensor/tensorflow_backend.py
@@ -174,7 +174,7 @@ class tensorflow_backend(object):
 
     def log(self, tensor_in):
         tensor_in = self.astensor(tensor_in)
-        return tf.log(tensor_in)
+        return tf.math.log(tensor_in)
 
     def exp(self, tensor_in):
         tensor_in = self.astensor(tensor_in)

--- a/pyhf/tensor/tensorflow_backend.py
+++ b/pyhf/tensor/tensorflow_backend.py
@@ -92,7 +92,7 @@ class tensorflow_backend(object):
         return tf.boolean_mask(tensor, mask)
 
     def isfinite(self, tensor):
-        return tf.is_finite(tensor)
+        return tf.math.is_finite(tensor)
 
     def astensor(self, tensor_in, dtype='float'):
         """


### PR DESCRIPTION
# Description

Use `tf.math` names for [`tf.log`](https://www.tensorflow.org/api_docs/python/tf/math/log) and [`tf.is_finite`](https://www.tensorflow.org/api_docs/python/tf/math/is_finite) as these names are deprecated. Avoids the warning:
> The name `tf.X` is deprecated. Please use `tf.math.X` instead.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
- Use tf.math names for tf.log and tf.is_finite as these names are deprecated. This avoids warnings.
```
