### PR TITLE
Simplify Travis CI with use of Xenial distribution and update package dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: xenial
 language: python
 cache: pip
 python:
+  - '2.7'
   - '3.6'
   - '3.7'
 before_install:
@@ -10,11 +11,7 @@ before_install:
   - export LD_PRELOAD="/usr/lib/libtcmalloc_minimal.so.4"
   - pip install --upgrade pip setuptools wheel
 install:
-  - if [[ $TRAVIS_DIST == 'trusty' ]]; then
-      pip install --ignore-installed -U -q --no-cache-dir -e .[complete];
-    else
-      pip install --ignore-installed -U -q -e .[complete];
-    fi
+  - pip install --ignore-installed -U -q -e .[complete];
   - pip freeze
 script:
   - pyflakes pyhf
@@ -22,10 +19,6 @@ script:
   - python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/test_notebooks.py
   - if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then black --check --diff --verbose .; fi
 after_success: if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then coveralls; fi
-# Include to force matrix expansion but use trusty for Python 3.6 instead
-matrix:
-  exclude:
-    - python: '3.6'
 
 # always test (on both 'push' and 'pr' builds in Travis)
 # test docs on 'pr' builds and 'push' builds on master
@@ -46,19 +39,13 @@ env:
 
 jobs:
   include:
-  - dist: trusty
-    python: '2.7'
-  - dist: trusty
-    python: '3.6'
   - name: "Python 2.7 Notebook Tests"
     python: '2.7'
-    dist: trusty
     script:
       - python -m pytest tests/test_notebooks.py
     after_success: skip
   - name: "Python 3.6 Notebook Tests"
     python: '3.6'
-    dist: trusty
     script:
       - python -m pytest tests/test_notebooks.py
     after_success: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,8 @@ after_success: if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then coveralls; fi
 # test docs on 'pr' builds and 'push' builds on master
 # benchmark and deploy to PyPI only when merged into master (those mereges are 'push' builds)
 stages:
-  - test
+  - name: test
+    if: NOT (branch =~ /^docs\//)
   - name: benchmark
     if: (branch = master) AND (NOT (type IN (pull_request)))
   - name: docs

--- a/pyhf/tensor/mxnet_backend.py
+++ b/pyhf/tensor/mxnet_backend.py
@@ -14,7 +14,7 @@ class mxnet_backend(object):
     def __init__(self, **kwargs):
         self.name = 'mxnet'
 
-    def clip(self, tensor_in, min, max):
+    def clip(self, tensor_in, min_value, max_value):
         """
         Clips (limits) the tensor values to be within a specified min and max.
 
@@ -30,14 +30,14 @@ class mxnet_backend(object):
 
         Args:
             tensor_in (`tensor`): The input tensor object
-            min (`scalar` or `tensor` or `None`): The minimum value to be cliped to
-            max (`scalar` or `tensor` or `None`): The maximum value to be cliped to
+            min_value (`scalar` or `tensor` or `None`): The minimum value to be cliped to
+            max_value (`scalar` or `tensor` or `None`): The maximum value to be cliped to
 
         Returns:
             MXNet NDArray: A clipped `tensor`
         """
         tensor_in = self.astensor(tensor_in)
-        return nd.clip(tensor_in, min, max)
+        return nd.clip(tensor_in, min_value, max_value)
 
     def tolist(self, tensor_in):
         """

--- a/pyhf/tensor/numpy_backend.py
+++ b/pyhf/tensor/numpy_backend.py
@@ -12,7 +12,7 @@ class numpy_backend(object):
     def __init__(self, **kwargs):
         self.name = 'numpy'
 
-    def clip(self, tensor_in, min, max):
+    def clip(self, tensor_in, min_value, max_value):
         """
         Clips (limits) the tensor values to be within a specified min and max.
 
@@ -26,13 +26,13 @@ class numpy_backend(object):
 
         Args:
             tensor_in (`tensor`): The input tensor object
-            min (`scalar` or `tensor` or `None`): The minimum value to be cliped to
-            max (`scalar` or `tensor` or `None`): The maximum value to be cliped to
+            min_value (`scalar` or `tensor` or `None`): The minimum value to be cliped to
+            max_value (`scalar` or `tensor` or `None`): The maximum value to be cliped to
 
         Returns:
             NumPy ndarray: A clipped `tensor`
         """
-        return np.clip(tensor_in, min, max)
+        return np.clip(tensor_in, min_value, max_value)
 
     def tolist(self, tensor_in):
         try:

--- a/pyhf/tensor/pytorch_backend.py
+++ b/pyhf/tensor/pytorch_backend.py
@@ -11,7 +11,7 @@ class pytorch_backend(object):
     def __init__(self, **kwargs):
         self.name = 'pytorch'
 
-    def clip(self, tensor_in, min, max):
+    def clip(self, tensor_in, min_value, max_value):
         """
         Clips (limits) the tensor values to be within a specified min and max.
 
@@ -25,14 +25,14 @@ class pytorch_backend(object):
 
         Args:
             tensor_in (`tensor`): The input tensor object
-            min (`scalar` or `tensor` or `None`): The minimum value to be cliped to
-            max (`scalar` or `tensor` or `None`): The maximum value to be cliped to
+            min_value (`scalar` or `tensor` or `None`): The minimum value to be cliped to
+            max_value (`scalar` or `tensor` or `None`): The maximum value to be cliped to
 
         Returns:
             PyTorch tensor: A clipped `tensor`
         """
         tensor_in = self.astensor(tensor_in)
-        return torch.clamp(tensor_in, min, max)
+        return torch.clamp(tensor_in, min_value, max_value)
 
     def tolist(self, tensor_in):
         try:

--- a/pyhf/tensor/tensorflow_backend.py
+++ b/pyhf/tensor/tensorflow_backend.py
@@ -12,7 +12,7 @@ class tensorflow_backend(object):
         self.session = kwargs.get('session')
         self.name = 'tensorflow'
 
-    def clip(self, tensor_in, min, max):
+    def clip(self, tensor_in, min_value, max_value):
         """
         Clips (limits) the tensor values to be within a specified min and max.
 
@@ -31,18 +31,18 @@ class tensorflow_backend(object):
 
         Args:
             tensor_in (`tensor`): The input tensor object
-            min (`scalar` or `tensor` or `None`): The minimum value to be cliped to
-            max (`scalar` or `tensor` or `None`): The maximum value to be cliped to
+            min_value (`scalar` or `tensor` or `None`): The minimum value to be cliped to
+            max_value (`scalar` or `tensor` or `None`): The maximum value to be cliped to
 
         Returns:
             TensorFlow Tensor: A clipped `tensor`
         """
         tensor_in = self.astensor(tensor_in)
-        if min is None:
-            min = tf.reduce_min(tensor_in)
-        if max is None:
-            max = tf.reduce_max(tensor_in)
-        return tf.clip_by_value(tensor_in, min, max)
+        if min_value is None:
+            min_value = tf.reduce_min(tensor_in)
+        if max_value is None:
+            max_value = tf.reduce_max(tensor_in)
+        return tf.clip_by_value(tensor_in, min_value, max_value)
 
     def tolist(self, tensor_in):
         try:

--- a/pyhf/utils.py
+++ b/pyhf/utils.py
@@ -279,11 +279,13 @@ def hypotest(
     asimov_mu = 0.0
     asimov_data = generate_asimov_data(asimov_mu, data, pdf, init_pars, par_bounds)
 
-    qmu_v = tensorlib.clip(qmu(poi_test, data, pdf, init_pars, par_bounds), 0, max=None)
+    qmu_v = tensorlib.clip(
+        qmu(poi_test, data, pdf, init_pars, par_bounds), 0, max_value=None
+    )
     sqrtqmu_v = tensorlib.sqrt(qmu_v)
 
     qmuA_v = tensorlib.clip(
-        qmu(poi_test, asimov_data, pdf, init_pars, par_bounds), 0, max=None
+        qmu(poi_test, asimov_data, pdf, init_pars, par_bounds), 0, max_value=None
     )
     sqrtqmuA_v = tensorlib.sqrt(qmuA_v)
 

--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,9 @@ extras_require = {
         'tensorflow~=1.14',
         'tensorflow-probability~=0.5',
         'numpy<=1.14.5,>=1.14.0',  # Lower of 1.14.0 instead of 1.13.3 to ensure doctest pass
-        'setuptools<=39.1.0',
     ],
     'torch': ['torch~=1.0'],
-    'mxnet': ['mxnet~=1.0', 'requests~=2.18.4', 'numpy<1.15.0,>=1.8.2'],
+    'mxnet': ['mxnet~=1.0', 'numpy<1.15.0,>=1.8.2', 'graphviz<0.9.0,>=0.8.1'],
     # 'dask': [
     #     'dask[array]'
     # ],
@@ -49,7 +48,7 @@ extras_require = {
         'sphinx-issues',
         'm2r',
         'jsonpatch',
-        'ipython<7',  # jupyter_console and ipython clash in dependency requirement -- downgrade ipython for now
+        'ipython',
         'pre-commit',
         'black;python_version>="3.6"',  # Black is Python3 only
         'twine',


### PR DESCRIPTION
# Description

This PR contains changes to see how much of the current `setup.py` dependencies and `.travis.yml` definitions we can further simplify down. As we move from `trusty` entirely to `xenial`, this happens to mitigate #468 as well, by, well, uhh... running away from the problem. Additionally, this incorporates #439 with a nice regex since we're already going ahead and simplifying things further.

- Resolves #468
- Resolves #439

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Simplify .travis.yml by switching to using xenial for everything
* Don't run the full test suit on docs/ branches
   - Only build and test the docs 
* Update existing backend signatures to use min_value/max_value instead of min/max for codefactor
* Simplify dependencies in setup.py as latest versions of various packages we pinned are behaving with each other appropriately
```