### PR TITLE
Fix the typo fix in the docs

### DIFF
--- a/docs/likelihood.rst
+++ b/docs/likelihood.rst
@@ -18,7 +18,7 @@ The overall document in the above code snippet describes a *workspace*, which i
   within each channel and their possible parametrised modifiers.
 * **measurements**: A set of measurements, which define among others the parameters of
   interest for a given statistical analysis objective.
-* **observations**: The observed data, with which a likelihood can be constructed from the
+* **observations**: The observed data, with which a likelihood can be constructed from the model
 
 A workspace consists of the channels, one set of observed data, but can
 include multiple measurements. If provided a JSON file, one can quickly

--- a/docs/likelihood.rst
+++ b/docs/likelihood.rst
@@ -18,7 +18,7 @@ The overall document in the above code snippet describes a *workspace*, which i
   within each channel and their possible parametrised modifiers.
 * **measurements**: A set of measurements, which define among others the parameters of
   interest for a given statistical analysis objective.
-* **observations**: The observed data, with which a likelihood can be constructed from the model
+* **observations**: The observed data, with which a likelihood can be constructed from the model.
 
 A workspace consists of the channels, one set of observed data, but can
 include multiple measurements. If provided a JSON file, one can quickly


### PR DESCRIPTION
# Description

#497 snuck in a typo fix that wasn't perfect.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Correct typo from ordering of old note
```