### PR TITLE
Use conditional control flow in 'pvals_from_teststat'

### DIFF
--- a/src/pyhf/tensor/mxnet_backend.py
+++ b/src/pyhf/tensor/mxnet_backend.py
@@ -42,7 +42,7 @@ class mxnet_backend(object):
 
     def subtract(self, tensor_in_1, tensor_in_2):
         """
-        Subtract two tensors element-wise as :code:`(tensor_in_2 - tensor_in_1)`
+        Subtract two tensors element-wise as :code:`(tensor_in_1 - tensor_in_2)`
 
         Example:
 

--- a/src/pyhf/tensor/mxnet_backend.py
+++ b/src/pyhf/tensor/mxnet_backend.py
@@ -42,7 +42,7 @@ class mxnet_backend(object):
 
     def subtract(self, tensor_in_1, tensor_in_2):
         """
-        Subtract two tensors element-wise
+        Subtract two tensors element-wise as :code:`(tensor_in_2 - tensor_in_1)`
 
         Example:
 

--- a/src/pyhf/tensor/mxnet_backend.py
+++ b/src/pyhf/tensor/mxnet_backend.py
@@ -14,6 +14,58 @@ class mxnet_backend(object):
     def __init__(self, **kwargs):
         self.name = 'mxnet'
 
+    def add(self, tensor_in_1, tensor_in_2):
+        """
+        Add two tensors element-wise
+
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend(pyhf.tensor.mxnet_backend())
+            >>> a = pyhf.tensorlib.astensor([1, 2, 3, 4])
+            >>> b = pyhf.tensorlib.astensor([5, 6, 7, 8])
+            >>> pyhf.tensorlib.add(a, b)
+            <BLANKLINE>
+            [ 6.  8. 10. 12.]
+            <NDArray 4 @cpu(0)>
+
+        Args:
+            tensor_in_1 (`Tensor`): The first tensor
+            tensor_in_2 (`Tensor`): The tensor of same type and shape as :code:`tensor_in_1`
+
+        Returns:
+            MXNet NDArray: The sum of the input tensors
+        """
+        tensor_in_1 = self.astensor(tensor_in_1)
+        tensor_in_2 = self.astensor(tensor_in_2)
+        return nd.add(tensor_in_1, tensor_in_2)
+
+    def subtract(self, tensor_in_1, tensor_in_2):
+        """
+        Subtract two tensors element-wise
+
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend(pyhf.tensor.mxnet_backend())
+            >>> a = pyhf.tensorlib.astensor([1, 2, 3, 4])
+            >>> b = pyhf.tensorlib.astensor([5, 6, 7, 8])
+            >>> pyhf.tensorlib.subtract(b, a)
+            <BLANKLINE>
+            [4. 4. 4. 4.]
+            <NDArray 4 @cpu(0)>
+
+        Args:
+            tensor_in_1 (`Tensor`): The first tensor
+            tensor_in_2 (`Tensor`): The tensor of same type and shape as :code:`tensor_in_1`
+
+        Returns:
+            MXNet NDArray: The difference of the input tensors
+        """
+        tensor_in_1 = self.astensor(tensor_in_1)
+        tensor_in_2 = self.astensor(tensor_in_2)
+        return nd.subtract(tensor_in_1, tensor_in_2)
+
     def clip(self, tensor_in, min_value, max_value):
         """
         Clips (limits) the tensor values to be within a specified min and max.

--- a/src/pyhf/tensor/mxnet_backend.py
+++ b/src/pyhf/tensor/mxnet_backend.py
@@ -16,7 +16,7 @@ class mxnet_backend(object):
 
     def add(self, tensor_in_1, tensor_in_2):
         """
-        Add two tensors element-wise
+        Add two tensors element-wise. Equivalent to :code:`sum([tensor_in_1, tensor_in_2], axis=0)`.
 
         Example:
 

--- a/src/pyhf/tensor/mxnet_backend.py
+++ b/src/pyhf/tensor/mxnet_backend.py
@@ -99,7 +99,7 @@ class mxnet_backend(object):
 
             >>> import pyhf
             >>> pyhf.set_backend(pyhf.tensor.mxnet_backend())
-            >>> tensorlib, _ = pyhf.get_backend()
+            >>> tensorlib = pyhf.tensorlib
             >>> a = tensorlib.astensor([4])
             >>> b = tensorlib.astensor([5])
             >>> tensorlib.conditional(

--- a/src/pyhf/tensor/mxnet_backend.py
+++ b/src/pyhf/tensor/mxnet_backend.py
@@ -98,12 +98,14 @@ class mxnet_backend(object):
         Example:
 
             >>> import pyhf
-            >>> import mxnet.ndarray as nd
             >>> pyhf.set_backend(pyhf.tensor.mxnet_backend())
-            >>> a = pyhf.tensorlib.astensor([4])
-            >>> b = pyhf.tensorlib.astensor([5])
-            >>> pyhf.tensorlib.conditional(
-            ...     nd.lesser(a,b)[0], lambda: nd.add(a, b), lambda: nd.subtract(a,b)
+            >>> tensorlib, _ = pyhf.get_backend()
+            >>> a = tensorlib.astensor([4])
+            >>> b = tensorlib.astensor([5])
+            >>> tensorlib.conditional(
+            ...     tensorlib.less(a, b)[0],
+            ...     lambda: tensorlib.add(a, b),
+            ...     lambda: tensorlib.subtract(a, b)
             ... )
             <BLANKLINE>
             [9.]

--- a/src/pyhf/tensor/mxnet_backend.py
+++ b/src/pyhf/tensor/mxnet_backend.py
@@ -39,6 +39,87 @@ class mxnet_backend(object):
         tensor_in = self.astensor(tensor_in)
         return nd.clip(tensor_in, min_value, max_value)
 
+    def conditional(self, predicate, true_callable, false_callable):
+        """
+        Runs a callable conditional on the boolean value of the evaulation of a predicate
+
+        Example:
+
+            >>> import pyhf
+            >>> import mxnet.ndarray as nd
+            >>> pyhf.set_backend(pyhf.tensor.mxnet_backend())
+            >>> a = pyhf.tensorlib.astensor([4])
+            >>> b = pyhf.tensorlib.astensor([5])
+            >>> pyhf.tensorlib.conditional(
+            ...     nd.lesser(a,b)[0], lambda: nd.add(a, b), lambda: nd.subtract(a,b)
+            ... )
+            <BLANKLINE>
+            [9.]
+            <NDArray 1 @cpu(0)>
+
+
+        Args:
+            predicate (`scalar`): The logical condition that determines which callable to evaluate
+            true_callable (`callable`): The callable that is evaluated when the :code:`predicate` evalutes to :code:`true`
+            false_callable (`callable`): The callable that is evaluated when the :code:`predicate` evalutes to :code:`false`
+
+        Returns:
+            MXNet NDArray: The output of the callable that was evaluated
+        """
+        return nd.contrib.cond(predicate, true_callable, false_callable)
+
+    def less(self, tensor_in_1, tensor_in_2):
+        """
+        The boolean value of :code:`(tensor_in_1 < tensor_in_2)` element-wise
+
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend(pyhf.tensor.mxnet_backend())
+            >>> a = pyhf.tensorlib.astensor([4])
+            >>> b = pyhf.tensorlib.astensor([5])
+            >>> pyhf.tensorlib.less(a, b)
+            <BLANKLINE>
+            [1.]
+            <NDArray 1 @cpu(0)>
+
+        Args:
+            tensor_in_1 (`Tensor`): The first tensor
+            tensor_in_2 (`Tensor`): The tensor of same type as :code:`tensor_in_1`
+
+        Returns:
+            MXNet NDArray: The bool of the comparison
+        """
+        tensor_in_1 = self.astensor(tensor_in_1)
+        tensor_in_2 = self.astensor(tensor_in_2)
+        return nd.lesser(tensor_in_1, tensor_in_2)
+
+    def greater(self, tensor_in_1, tensor_in_2):
+        """
+        The boolean value of :code:`(tensor_in_1 > tensor_in_2)` element-wise
+
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend(pyhf.tensor.mxnet_backend())
+            >>> a = pyhf.tensorlib.astensor([4])
+            >>> b = pyhf.tensorlib.astensor([5])
+            >>> pyhf.tensorlib.greater(b, a)
+            <BLANKLINE>
+            [1.]
+            <NDArray 1 @cpu(0)>
+
+        Args:
+            tensor_in_1 (`Tensor`): The first tensor
+            tensor_in_2 (`Tensor`): The tensor of same type as :code:`tensor_in_1`
+
+        Returns:
+            MXNet NDArray: The bool of the comparison
+        """
+        tensor_in_1 = self.astensor(tensor_in_1)
+        tensor_in_2 = self.astensor(tensor_in_2)
+        return nd.greater(tensor_in_1, tensor_in_2)
+
     def tolist(self, tensor_in):
         """
         Convert a tensor to a list.

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -14,7 +14,7 @@ class numpy_backend(object):
 
     def add(self, tensor_in_1, tensor_in_2):
         """
-        Add two tensors element-wise
+        Add two tensors element-wise. Equivalent to :code:`sum([tensor_in_1, tensor_in_2], axis=0)`.
 
         Example:
 

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -12,6 +12,54 @@ class numpy_backend(object):
     def __init__(self, **kwargs):
         self.name = 'numpy'
 
+    def add(self, tensor_in_1, tensor_in_2):
+        """
+        Add two tensors element-wise
+
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend(pyhf.tensor.numpy_backend())
+            >>> a = pyhf.tensorlib.astensor([1, 2, 3, 4])
+            >>> b = pyhf.tensorlib.astensor([5, 6, 7, 8])
+            >>> pyhf.tensorlib.add(a, b)
+            array([ 6.,  8., 10., 12.])
+
+        Args:
+            tensor_in_1 (`Tensor`): The first tensor
+            tensor_in_2 (`Tensor`): The tensor of same type and shape as :code:`tensor_in_1`
+
+        Returns:
+            NumPy ndarray: The sum of the input tensors
+        """
+        tensor_in_1 = self.astensor(tensor_in_1)
+        tensor_in_2 = self.astensor(tensor_in_2)
+        return np.add(tensor_in_1, tensor_in_2)
+
+    def subtract(self, tensor_in_1, tensor_in_2):
+        """
+        Subtract two tensors element-wise
+
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend(pyhf.tensor.numpy_backend())
+            >>> a = pyhf.tensorlib.astensor([1, 2, 3, 4])
+            >>> b = pyhf.tensorlib.astensor([5, 6, 7, 8])
+            >>> pyhf.tensorlib.subtract(b, a)
+            array([ 4.,  4., 4., 4.])
+
+        Args:
+            tensor_in_1 (`Tensor`): The first tensor
+            tensor_in_2 (`Tensor`): The tensor of same type and shape as :code:`tensor_in_1`
+
+        Returns:
+            NumPy ndarray: The difference of the input tensors
+        """
+        tensor_in_1 = self.astensor(tensor_in_1)
+        tensor_in_2 = self.astensor(tensor_in_2)
+        return np.subtract(tensor_in_1, tensor_in_2)
+
     def clip(self, tensor_in, min_value, max_value):
         """
         Clips (limits) the tensor values to be within a specified min and max.

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -38,7 +38,7 @@ class numpy_backend(object):
 
     def subtract(self, tensor_in_1, tensor_in_2):
         """
-        Subtract two tensors element-wise as :code:`(tensor_in_2 - tensor_in_1)`
+        Subtract two tensors element-wise as :code:`(tensor_in_1 - tensor_in_2)`
 
         Example:
 

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -38,7 +38,7 @@ class numpy_backend(object):
 
     def subtract(self, tensor_in_1, tensor_in_2):
         """
-        Subtract two tensors element-wise
+        Subtract two tensors element-wise as :code:`(tensor_in_2 - tensor_in_1)`
 
         Example:
 
@@ -47,7 +47,7 @@ class numpy_backend(object):
             >>> a = pyhf.tensorlib.astensor([1, 2, 3, 4])
             >>> b = pyhf.tensorlib.astensor([5, 6, 7, 8])
             >>> pyhf.tensorlib.subtract(b, a)
-            array([ 4.,  4., 4., 4.])
+            array([4., 4., 4., 4.])
 
         Args:
             tensor_in_1 (`Tensor`): The first tensor

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -90,7 +90,7 @@ class numpy_backend(object):
 
             >>> import pyhf
             >>> pyhf.set_backend(pyhf.tensor.numpy_backend())
-            >>> tensorlib, _ = pyhf.get_backend()
+            >>> tensorlib = pyhf.tensorlib
             >>> a = tensorlib.astensor([4])
             >>> b = tensorlib.astensor([5])
             >>> tensorlib.conditional(

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -89,12 +89,14 @@ class numpy_backend(object):
         Example:
 
             >>> import pyhf
-            >>> import numpy as np
             >>> pyhf.set_backend(pyhf.tensor.numpy_backend())
-            >>> a = pyhf.tensorlib.astensor([4])
-            >>> b = pyhf.tensorlib.astensor([5])
-            >>> pyhf.tensorlib.conditional(
-            ...     np.less(a, b)[0], lambda: np.add(a, b), lambda: np.subtract(a, b)
+            >>> tensorlib, _ = pyhf.get_backend()
+            >>> a = tensorlib.astensor([4])
+            >>> b = tensorlib.astensor([5])
+            >>> tensorlib.conditional(
+            ...     tensorlib.less(a, b)[0],
+            ...     lambda: tensorlib.add(a, b),
+            ...     lambda: tensorlib.subtract(a, b)
             ... )
             array([9.])
 

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -34,6 +34,80 @@ class numpy_backend(object):
         """
         return np.clip(tensor_in, min_value, max_value)
 
+    def conditional(self, predicate, true_callable, false_callable):
+        """
+        Runs a callable conditional on the boolean value of the evaulation of a predicate
+
+        Example:
+
+            >>> import pyhf
+            >>> import numpy as np
+            >>> pyhf.set_backend(pyhf.tensor.numpy_backend())
+            >>> a = pyhf.tensorlib.astensor([4])
+            >>> b = pyhf.tensorlib.astensor([5])
+            >>> pyhf.tensorlib.conditional(
+            ...     np.less(a, b)[0], lambda: np.add(a, b), lambda: np.subtract(a, b)
+            ... )
+            array([9.])
+
+        Args:
+            predicate (`scalar`): The logical condition that determines which callable to evaluate
+            true_callable (`callable`): The callable that is evaluated when the :code:`predicate` evalutes to :code:`true`
+            false_callable (`callable`): The callable that is evaluated when the :code:`predicate` evalutes to :code:`false`
+
+        Returns:
+            NumPy ndarray: The output of the callable that was evaluated
+        """
+        return true_callable() if predicate else false_callable()
+
+    def less(self, tensor_in_1, tensor_in_2):
+        """
+        The boolean value of :code:`(tensor_in_1 < tensor_in_2)` element-wise
+
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend(pyhf.tensor.numpy_backend())
+            >>> a = pyhf.tensorlib.astensor([4])
+            >>> b = pyhf.tensorlib.astensor([5])
+            >>> pyhf.tensorlib.less(a, b)
+            array([ True])
+
+        Args:
+            tensor_in_1 (`Tensor`): The first tensor
+            tensor_in_2 (`Tensor`): The tensor of same type as :code:`tensor_in_1`
+
+        Returns:
+            NumPy ndarray: The bool of the comparison
+        """
+        tensor_in_1 = self.astensor(tensor_in_1)
+        tensor_in_2 = self.astensor(tensor_in_2)
+        return np.less(tensor_in_1, tensor_in_2)
+
+    def greater(self, tensor_in_1, tensor_in_2):
+        """
+        The boolean value of :code:`(tensor_in_1 > tensor_in_2)` element-wise
+
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend(pyhf.tensor.numpy_backend())
+            >>> a = pyhf.tensorlib.astensor([4])
+            >>> b = pyhf.tensorlib.astensor([5])
+            >>> pyhf.tensorlib.greater(b, a)
+            array([ True])
+
+        Args:
+            tensor_in_1 (`Tensor`): The first tensor
+            tensor_in_2 (`Tensor`): The tensor of same type as :code:`tensor_in_1`
+
+        Returns:
+            NumPy ndarray: The bool of the comparison
+        """
+        tensor_in_1 = self.astensor(tensor_in_1)
+        tensor_in_2 = self.astensor(tensor_in_2)
+        return np.greater(tensor_in_1, tensor_in_2)
+
     def tolist(self, tensor_in):
         try:
             return tensor_in.tolist()

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -11,6 +11,54 @@ class pytorch_backend(object):
     def __init__(self, **kwargs):
         self.name = 'pytorch'
 
+    def add(self, tensor_in_1, tensor_in_2):
+        """
+        Add two tensors element-wise
+
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend(pyhf.tensor.pytorch_backend())
+            >>> a = pyhf.tensorlib.astensor([1, 2, 3, 4])
+            >>> b = pyhf.tensorlib.astensor([5, 6, 7, 8])
+            >>> pyhf.tensorlib.add(a, b)
+            tensor([ 6.,  8., 10., 12.])
+
+        Args:
+            tensor_in_1 (`Tensor`): The first tensor
+            tensor_in_2 (`Tensor`): The tensor of same type and shape as :code:`tensor_in_1`
+
+        Returns:
+            PyTorch tensor: The sum of the input tensors
+        """
+        tensor_in_1 = self.astensor(tensor_in_1)
+        tensor_in_2 = self.astensor(tensor_in_2)
+        return torch.add(tensor_in_1, tensor_in_2)
+
+    def subtract(self, tensor_in_1, tensor_in_2):
+        """
+        Subtract two tensors element-wise
+
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend(pyhf.tensor.pytorch_backend())
+            >>> a = pyhf.tensorlib.astensor([1, 2, 3, 4])
+            >>> b = pyhf.tensorlib.astensor([5, 6, 7, 8])
+            >>> pyhf.tensorlib.subtract(b, a)
+            tensor([4., 4., 4., 4.])
+
+        Args:
+            tensor_in_1 (`Tensor`): The first tensor
+            tensor_in_2 (`Tensor`): The tensor of same type and shape as :code:`tensor_in_1`
+
+        Returns:
+            PyTorch tensor: The difference of the input tensors
+        """
+        tensor_in_1 = self.astensor(tensor_in_1)
+        tensor_in_2 = self.astensor(tensor_in_2)
+        return torch.add(tensor_in_2, -1, tensor_in_1)
+
     def clip(self, tensor_in, min_value, max_value):
         """
         Clips (limits) the tensor values to be within a specified min and max.

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -37,7 +37,7 @@ class pytorch_backend(object):
 
     def subtract(self, tensor_in_1, tensor_in_2):
         """
-        Subtract two tensors element-wise
+        Subtract two tensors element-wise as :code:`(tensor_in_2 - tensor_in_1)`
 
         Example:
 
@@ -57,7 +57,7 @@ class pytorch_backend(object):
         """
         tensor_in_1 = self.astensor(tensor_in_1)
         tensor_in_2 = self.astensor(tensor_in_2)
-        return torch.add(tensor_in_2, -1, tensor_in_1)
+        return torch.add(tensor_in_1, -1, tensor_in_2)
 
     def clip(self, tensor_in, min_value, max_value):
         """

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -89,12 +89,14 @@ class pytorch_backend(object):
         Example:
 
             >>> import pyhf
-            >>> import torch
             >>> pyhf.set_backend(pyhf.tensor.pytorch_backend())
-            >>> a = pyhf.tensorlib.astensor([4])
-            >>> b = pyhf.tensorlib.astensor([5])
-            >>> pyhf.tensorlib.conditional(
-            ...     torch.lt(a, b)[0], lambda: torch.add(a, b), lambda: torch.subtract(a, b)
+            >>> tensorlib, _ = pyhf.get_backend()
+            >>> a = tensorlib.astensor([4])
+            >>> b = tensorlib.astensor([5])
+            >>> tensorlib.conditional(
+            ...     tensorlib.less(a, b)[0],
+            ...     lambda: tensorlib.add(a, b),
+            ...     lambda: tensorlib.subtract(a, b)
             ... )
             tensor([9.])
 

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -13,7 +13,7 @@ class pytorch_backend(object):
 
     def add(self, tensor_in_1, tensor_in_2):
         """
-        Add two tensors element-wise
+        Add two tensors element-wise. Equivalent to :code:`sum([tensor_in_1, tensor_in_2], axis=0)`.
 
         Example:
 

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -34,6 +34,80 @@ class pytorch_backend(object):
         tensor_in = self.astensor(tensor_in)
         return torch.clamp(tensor_in, min_value, max_value)
 
+    def conditional(self, predicate, true_callable, false_callable):
+        """
+        Runs a callable conditional on the boolean value of the evaulation of a predicate
+
+        Example:
+
+            >>> import pyhf
+            >>> import torch
+            >>> pyhf.set_backend(pyhf.tensor.pytorch_backend())
+            >>> a = pyhf.tensorlib.astensor([4])
+            >>> b = pyhf.tensorlib.astensor([5])
+            >>> pyhf.tensorlib.conditional(
+            ...     torch.lt(a, b)[0], lambda: torch.add(a, b), lambda: torch.subtract(a, b)
+            ... )
+            tensor([9.])
+
+        Args:
+            predicate (`scalar`): The logical condition that determines which callable to evaluate
+            true_callable (`callable`): The callable that is evaluated when the :code:`predicate` evalutes to :code:`true`
+            false_callable (`callable`): The callable that is evaluated when the :code:`predicate` evalutes to :code:`false`
+
+        Returns:
+            PyTorch Tensor: The output of the callable that was evaluated
+        """
+        return true_callable() if predicate else false_callable()
+
+    def less(self, tensor_in_1, tensor_in_2):
+        """
+        The boolean value of :code:`(tensor_in_1 < tensor_in_2)` element-wise
+
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend(pyhf.tensor.pytorch_backend())
+            >>> a = pyhf.tensorlib.astensor([4])
+            >>> b = pyhf.tensorlib.astensor([5])
+            >>> pyhf.tensorlib.less(a, b)
+            tensor([True])
+
+        Args:
+            tensor_in_1 (`Tensor`): The first tensor
+            tensor_in_2 (`Tensor`): The tensor of same type as :code:`tensor_in_1`
+
+        Returns:
+            PyTorch Tensor: The bool of the comparison
+        """
+        tensor_in_1 = self.astensor(tensor_in_1)
+        tensor_in_2 = self.astensor(tensor_in_2)
+        return torch.lt(tensor_in_1, tensor_in_2)
+
+    def greater(self, tensor_in_1, tensor_in_2):
+        """
+        The boolean value of :code:`(tensor_in_1 > tensor_in_2)` element-wise
+
+        Example:
+
+            >>> import pyhf
+            >>> pyhf.set_backend(pyhf.tensor.pytorch_backend())
+            >>> a = pyhf.tensorlib.astensor([4])
+            >>> b = pyhf.tensorlib.astensor([5])
+            >>> pyhf.tensorlib.greater(b, a)
+            tensor([True])
+
+        Args:
+            tensor_in_1 (`Tensor`): The first tensor
+            tensor_in_2 (`Tensor`): The tensor of same type as :code:`tensor_in_1`
+
+        Returns:
+            PyTorch Tensor: The bool of the comparison
+        """
+        tensor_in_1 = self.astensor(tensor_in_1)
+        tensor_in_2 = self.astensor(tensor_in_2)
+        return torch.gt(tensor_in_1, tensor_in_2)
+
     def tolist(self, tensor_in):
         try:
             return tensor_in.data.numpy().tolist()

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -37,7 +37,7 @@ class pytorch_backend(object):
 
     def subtract(self, tensor_in_1, tensor_in_2):
         """
-        Subtract two tensors element-wise as :code:`(tensor_in_2 - tensor_in_1)`
+        Subtract two tensors element-wise as :code:`(tensor_in_1 - tensor_in_2)`
 
         Example:
 

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -90,7 +90,7 @@ class pytorch_backend(object):
 
             >>> import pyhf
             >>> pyhf.set_backend(pyhf.tensor.pytorch_backend())
-            >>> tensorlib, _ = pyhf.get_backend()
+            >>> tensorlib = pyhf.tensorlib
             >>> a = tensorlib.astensor([4])
             >>> b = tensorlib.astensor([5])
             >>> tensorlib.conditional(

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -14,7 +14,7 @@ class tensorflow_backend(object):
 
     def add(self, tensor_in_1, tensor_in_2):
         """
-        Add two tensors element-wise
+        Add two tensors element-wise. Equivalent to :code:`sum([tensor_in_1, tensor_in_2], axis=0)`.
 
         Example:
 

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -43,7 +43,7 @@ class tensorflow_backend(object):
 
     def subtract(self, tensor_in_1, tensor_in_2):
         """
-        Subtract two tensors element-wise
+        Subtract two tensors element-wise as :code:`(tensor_in_2 - tensor_in_1)`
 
         Example:
 

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -12,6 +12,64 @@ class tensorflow_backend(object):
         self.session = kwargs.get('session')
         self.name = 'tensorflow'
 
+    def add(self, tensor_in_1, tensor_in_2):
+        """
+        Add two tensors element-wise
+
+        Example:
+
+            >>> import pyhf
+            >>> import tensorflow as tf
+            >>> sess = tf.Session()
+            ...
+            >>> pyhf.set_backend(pyhf.tensor.tensorflow_backend(session=sess))
+            >>> a = pyhf.tensorlib.astensor([1, 2, 3, 4])
+            >>> b = pyhf.tensorlib.astensor([5, 6, 7, 8])
+            >>> with sess.as_default():
+            ...   sess.run(pyhf.tensorlib.add(a, b))
+            ...
+            array([ 6.,  8., 10., 12.], dtype=float32)
+
+        Args:
+            tensor_in_1 (`Tensor`): The first tensor
+            tensor_in_2 (`Tensor`): The tensor of same type and shape as :code:`tensor_in_1`
+
+        Returns:
+            TensorFlow Tensor: The sum of the input tensors
+        """
+        tensor_in_1 = self.astensor(tensor_in_1)
+        tensor_in_2 = self.astensor(tensor_in_2)
+        return tf.add(tensor_in_1, tensor_in_2)
+
+    def subtract(self, tensor_in_1, tensor_in_2):
+        """
+        Subtract two tensors element-wise
+
+        Example:
+
+            >>> import pyhf
+            >>> import tensorflow as tf
+            >>> sess = tf.Session()
+            ...
+            >>> pyhf.set_backend(pyhf.tensor.tensorflow_backend(session=sess))
+            >>> a = pyhf.tensorlib.astensor([1, 2, 3, 4])
+            >>> b = pyhf.tensorlib.astensor([5, 6, 7, 8])
+            >>> with sess.as_default():
+            ...   sess.run(pyhf.tensorlib.subtract(b, a))
+            ...
+            array([4., 4., 4., 4.], dtype=float32)
+
+        Args:
+            tensor_in_1 (`Tensor`): The first tensor
+            tensor_in_2 (`Tensor`): The tensor of same type and shape as :code:`tensor_in_1`
+
+        Returns:
+            TensorFlow Tensor: The difference of the input tensors
+        """
+        tensor_in_1 = self.astensor(tensor_in_1)
+        tensor_in_2 = self.astensor(tensor_in_2)
+        return tf.subtract(tensor_in_1, tensor_in_2)
+
     def clip(self, tensor_in, min_value, max_value):
         """
         Clips (limits) the tensor values to be within a specified min and max.

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -43,7 +43,7 @@ class tensorflow_backend(object):
 
     def subtract(self, tensor_in_1, tensor_in_2):
         """
-        Subtract two tensors element-wise as :code:`(tensor_in_2 - tensor_in_1)`
+        Subtract two tensors element-wise as :code:`(tensor_in_1 - tensor_in_2)`
 
         Example:
 

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -113,12 +113,15 @@ class tensorflow_backend(object):
             >>> sess = tf.Session()
             ...
             >>> pyhf.set_backend(pyhf.tensor.tensorflow_backend(session=sess))
-            >>> a = pyhf.tensorlib.astensor([4])
-            >>> b = pyhf.tensorlib.astensor([5])
+            >>> tensorlib, _ = pyhf.get_backend()
+            >>> a = tensorlib.astensor([4])
+            >>> b = tensorlib.astensor([5])
             >>> with sess.as_default():
-            ...   sess.run(
-            ...       pyhf.tensorlib.conditional(
-            ...           tf.less(a, b)[0], lambda: tf.add(a, b), lambda: tf.subtract(a, b)
+            ...     sess.run(
+            ...         tensorlib.conditional(
+            ...             tensorlib.less(a, b)[0],
+            ...             lambda: tensorlib.add(a, b),
+            ...             lambda: tensorlib.subtract(a, b)
             ...       )
             ...   )
             ...

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -113,7 +113,7 @@ class tensorflow_backend(object):
             >>> sess = tf.Session()
             ...
             >>> pyhf.set_backend(pyhf.tensor.tensorflow_backend(session=sess))
-            >>> tensorlib, _ = pyhf.get_backend()
+            >>> tensorlib = pyhf.tensorlib
             >>> a = tensorlib.astensor([4])
             >>> b = tensorlib.astensor([5])
             >>> with sess.as_default():

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -44,6 +44,96 @@ class tensorflow_backend(object):
             max_value = tf.reduce_max(tensor_in)
         return tf.clip_by_value(tensor_in, min_value, max_value)
 
+    def conditional(self, predicate, true_callable, false_callable):
+        """
+        Runs a callable conditional on the boolean value of the evaulation of a predicate
+
+        Example:
+
+            >>> import pyhf
+            >>> import tensorflow as tf
+            >>> sess = tf.Session()
+            ...
+            >>> pyhf.set_backend(pyhf.tensor.tensorflow_backend(session=sess))
+            >>> a = pyhf.tensorlib.astensor([4])
+            >>> b = pyhf.tensorlib.astensor([5])
+            >>> with sess.as_default():
+            ...   sess.run(
+            ...       pyhf.tensorlib.conditional(
+            ...           tf.less(a, b)[0], lambda: tf.add(a, b), lambda: tf.subtract(a, b)
+            ...       )
+            ...   )
+            ...
+            array([9.], dtype=float32)
+
+        Args:
+            predicate (`scalar`): The logical condition that determines which callable to evaluate
+            true_callable (`callable`): The callable that is evaluated when the :code:`predicate` evalutes to :code:`true`
+            false_callable (`callable`): The callable that is evaluated when the :code:`predicate` evalutes to :code:`false`
+
+        Returns:
+            TensorFlow Tensor: The output of the callable that was evaluated
+        """
+        return tf.cond(predicate, true_callable, false_callable)
+
+    def less(self, tensor_in_1, tensor_in_2):
+        """
+        The boolean value of :code:`(tensor_in_1 < tensor_in_2)` element-wise
+
+        Example:
+
+            >>> import pyhf
+            >>> import tensorflow as tf
+            >>> sess = tf.Session()
+            ...
+            >>> pyhf.set_backend(pyhf.tensor.tensorflow_backend(session=sess))
+            >>> a = pyhf.tensorlib.astensor([4])
+            >>> b = pyhf.tensorlib.astensor([5])
+            >>> with sess.as_default():
+            ...   sess.run(pyhf.tensorlib.less(a, b))
+            ...
+            array([ True])
+
+        Args:
+            tensor_in_1 (`Tensor`): The first tensor
+            tensor_in_2 (`Tensor`): The tensor of same type as :code:`tensor_in_1`
+
+        Returns:
+            TensorFlow Tensor: The bool of the comparison
+        """
+        tensor_in_1 = self.astensor(tensor_in_1)
+        tensor_in_2 = self.astensor(tensor_in_2)
+        return tf.math.less(tensor_in_1, tensor_in_2)
+
+    def greater(self, tensor_in_1, tensor_in_2):
+        """
+        The boolean value of :code:`(tensor_in_1 > tensor_in_2)` element-wise
+
+        Example:
+
+            >>> import pyhf
+            >>> import tensorflow as tf
+            >>> sess = tf.Session()
+            ...
+            >>> pyhf.set_backend(pyhf.tensor.tensorflow_backend(session=sess))
+            >>> a = pyhf.tensorlib.astensor([4])
+            >>> b = pyhf.tensorlib.astensor([5])
+            >>> with sess.as_default():
+            ...   sess.run(pyhf.tensorlib.greater(b, a))
+            ...
+            array([ True])
+
+        Args:
+            tensor_in_1 (`Tensor`): The first tensor
+            tensor_in_2 (`Tensor`): The tensor of same type as :code:`tensor_in_1`
+
+        Returns:
+            TensorFlow Tensor: The bool of the comparison
+        """
+        tensor_in_1 = self.astensor(tensor_in_1)
+        tensor_in_2 = self.astensor(tensor_in_2)
+        return tf.math.greater(tensor_in_1, tensor_in_2)
+
     def tolist(self, tensor_in):
         try:
             return self.session.run(tensor_in).tolist()

--- a/src/pyhf/utils.py
+++ b/src/pyhf/utils.py
@@ -159,14 +159,22 @@ def pvals_from_teststat(sqrtqmu_v, sqrtqmuA_v, qtilde=False):
         nullval = sqrtqmu_v
         altval = -(sqrtqmuA_v - sqrtqmu_v)
     else:  # qtilde
-        if sqrtqmu_v < sqrtqmuA_v:
+
+        def _true_case():
             nullval = sqrtqmu_v
             altval = -(sqrtqmuA_v - sqrtqmu_v)
-        else:
+            return nullval, altval
+
+        def _false_case():
             qmu = tensorlib.power(sqrtqmu_v, 2)
             qmu_A = tensorlib.power(sqrtqmuA_v, 2)
             nullval = (qmu + qmu_A) / (2 * sqrtqmuA_v)
             altval = (qmu - qmu_A) / (2 * sqrtqmuA_v)
+            return nullval, altval
+
+        nullval, altval = tensorlib.conditional(
+            tensorlib.less(sqrtqmu_v, sqrtqmuA_v)[0], _true_case, _false_case
+        )
     CLsb = 1 - tensorlib.normal_cdf(nullval)
     CLb = 1 - tensorlib.normal_cdf(altval)
     CLs = CLsb / CLb

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -20,6 +20,9 @@ def test_simple_tensor_ops(backend):
     assert tb.tolist(tb.subtract([1, 2, 3], [4, 5, 6])) == [-3, -3, -3]
     assert tb.tolist(tb.subtract([4, 5, 6], [1])) == [3, 4, 5]
     assert tb.tolist(tb.sum([[1, 2, 3], [4, 5, 6]], axis=0)) == [5, 7, 9]
+    assert tb.tolist(tb.add([1, 2, 3], [4, 5, 6])) == tb.tolist(
+        tb.sum([[1, 2, 3], [4, 5, 6]], axis=0)
+    )
     assert tb.tolist(tb.product([[1, 2, 3], [4, 5, 6]], axis=0)) == [4, 10, 18]
     assert tb.tolist(tb.power([1, 2, 3], [1, 2, 3])) == [1, 4, 27]
     assert tb.tolist(tb.divide([4, 9, 16], [2, 3, 4])) == [2, 3, 4]

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -15,6 +15,10 @@ def test_astensor_dtype(backend, caplog):
 
 def test_simple_tensor_ops(backend):
     tb = pyhf.tensorlib
+    assert tb.tolist(tb.add([1, 2, 3], [4, 5, 6])) == [5, 7, 9]
+    assert tb.tolist(tb.add([1], [4, 5, 6])) == [5, 6, 7]
+    assert tb.tolist(tb.subtract([1, 2, 3], [4, 5, 6])) == [-3, -3, -3]
+    assert tb.tolist(tb.subtract([4, 5, 6], [1])) == [3, 4, 5]
     assert tb.tolist(tb.sum([[1, 2, 3], [4, 5, 6]], axis=0)) == [5, 7, 9]
     assert tb.tolist(tb.product([[1, 2, 3], [4, 5, 6]], axis=0)) == [4, 10, 18]
     assert tb.tolist(tb.power([1, 2, 3], [1, 2, 3])) == [1, 4, 27]
@@ -22,6 +26,22 @@ def test_simple_tensor_ops(backend):
     assert tb.tolist(tb.sqrt([4, 9, 16])) == [2, 3, 4]
     assert tb.tolist(tb.log(tb.exp([2, 3, 4]))) == [2, 3, 4]
     assert tb.tolist(tb.abs([-1, -2])) == [1, 2]
+    assert tb.tolist(tb.less(1, 2))[0] is True
+    assert tb.tolist(tb.less(2, 1))[0] is False
+    assert tb.tolist(tb.less(1, 1))[0] is False
+    assert tb.tolist(tb.greater(1, 2))[0] is False
+    assert tb.tolist(tb.greater(2, 1))[0] is True
+    assert tb.tolist(tb.greater(1, 1))[0] is False
+    assert tb.tolist(
+        tb.conditional(
+            tb.less(4, 5)[0], lambda: tb.add(4, 5), lambda: tb.subtract(4, 5)
+        )
+    ) == [9]
+    assert tb.tolist(
+        tb.conditional(
+            tb.greater(4, 5)[0], lambda: tb.add(4, 5), lambda: tb.subtract(4, 5)
+        )
+    ) == [-1]
 
 
 def test_complex_tensor_ops(backend):
@@ -100,6 +120,18 @@ def test_shape(backend):
     assert tb.shape(tb.astensor(0.0)) == tb.shape(tb.astensor([0.0]))
     assert tb.shape(tb.astensor((1.0, 1.0))) == tb.shape(tb.astensor([1.0, 1.0]))
     assert tb.shape(tb.astensor((0.0, 0.0))) == tb.shape(tb.astensor([0.0, 0.0]))
+    with pytest.raises((ValueError, RuntimeError)):
+        tb.add([1, 2], [3, 4, 5])
+    with pytest.raises((ValueError, RuntimeError)):
+        tb.subtract([1, 2], [3, 4, 5])
+    with pytest.raises((ValueError, RuntimeError)):
+        tb.less([1, 2], [3, 4, 5])
+    with pytest.raises((ValueError, RuntimeError)):
+        tb.greater([1, 2], [3, 4, 5])
+    with pytest.raises((ValueError, RuntimeError)):
+        tb.conditional(
+            tb.less([1, 2], [3, 4]), lambda: tb.add(4, 5), lambda: tb.subtract(4, 5)
+        )
 
 
 def test_pdf_calculations(backend):


### PR DESCRIPTION
# Description

Conditional on PR #535 and in support of PR #534, use a conditional control flow in `pvals_from_teststat` to avoid a TensorFlow error of

```python-traceback
TypeError: Using a `tf.Tensor` as a Python `bool` is not allowed. Use `if t is not None:` instead of `if t:` to test if a tensor is defined, and use TensorFlow ops such as tf.cond to execute subgraphs conditioned on the value of a tensor.
```

in the `if sqrtqmu_v < sqrtqmuA_v` of 

https://github.com/diana-hep/pyhf/blob/f3b0680c115ef64cfb61a7631d9a550ec50c095f/src/pyhf/utils.py#L158-L169

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [ ] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use a conditional control flow in `pvals_from_teststat` to avoid a TensorFlow TypeError related to using a tf.Tensor as a bool
```
