### PR TITLE
Add SciPy 2019 poster BibTeX information

### DIFF
--- a/docs/bib/posters.bib
+++ b/docs/bib/posters.bib
@@ -14,7 +14,7 @@
   author = {Matthew Feickert and Lukas Heinrich and Giordon Stark and Kyle Cranmer},
   year   = {2019},
   month  = {July},
-  day    = {12},
+  day    = {10},
   note   = {18th Scientific Computing with Python Conference (SciPy 2019)},
   doi    = {10.25080/Majora-7ddc1dd1-019},
   url    = {http://conference.scipy.org/proceedings/scipy2019/slides.html},

--- a/docs/bib/posters.bib
+++ b/docs/bib/posters.bib
@@ -8,3 +8,14 @@
   organization = {CERN},
   url    = {https://indico.cern.ch/event/708041/contributions/3272095/},
 }
+
+@misc{Feickert_SciPy2019,
+  title  = {{pyhf: a pure Python statistical fitting library for High Energy Physics with tensors and autograd}},
+  author = {Matthew Feickert and Lukas Heinrich and Giordon Stark and Kyle Cranmer},
+  year   = {2019},
+  month  = {July},
+  day    = {12},
+  note   = {18th Scientific Computing with Python Conference (SciPy 2019)},
+  doi    = {10.25080/Majora-7ddc1dd1-019},
+  url    = {http://conference.scipy.org/proceedings/scipy2019/slides.html},
+}


### PR DESCRIPTION
# Description

Add BibTeX entry and link to SciPy 2019 proceedings:
http://conference.scipy.org/proceedings/scipy2019/slides.html

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add BibTeX entry and link to the proceedings for poster shown by Matthew at SciPy 2019:
http://conference.scipy.org/proceedings/scipy2019/slides.html
* Poster LaTeX source found at: https://github.com/matthewfeickert/SciPy2019-Poster
```
