### PR TITLE
Always test the docs on docs branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ stages:
   - name: benchmark
     if: (branch = master) AND (NOT (type IN (pull_request)))
   - name: docs
-    if: (branch = master)
+    if: (branch = master) OR (branch =~ /^docs\//)
   - name: binder
     if: (branch = master) AND (NOT (type IN (pull_request)))
   - name: deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ script:
 after_success: if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then coveralls; fi
 
 # always test (on both 'push' and 'pr' builds in Travis)
-# test docs on 'pr' builds and 'push' builds on master
+# test docs on 'pr' builds and 'push' builds on master and on docs branches
 # benchmark and deploy to PyPI only when merged into master (those mereges are 'push' builds)
 stages:
   - name: test


### PR DESCRIPTION
# Description

Amends PR #491 and resolves #439 

As the `/^docs\//` branches are meant to focus on the docs only, build and test the docs on push commits to the docs branches. This will not build the docs on push builds of branches that don't match the desired pattern, as seen in the following screenshot

![no_run_on_test](https://user-images.githubusercontent.com/5142394/60229162-983b1c00-985a-11e9-9f7b-bb9b0531c5f8.png)


# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Build and test the docs on push builds of /^docs\// branches
```
