### PR TITLE
Add Git pre-commit hook install to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,11 +25,21 @@ If you have found a bug please report it by filling out the [bug report template
 
 ## Installing the development environment
 
-You can install the development environment (which includes a number of extra) libraries via `pip`:
+We recommend first reading the "[Developing](https://diana-hep.org/pyhf/development.html)" page on the pyhf website and the coming back here.
+
+You can install the development environment (which includes a number of extra) libraries and all others needed to run the tests via `pip`:
 
 ```
-pip install --ignore-installed -U -e .[tensorflow,torch,mxnet,develop]
+pip install --ignore-installed -U -e .[complete]
 ```
+
+To make the PR process much smoother we also strongly recommend that you setup the Git pre-commit hook for [Black](https://github.com/psf/black) by running
+
+```
+pre-commit install
+```
+
+This will run `black` over your code each time you attempt to make a commit and warn you if there is an error, canceling the commit.
 
 ## Running the tests
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -13,7 +13,7 @@ and install all necessary packages for development
 
     pip install --ignore-installed -U -e .[complete]
 
-Then setup the Git pre-commit hook for `Black <https://github.com/ambv/black>`__  by running
+Then setup the Git pre-commit hook for `Black <https://github.com/psf/black>`__  by running
 
 .. code-block:: console
 


### PR DESCRIPTION
# Description

Add the installation of the git pre-commit hook as part of the recommendations for contributing a PR. Additionally, update the [Black](https://github.com/psf/black) link endpoint to reflect that Black is now part of the Python Software Foundation :tada: &mdash; where it is now maintained for the whole community by awesome people like Carol Willing. :rocket: 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add installation of pre-commit for Git pre-commit hook to development recommendations in CONTRIBUTING
```
