### PR TITLE
Use torch.bool over torch.uint8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ extras_require = {
         'tensorflow-probability~=0.5',
         'numpy<=1.14.5,>=1.14.0',  # Lower of 1.14.0 instead of 1.13.3 to ensure doctest pass
     ],
-    'torch': ['torch~=1.0'],
+    'torch': ['torch~=1.2'],
     'mxnet': ['mxnet~=1.0', 'numpy<1.15.0,>=1.8.2', 'graphviz<0.9.0,>=0.8.1'],
     # 'dask': [
     #     'dask[array]'

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -57,7 +57,7 @@ class pytorch_backend(object):
         Returns:
             torch.Tensor: A multi-dimensional matrix containing elements of a single data type.
         """
-        dtypemap = {'float': torch.float, 'int': torch.int, 'bool': torch.uint8}
+        dtypemap = {'float': torch.float, 'int': torch.int, 'bool': torch.bool}
         try:
             dtype = dtypemap[dtype]
         except KeyError:
@@ -76,7 +76,7 @@ class pytorch_backend(object):
         return torch.take(tensor, indices.type(torch.LongTensor))
 
     def boolean_mask(self, tensor, mask):
-        mask = self.astensor(mask).type(torch.ByteTensor)
+        mask = self.astensor(mask, dtype='bool')
         return torch.masked_select(tensor, mask)
 
     def reshape(self, tensor, newshape):


### PR DESCRIPTION
# Description

`torch.uint8` was deprecated in favor `torch.bool` for `torch.masked_select` in [PyTorch release `v1.2.0`](https://github.com/pytorch/pytorch/releases/tag/v1.2.0)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use torch.bool instead of torch.uint8 given deprecation for torch.masked_select in PyTorch release v1.2.0
   - c.f. https://github.com/pytorch/pytorch/releases/tag/v1.2.0
* Require PyTorch version compatible with release v1.2.0
```
