### PR TITLE
Trigger Binder builds on both GKE and OVH clusters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ jobs:
     before_install: skip
     install: skip
     script:
-      # Use Binder build API to trigger repo2docker to build image
+      # Use Binder build API to trigger repo2docker to build image on GKE and OVH Binder Federation clusters
       - bash binder/trigger_binder.sh https://gke.mybinder.org/build/gh/diana-hep/pyhf/"${TRAVIS_BRANCH}"
       - bash binder/trigger_binder.sh https://ovh.mybinder.org/build/gh/diana-hep/pyhf/"${TRAVIS_BRANCH}"
     after_success: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,8 @@ jobs:
     install: skip
     script:
       # Use Binder build API to trigger repo2docker to build image
-      - bash binder/trigger_binder.sh https://mybinder.org/build/gh/diana-hep/pyhf/"${TRAVIS_BRANCH}"
+      - bash binder/trigger_binder.sh https://gke.mybinder.org/build/gh/diana-hep/pyhf/"${TRAVIS_BRANCH}"
+      - bash binder/trigger_binder.sh https://ovh.mybinder.org/build/gh/diana-hep/pyhf/"${TRAVIS_BRANCH}"
     after_success: skip
   - stage: deploy
     # Tests deployment to PyPI for all commits to master


### PR DESCRIPTION
# Description

Amends PR #487 

Given that [the Binder Federation](https://discourse.jupyter.org/t/the-binder-federation/1286) exists on both GKE and OVH there is no guarantee that the cluster that a build is triggered on is the same cluster that a user will be directed to when they launch the Binder. As a result, both clusters should be triggered when a PR is merged.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Trigger Binder builds on both GKE and OVH clusters
```
