### PR TITLE
Add learn notebooks and split up notebook tests

### DIFF
--- a/docs/examples/notebooks/learn/InterpolationCodes.ipynb
+++ b/docs/examples/notebooks/learn/InterpolationCodes.ipynb
@@ -24,11 +24,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Piecewise Linear Interpolation (Interpolation Code 0)\n",
+    "# Piecewise Linear Interpolation\n",
     "\n",
     "References: https://cds.cern.ch/record/1456844/files/CERN-OPEN-2012-016.pdf\n",
     "\n",
-    "We wish to understand interpolation using the piecewise linear function defined as (nb: vector denotes bold)\n",
+    "We wish to understand interpolation using the piecewise linear function. This is `interpcode=0` in the above reference. This function is defined as (nb: vector denotes bold)\n",
     "\n",
     "$$\n",
     "\\eta_s (\\vec{\\alpha}) = \\sigma_{sb}^0(\\vec{\\alpha}) + \\underbrace{\\sum_{p \\in \\text{Syst}} I_\\text{lin.} (\\alpha_p; \\sigma_{sb}^0, \\sigma_{psb}^+, \\sigma_{psb}^-)}_\\text{deltas to calculate}\n",
@@ -449,21 +449,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.14"
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/docs/examples/notebooks/learn/TensorizingInterpolations.ipynb
+++ b/docs/examples/notebooks/learn/TensorizingInterpolations.ipynb
@@ -172,9 +172,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Tensorizing the Linear Interpolator\n",
+    "## Tensorizing the Linear Interpolator\n",
     "\n",
-    "#### Step 0\n",
+    "### Step 0\n",
     "\n",
     "Step 0 requires converting the innermost conditional check on `alpha > 0` into something tensorizable. This also means the calculation itself is going to become tensorized. So we will convert from\n",
     "\n",
@@ -255,7 +255,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loop, best of 3: 182 ms per loop\n"
+      "189 ms ± 6.14 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -273,7 +273,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loop, best of 3: 254 ms per loop\n"
+      "255 ms ± 11.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -288,7 +288,7 @@
    "source": [
     "Great! We're a little bit slower right now, but that's expected. We're just getting started.\n",
     "\n",
-    "#### Step 1\n",
+    "### Step 1\n",
     "\n",
     "In this step, we would like to remove the innermost `zip()` call over the histogram bins by calculating the interpolation between the histograms in one fell swoop. This means, instead of writing something like\n",
     "\n",
@@ -368,7 +368,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10 loops, best of 3: 182 ms per loop\n"
+      "188 ms ± 7.14 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -386,7 +386,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loop, best of 3: 433 ms per loop\n"
+      "492 ms ± 42.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -401,7 +401,7 @@
    "source": [
     "Great!\n",
     "\n",
-    "#### Step 2\n",
+    "### Step 2\n",
     "\n",
     "In this step, we would like to move the giant array of the deltas calculated to the beginning -- outside of all loops -- and then only take a subset of it for the calculation itself. This allows us to figure out the entire structure of the input for the rest of the calculations as we slowly move towards including `einsum()` calls (einstein summation). This means we would like to go from\n",
     "\n",
@@ -490,7 +490,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loop, best of 3: 176 ms per loop\n"
+      "179 ms ± 12.4 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -508,7 +508,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loop, best of 3: 376 ms per loop\n"
+      "409 ms ± 20.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -523,7 +523,7 @@
    "source": [
     "Great!\n",
     "\n",
-    "#### Step 3\n",
+    "### Step 3\n",
     "\n",
     "In this step, we get to introduce einstein summation to generalize the calculations we perform across many dimensions in a more concise, straightforward way. See [this blog post](https://rockt.github.io/2018/04/30/einsum) for some more details on einstein summation notation. In short, it allows us to write\n",
     "\n",
@@ -624,7 +624,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loop, best of 3: 176 ms per loop\n"
+      "166 ms ± 11.6 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -642,7 +642,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loop, best of 3: 786 ms per loop\n"
+      "921 ms ± 133 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -657,7 +657,7 @@
    "source": [
     "Great! Note that we've been getting a little bit slower during these steps. It will all pay off in the end when we're fully tensorized! A lot of the internal steps are overkill with the heavy einstein summation and broadcasting at the moment, especially for how many loops in we are.\n",
     "\n",
-    "#### Step 4\n",
+    "### Step 4\n",
     "\n",
     "Now in this step, we will move the einstein summations to the outer loop, so that we're calculating it once! This is the big step, but a little bit easier because all we're doing is adding extra dimensions into the calculation. The underlying calculation won't have changed. At this point, we'll also rename from `i` and `j` to `a` and `b` for `alpha` and `bin` (as in the bin in the histogram). To continue the notation as well, here's a summary of the dimensions involved:\n",
     "\n",
@@ -753,7 +753,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loop, best of 3: 185 ms per loop\n"
+      "160 ms ± 5 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -771,7 +771,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10 loops, best of 3: 131 ms per loop\n"
+      "119 ms ± 3.19 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -786,7 +786,7 @@
    "source": [
     "Great! And look at that huge speed up in time already, just from moving the multiple, heavy einstein summation calculations up through the loops. We still have some more optimizing to do as we still have explicit loops in our code. Let's keep at it, we're almost there!\n",
     "\n",
-    "#### Step 5\n",
+    "### Step 5\n",
     "\n",
     "The hard part is mostly over. We have to now think about the nominal variations. Recall that we were trying to add the nominals to the deltas in order to compute the new value. In practice, we'll return the delta variation only, but we'll show you how to get rid of this last loop. In this case, we want to figure out how to change code like\n",
     "\n",
@@ -876,7 +876,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loop, best of 3: 182 ms per loop\n"
+      "160 ms ± 8.28 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -894,7 +894,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1000 loops, best of 3: 1.66 ms per loop\n"
+      "1.57 ms ± 75.2 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)\n"
      ]
     }
    ],
@@ -909,7 +909,7 @@
    "source": [
     "Fantastic! And look at the speed up. We're already faster than the for-loop and we're not even done yet.\n",
     "\n",
-    "#### Step 6\n",
+    "### Step 6\n",
     "\n",
     "The final frontier. Also probably the best Star Wars episode. In any case, we have one more for-loop that needs to die in a slab of carbonite. This should be much easier now that you're more comfortable with tensor broadcasting and einstein summations.\n",
     "\n",
@@ -918,7 +918,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -948,7 +948,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -966,14 +966,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loop, best of 3: 194 ms per loop\n"
+      "156 ms ± 6.29 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -984,14 +984,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1000 loops, best of 3: 435 µs per loop\n"
+      "468 µs ± 37.1 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)\n"
      ]
     }
    ],
@@ -1006,14 +1006,14 @@
    "source": [
     "And we're done tensorizing it. There are some more improvements that could be made to make this interpolation calculation even more robust -- but for now we're done.\n",
     "\n",
-    "### Tensorizing the Non-Linear Interpolator\n",
+    "## Tensorizing the Non-Linear Interpolator\n",
     "\n",
     "This is very, very similar to what we've done for the case of the linear interpolator. As such, we will provide the resulting functions for each step, and you can see how things perform all the way at the bottom. Enjoy and learn at your own pace!"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1202,7 +1202,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
@@ -1220,14 +1220,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loop, best of 3: 182 ms per loop\n"
+      "149 ms ± 9.45 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -1238,14 +1238,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loop, best of 3: 593 ms per loop\n"
+      "527 ms ± 29.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -1256,7 +1256,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
@@ -1274,14 +1274,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loop, best of 3: 185 ms per loop\n"
+      "150 ms ± 5.21 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -1292,14 +1292,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loop, best of 3: 545 ms per loop\n"
+      "456 ms ± 17.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -1310,7 +1310,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
@@ -1328,14 +1328,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loop, best of 3: 177 ms per loop\n"
+      "154 ms ± 4.49 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -1346,14 +1346,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loop, best of 3: 446 ms per loop\n"
+      "412 ms ± 31 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -1364,7 +1364,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
@@ -1382,14 +1382,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10 loops, best of 3: 181 ms per loop\n"
+      "145 ms ± 5.15 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -1400,14 +1400,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loop, best of 3: 1.27 s per loop\n"
+      "1.28 s ± 74.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -1418,7 +1418,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [
     {
@@ -1436,14 +1436,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loop, best of 3: 167 ms per loop\n"
+      "147 ms ± 8.4 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -1454,14 +1454,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10 loops, best of 3: 128 ms per loop\n"
+      "120 ms ± 3.06 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -1472,7 +1472,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [
     {
@@ -1490,14 +1490,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10 loops, best of 3: 171 ms per loop\n"
+      "151 ms ± 5.29 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -1508,14 +1508,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "100 loops, best of 3: 2.47 ms per loop\n"
+      "2.65 ms ± 57.6 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
      ]
     }
    ],
@@ -1526,7 +1526,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 52,
    "metadata": {},
    "outputs": [
     {
@@ -1544,14 +1544,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10 loops, best of 3: 192 ms per loop\n"
+      "156 ms ± 3.35 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -1562,14 +1562,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 54,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1000 loops, best of 3: 1.51 ms per loop\n"
+      "1.49 ms ± 16 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)\n"
      ]
     }
    ],
@@ -1581,21 +1581,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.14"
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@
 
    intro
    likelihood
+   learn
    examples
    talks
    installation

--- a/docs/learn.rst
+++ b/docs/learn.rst
@@ -1,0 +1,10 @@
+Fundamentals
+============
+
+Notebooks:
+
+.. toctree::
+   :maxdepth: 2
+
+   examples/notebooks/learn/InterpolationCodes.ipynb
+   examples/notebooks/learn/TensorizingInterpolations.ipynb

--- a/docs/likelihood.rst
+++ b/docs/likelihood.rst
@@ -14,11 +14,11 @@ Workspace
 
 The overall document in the above code snippet describes a *workspace*, which includes
 
-* **measurements**: The channels in the model, which include a description of the samples
+* **channels**: The channels in the model, which include a description of the samples
   within each channel and their possible parametrised modifiers.
-* **observations**: The observed data, with which a likelihood can be constructed from the
-* **model**: A set of measurements, which define among others the parameters of
+* **measurements**: A set of measurements, which define among others the parameters of
   interest for a given statistical analysis objective.
+* **observations**: The observed data, with which a likelihood can be constructed from the
 
 A workspace consists of the channels, one set of observed data, but can
 include multiple measurements. If provided a JSON file, one can quickly

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -2,21 +2,29 @@ import sys
 import os
 import papermill as pm
 import scrapbook as sb
+import pytest
 
 
-def test_notebooks(tmpdir):
+@pytest.fixture()
+def common_kwargs(tmpdir):
     outputnb = tmpdir.join('output.ipynb')
-    common_kwargs = {
+    return {
         'output_path': str(outputnb),
         'kernel_name': 'python{}'.format(sys.version_info.major),
     }
 
+
+def test_hello_world(common_kwargs):
     pm.execute_notebook('docs/examples/notebooks/hello-world.ipynb', **common_kwargs)
 
+
+def test_xml_importexport(common_kwargs):
     pm.execute_notebook(
         'docs/examples/notebooks/XML_ImportExport.ipynb', **common_kwargs
     )
 
+
+def test_statisticalanalysis(common_kwargs):
     if sys.version_info.major > 2:
         # The Binder example uses specific relative paths
         cwd = os.getcwd()
@@ -24,21 +32,36 @@ def test_notebooks(tmpdir):
         pm.execute_notebook('StatisticalAnalysis.ipynb', **common_kwargs)
         os.chdir(cwd)
 
-    pm.execute_notebook(
-        'docs/examples/notebooks/learn/InterpolationCodes.ipynb', **common_kwargs
-    )
 
+def test_shapefactor(common_kwargs):
     pm.execute_notebook('docs/examples/notebooks/ShapeFactor.ipynb', **common_kwargs)
+
+
+def test_multichannel_coupled_histos(common_kwargs):
     pm.execute_notebook(
         'docs/examples/notebooks/multichannel-coupled-histo.ipynb',
         parameters={'validation_datadir': 'validation/data'},
         **common_kwargs
     )
+
+
+def test_multibinpois(common_kwargs):
     pm.execute_notebook(
         'docs/examples/notebooks/multiBinPois.ipynb',
         parameters={'validation_datadir': 'validation/data'},
         **common_kwargs
     )
-
-    nb = sb.read_notebook(str(outputnb))
+    nb = sb.read_notebook(common_kwargs['output_path'])
     assert nb.scraps['number_2d_successpoints'].data > 200
+
+
+def test_learn_interpolationcodes(common_kwargs):
+    pm.execute_notebook(
+        'docs/examples/notebooks/learn/InterpolationCodes.ipynb', **common_kwargs
+    )
+
+
+def test_learn_tensorizinginterpolations(common_kwargs):
+    pm.execute_notebook(
+        'docs/examples/notebooks/learn/TensorizingInterpolations.ipynb', **common_kwargs
+    )


### PR DESCRIPTION
# Description

This resolves #496. Learn notebooks are now added via `learn.rst` with the title `Fundamentals`.

<img width="297" alt="Screenshot 2019-06-27 20 22 42" src="https://user-images.githubusercontent.com/761483/60315630-304d0a00-991c-11e9-8452-8d8943797e10.png">

Other titles considered:
- Foundations
- Learn the Fundamentals
- Learn Some Fundamentals
- Learn Some Concepts
- Underpinnings
- Tutorials
- Guides
- Learn the Code
- Learning Guides
- Learning Topics
- Learning
- Learnings

Related issues: #168, #325

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
- add learn notebooks to docs
- refactor notebook tests by making a fixture and splitting each notebook into an individual test
```