### PR TITLE
Use curl -L to have trigger_binder follow URL redirect

### DIFF
--- a/binder/trigger_binder.sh
+++ b/binder/trigger_binder.sh
@@ -3,7 +3,7 @@
 function trigger_binder() {
     local URL="${1}"
 
-    curl --connect-timeout 10 --max-time 30 "${URL}"
+    curl -L --connect-timeout 10 --max-time 30 "${URL}"
     curl_return=$?
 
     # Return code 28 is when the --max-time is reached


### PR DESCRIPTION
# Description

Resolves #486 

BinderHub now operates as a Binder Federation and so there is no guarantee where the Binder build will take place. As a result, the Binder trigger must follow any redirect of the URL.

c.f.
https://discourse.jupyter.org/t/problem-triggering-binder-build-through-api-endpoint/1440

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use curl -L to have trigger_binder follow redirect of BinderHub URL
c.f. https://discourse.jupyter.org/t/problem-triggering-binder-build-through-api-endpoint/1440
```
