### PR TITLE
Update workspace specification to use 'observations' instead of 'data'

### DIFF
--- a/docs/examples/notebooks/binderexample/StatisticalAnalysis.ipynb
+++ b/docs/examples/notebooks/binderexample/StatisticalAnalysis.ipynb
@@ -92,7 +92,8 @@
    "outputs": [],
    "source": [
     "parsed = pyhf.readxml.parse('meas.xml',os.getcwd())\n",
-    "obs_data = next(obs for obs in parsed['observations'] if obs['name'] == 'channel1')['data']"
+    "workspace = pyhf.Workspace(parsed)\n",
+    "obs_data = workspace.observations['channel1']"
    ]
   },
   {
@@ -1016,7 +1017,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "478f4314cca4419ebdbeead4a7538e72",
+       "model_id": "ac148ecb896849e9b43ece327f2b6cde",
        "version_major": 2,
        "version_minor": 0
       },

--- a/docs/examples/notebooks/binderexample/StatisticalAnalysis.ipynb
+++ b/docs/examples/notebooks/binderexample/StatisticalAnalysis.ipynb
@@ -92,7 +92,7 @@
    "outputs": [],
    "source": [
     "parsed = pyhf.readxml.parse('meas.xml',os.getcwd())\n",
-    "obs_data = parsed['data']['channel1'] "
+    "obs_data = next(obs for obs in parsed['observations'] if obs['name'] == 'channel1')['data']"
    ]
   },
   {
@@ -234,7 +234,7 @@
        "    } else if (typeof(MozWebSocket) !== 'undefined') {\n",
        "        return MozWebSocket;\n",
        "    } else {\n",
-       "        alert('Your browser does not have WebSocket support.' +\n",
+       "        alert('Your browser does not have WebSocket support. ' +\n",
        "              'Please try Chrome, Safari or Firefox ≥ 6. ' +\n",
        "              'Firefox 4 and 5 are also supported but you ' +\n",
        "              'have to enable WebSockets in about:config.');\n",
@@ -451,7 +451,7 @@
        "mpl.figure.prototype._init_toolbar = function() {\n",
        "    var fig = this;\n",
        "\n",
-       "    var nav_element = $('<div/>')\n",
+       "    var nav_element = $('<div/>');\n",
        "    nav_element.attr('style', 'width: 100%');\n",
        "    this.root.append(nav_element);\n",
        "\n",
@@ -508,7 +508,7 @@
        "        var fmt = mpl.extensions[ind];\n",
        "        var option = $(\n",
        "            '<option/>', {selected: fmt === mpl.default_extension}).html(fmt);\n",
-       "        fmt_picker.append(option)\n",
+       "        fmt_picker.append(option);\n",
        "    }\n",
        "\n",
        "    // Add hover states to the ui-buttons\n",
@@ -877,7 +877,7 @@
        "mpl.figure.prototype._init_toolbar = function() {\n",
        "    var fig = this;\n",
        "\n",
-       "    var nav_element = $('<div/>')\n",
+       "    var nav_element = $('<div/>');\n",
        "    nav_element.attr('style', 'width: 100%');\n",
        "    this.root.append(nav_element);\n",
        "\n",
@@ -1016,7 +1016,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "48075003fde747a3bdc2f4cd31a0768b",
+       "model_id": "478f4314cca4419ebdbeead4a7538e72",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1087,7 +1087,7 @@
        "    } else if (typeof(MozWebSocket) !== 'undefined') {\n",
        "        return MozWebSocket;\n",
        "    } else {\n",
-       "        alert('Your browser does not have WebSocket support.' +\n",
+       "        alert('Your browser does not have WebSocket support. ' +\n",
        "              'Please try Chrome, Safari or Firefox ≥ 6. ' +\n",
        "              'Firefox 4 and 5 are also supported but you ' +\n",
        "              'have to enable WebSockets in about:config.');\n",
@@ -1304,7 +1304,7 @@
        "mpl.figure.prototype._init_toolbar = function() {\n",
        "    var fig = this;\n",
        "\n",
-       "    var nav_element = $('<div/>')\n",
+       "    var nav_element = $('<div/>');\n",
        "    nav_element.attr('style', 'width: 100%');\n",
        "    this.root.append(nav_element);\n",
        "\n",
@@ -1361,7 +1361,7 @@
        "        var fmt = mpl.extensions[ind];\n",
        "        var option = $(\n",
        "            '<option/>', {selected: fmt === mpl.default_extension}).html(fmt);\n",
-       "        fmt_picker.append(option)\n",
+       "        fmt_picker.append(option);\n",
        "    }\n",
        "\n",
        "    // Add hover states to the ui-buttons\n",
@@ -1730,7 +1730,7 @@
        "mpl.figure.prototype._init_toolbar = function() {\n",
        "    var fig = this;\n",
        "\n",
-       "    var nav_element = $('<div/>')\n",
+       "    var nav_element = $('<div/>');\n",
        "    nav_element.attr('style', 'width: 100%');\n",
        "    this.root.append(nav_element);\n",
        "\n",
@@ -1945,7 +1945,7 @@
        "    } else if (typeof(MozWebSocket) !== 'undefined') {\n",
        "        return MozWebSocket;\n",
        "    } else {\n",
-       "        alert('Your browser does not have WebSocket support.' +\n",
+       "        alert('Your browser does not have WebSocket support. ' +\n",
        "              'Please try Chrome, Safari or Firefox ≥ 6. ' +\n",
        "              'Firefox 4 and 5 are also supported but you ' +\n",
        "              'have to enable WebSockets in about:config.');\n",
@@ -2162,7 +2162,7 @@
        "mpl.figure.prototype._init_toolbar = function() {\n",
        "    var fig = this;\n",
        "\n",
-       "    var nav_element = $('<div/>')\n",
+       "    var nav_element = $('<div/>');\n",
        "    nav_element.attr('style', 'width: 100%');\n",
        "    this.root.append(nav_element);\n",
        "\n",
@@ -2219,7 +2219,7 @@
        "        var fmt = mpl.extensions[ind];\n",
        "        var option = $(\n",
        "            '<option/>', {selected: fmt === mpl.default_extension}).html(fmt);\n",
-       "        fmt_picker.append(option)\n",
+       "        fmt_picker.append(option);\n",
        "    }\n",
        "\n",
        "    // Add hover states to the ui-buttons\n",
@@ -2588,7 +2588,7 @@
        "mpl.figure.prototype._init_toolbar = function() {\n",
        "    var fig = this;\n",
        "\n",
-       "    var nav_element = $('<div/>')\n",
+       "    var nav_element = $('<div/>');\n",
        "    nav_element.attr('style', 'width: 100%');\n",
        "    this.root.append(nav_element);\n",
        "\n",
@@ -2794,7 +2794,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.7.3"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/docs/likelihood.rst
+++ b/docs/likelihood.rst
@@ -18,18 +18,18 @@ Workspace
        "properties": {
            "channels": { "type": "array", "items": {"$ref": "defs.json#/definitions/channel"} },
            "measurements": { "type": "array", "items": {"$ref": "defs.json#/definitions/measurement"} },
-           "data": { "type": "object" },
+           "observations": { "type": "array", "items": {"$ref": "defs.json#/definitions/observation" } },
            "version": { "const": "1.0.0" }
        },
        "additionalProperties": false,
-       "required": ["channels", "measurements", "data", "version"]
+       "required": ["channels", "measurements", "observations", "version"]
    }
 
 The overall document in the above code snippet describes a *workspace*, which includes
 
 * **measurements**: The channels in the model, which include a description of the samples
   within each channel and their possible parametrised modifiers.
-* **data**: The observed data, with which a likelihood can be constructed from the
+* **observations**: The observed data, with which a likelihood can be constructed from the
 * **model**: A set of measurements, which define among others the parameters of
   interest for a given statistical analysis objective.
 
@@ -307,6 +307,31 @@ An example is shown below:
    }
 
 An example of a measurement. This measurement, which scans over the parameter of interest ``SigXSec``, is setting configurations for the luminosity modifier, changing the default bounds for the normfactor modifier named ``alpha_ttbar``, and specifying that the modifier ``rw_1CR`` is held constant (``fixed``).
+
+.. _ssec:observations:
+
+Observations
+------------
+
+This is what we evaluate the hypothesis testing against, to determine the
+compatibility of signal+background hypothesis to the background-only
+hypothesis. This is specified as a list of objects, with each object structured
+as
+
+* **name**: the channel for which the observations are recorded
+* **data**: the bin-by-bin observations for the named channel
+
+An example is shown below:
+
+.. code:: json
+
+   {
+       "name": "channel1",
+       "data": [110.0, 120.0]
+   }
+
+An example of an observation. This observation recorded for a 2-bin channel ``channel1``, has values ``110.0`` and ``120.0``.
+
 
 Toy example
 -----------

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -605,7 +605,15 @@ class Workspace(object):
             data: A list of numbers
         """
 
-        observed_data = sum((self.observations[c] for c in model.config.channels), [])
+        try:
+            observed_data = sum(
+                (self.observations[c] for c in model.config.channels), []
+            )
+        except KeyError:
+            log.error(
+                "Invalid channel: the workspace does not have observation data for one of the channels in the model."
+            )
+            raise
         if with_aux:
             observed_data += model.config.auxdata
         return observed_data

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -493,6 +493,10 @@ class Workspace(object):
         for measurement in self.spec.get('measurements', []):
             self.measurement_names.append(measurement['name'])
 
+        self.observations = {}
+        for obs in self.spec['observations']:
+            self.observations[obs['name']] = obs['data']
+
     # NB: this is a wrapper function to validate the returned measurement object against the spec
     def get_measurement(self, **config_kwargs):
         """
@@ -601,15 +605,7 @@ class Workspace(object):
             data: A list of numbers
         """
 
-        observed_data = sum(
-            (
-                next(obs for obs in self.spec['observations'] if obs['name'] == c)[
-                    'data'
-                ]
-                for c in model.config.channels
-            ),
-            [],
-        )
+        observed_data = sum((self.observations[c] for c in model.config.channels), [])
         if with_aux:
             observed_data += model.config.auxdata
         return observed_data

--- a/pyhf/pdf.py
+++ b/pyhf/pdf.py
@@ -601,7 +601,15 @@ class Workspace(object):
             data: A list of numbers
         """
 
-        observed_data = sum((self.spec['data'][c] for c in model.config.channels), [])
+        observed_data = sum(
+            (
+                next(obs for obs in self.spec['observations'] if obs['name'] == c)[
+                    'data'
+                ]
+                for c in model.config.channels
+            ),
+            [],
+        )
         if with_aux:
             observed_data += model.config.auxdata
         return observed_data

--- a/pyhf/readxml.py
+++ b/pyhf/readxml.py
@@ -269,7 +269,7 @@ def parse(configfile, rootdir, track_progress=False):
     result = {
         'measurements': process_measurements(toplvl),
         'channels': [{'name': k, 'samples': v['samples']} for k, v in channels.items()],
-        'data': {k: v['data'] for k, v in channels.items()},
+        'observations': [{'name': k, 'data': v['data']} for k, v in channels.items()],
         'version': utils.SCHEMA_VERSION,
     }
 

--- a/pyhf/schemas/1.0.0/defs.json
+++ b/pyhf/schemas/1.0.0/defs.json
@@ -2,6 +2,15 @@
     "$schema": "http://json-schema.org/draft-06/schema#",
     "$id": "https://diana-hep.org/pyhf/schemas/1.0.0/defs.json",
     "definitions": {
+        "observation": {
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" },
+                "data": { "type": "array", "items": {"type": "number"}, "minItems": 1 }
+            },
+            "required": ["name", "data"],
+            "additionalProperties": false
+        },
         "measurement": {
             "type": "object",
             "properties": {

--- a/pyhf/schemas/1.0.0/workspace.json
+++ b/pyhf/schemas/1.0.0/workspace.json
@@ -5,20 +5,9 @@
     "properties": {
         "channels": { "type": "array", "items": {"$ref": "defs.json#/definitions/channel"} },
         "measurements": { "type": "array", "items": {"$ref": "defs.json#/definitions/measurement"} },
-        "data": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "name": { "type": "string" },
-                    "data": { "type": "array", "items": { "type": "number" }, "minItems": 1 }
-                },
-                "required": ["name", "data"],
-                "additionalProperties": false
-            }
-        },
+        "observations": { "type": "array", "items": {"$ref": "defs.json#/definitions/observation" } },
         "version": { "const": "1.0.0" }
     },
     "additionalProperties": false,
-    "required": ["channels", "measurements", "data", "version"]
+    "required": ["channels", "measurements", "observations", "version"]
 }

--- a/pyhf/schemas/1.0.0/workspace.json
+++ b/pyhf/schemas/1.0.0/workspace.json
@@ -5,7 +5,18 @@
     "properties": {
         "channels": { "type": "array", "items": {"$ref": "defs.json#/definitions/channel"} },
         "measurements": { "type": "array", "items": {"$ref": "defs.json#/definitions/measurement"} },
-        "data": { "type": "object" },
+        "data": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" },
+                    "data": { "type": "array", "items": { "type": "number" }, "minItems": 1 }
+                },
+                "required": ["name", "data"],
+                "additionalProperties": false
+            }
+        },
         "version": { "const": "1.0.0" }
     },
     "additionalProperties": false,

--- a/pyhf/writexml.py
+++ b/pyhf/writexml.py
@@ -183,19 +183,21 @@ def build_sample(samplespec, channelname):
     return sample
 
 
-def build_data(dataspec, channelname):
+def build_data(obsspec, channelname):
     histname = _make_hist_name(channelname, 'data')
     data = ET.Element('Data', HistoName=histname, InputFile=_ROOT_DATA_FILE._path)
-    _export_root_histogram(histname, dataspec[channelname])
+
+    observation = next((obs for obs in obsspec if obs['name'] == channelname), None)
+    _export_root_histogram(histname, observation['data'])
     return data
 
 
-def build_channel(channelspec, dataspec):
+def build_channel(channelspec, obsspec):
     channel = ET.Element(
         'Channel', Name=channelspec['name'], InputFile=_ROOT_DATA_FILE._path
     )
-    if dataspec:
-        data = build_data(dataspec, channelspec['name'])
+    if obsspec:
+        data = build_data(obsspec, channelspec['name'])
         channel.append(data)
     for samplespec in channelspec['samples']:
         channel.append(build_sample(samplespec, channelspec['name']))
@@ -219,7 +221,7 @@ def writexml(spec, specdir, data_rootdir, resultprefix):
                 specdir, '{0:s}_{1:s}.xml'.format(resultprefix, channelspec['name'])
             )
             with open(channelfilename, 'w') as channelfile:
-                channel = build_channel(channelspec, spec.get('data'))
+                channel = build_channel(channelspec, spec.get('observations'))
                 indent(channel)
                 channelfile.write(
                     "<!DOCTYPE Channel SYSTEM '../HistFactorySchema.dtd'>\n\n"

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -269,7 +269,7 @@ def test_export_channel(mocker, spec):
 
 def test_export_data(mocker):
     channelname = 'channel'
-    dataspec = {channelname: [0, 1, 2, 3]}
+    dataspec = [{'name': channelname, 'data': [0, 1, 2, 3]}]
 
     mocker.patch('pyhf.writexml._ROOT_DATA_FILE')
     data = pyhf.writexml.build_data(dataspec, channelname)

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -56,7 +56,7 @@ def test_import_prepHistFactory():
     data = [
         binvalue
         for k in pdf.spec['channels']
-        for binvalue in parsed_xml['data'][k['name']]
+        for binvalue in next(obs for obs in parsed_xml['observations'] if obs['name'] == k['name'])['data']
     ] + pdf.config.auxdata
 
     channels = {channel['name'] for channel in pdf.spec['channels']}
@@ -120,7 +120,7 @@ def test_import_histosys():
     data = [
         binvalue
         for k in pdf.spec['channels']
-        for binvalue in parsed_xml['data'][k['name']]
+        for binvalue in next(obs for obs in parsed_xml['observations'] if obs['name'] == k['name'])['data']
     ] + pdf.config.auxdata
 
     channels = {channel['name']: channel for channel in pdf.spec['channels']}
@@ -172,7 +172,7 @@ def test_import_shapesys():
     data = [
         binvalue
         for k in pdf.spec['channels']
-        for binvalue in parsed_xml['data'][k['name']]
+        for binvalue in next(obs for obs in parsed_xml['observations'] if obs['name'] == k['name'])['data']
     ] + pdf.config.auxdata
 
     channels = {channel['name']: channel for channel in pdf.spec['channels']}

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -56,7 +56,9 @@ def test_import_prepHistFactory():
     data = [
         binvalue
         for k in pdf.spec['channels']
-        for binvalue in next(obs for obs in parsed_xml['observations'] if obs['name'] == k['name'])['data']
+        for binvalue in next(
+            obs for obs in parsed_xml['observations'] if obs['name'] == k['name']
+        )['data']
     ] + pdf.config.auxdata
 
     channels = {channel['name'] for channel in pdf.spec['channels']}
@@ -120,7 +122,9 @@ def test_import_histosys():
     data = [
         binvalue
         for k in pdf.spec['channels']
-        for binvalue in next(obs for obs in parsed_xml['observations'] if obs['name'] == k['name'])['data']
+        for binvalue in next(
+            obs for obs in parsed_xml['observations'] if obs['name'] == k['name']
+        )['data']
     ] + pdf.config.auxdata
 
     channels = {channel['name']: channel for channel in pdf.spec['channels']}
@@ -172,7 +176,9 @@ def test_import_shapesys():
     data = [
         binvalue
         for k in pdf.spec['channels']
-        for binvalue in next(obs for obs in parsed_xml['observations'] if obs['name'] == k['name'])['data']
+        for binvalue in next(
+            obs for obs in parsed_xml['observations'] if obs['name'] == k['name']
+        )['data']
     ] + pdf.config.auxdata
 
     channels = {channel['name']: channel for channel in pdf.spec['channels']}

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -801,13 +801,17 @@ def test_import_roundtrip(tmpdir, toplvl, basedir):
     data_before = [
         binvalue
         for k in pdf_before.config.channels
-        for binvalue in parsed_xml_before['data'][k]
+        for binvalue in next(
+            obs for obs in parsed_xml_before['observations'] if obs['name'] == k
+        )['data']
     ] + pdf_before.config.auxdata
 
     data_after = [
         binvalue
         for k in pdf_after.config.channels
-        for binvalue in parsed_xml_after['data'][k]
+        for binvalue in next(
+            obs for obs in parsed_xml_after['observations'] if obs['name'] == k
+        )['data']
     ] + pdf_after.config.auxdata
 
     assert data_before == data_after

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -3,6 +3,7 @@ import pyhf.readxml
 import pytest
 import pyhf.exceptions
 import json
+import logging
 
 
 @pytest.fixture(
@@ -104,3 +105,25 @@ def test_get_workspace_model_default(workspace_factory):
     w = workspace_factory()
     m = w.model()
     assert m
+
+
+def test_workspace_observations(workspace_factory):
+    w = workspace_factory()
+    assert w.observations
+
+
+def test_get_workspace_data(workspace_factory):
+    w = workspace_factory()
+    m = w.model()
+    assert w.data(m)
+
+
+def test_get_workspace_data_bad_model(workspace_factory, caplog):
+    w = workspace_factory()
+    m = w.model()
+    # the iconic fragrance of an expected failure
+    m.config.channels = [c.replace('channel', 'chanel') for c in m.config.channels]
+    with caplog.at_level(logging.INFO, 'pyhf.pdf'):
+        with pytest.raises(KeyError):
+            assert w.data(m)
+            assert 'Invalid channel' in caplog.text


### PR DESCRIPTION
# Description

This is the last thing needed for the v1.0.0 of the JSON schema -- which is to switch out how we define the observed `data` of the workspace. I was initially lazy and defined it as a regular `object` which could've been anything... now we tighten up that definition ahead of release v1.0.0 of the schema.

This resolves #474.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
- workspace 'data' renamed to 'observations'
- 'observation' specification is defined requiring a 'name' (channel) and 'data' (observations for that channel)
- code and tests are updated to reflect the change in the schema
- resolves #474
- additional test added to check that workspace data is retrieved correctly, and to handle situations in when the observed data requested for a channel does not exist
```