### PR TITLE
Rewrite Model into PDF composition of MainModel and ConstrainedModel

### DIFF
--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -499,7 +499,7 @@ class Model(object):
         return self.main_model._modifications(pars)
 
     @property
-    def nominal_rates(self, pars):
+    def nominal_rates(self):
         return self.main_model.nominal_rates
 
     def expected_actualdata(self, pars):

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -291,16 +291,6 @@ class Model(object):
         # build up our representation of the specification
         self.config = _ModelConfig(self.spec, **config_kwargs)
 
-        # this is tricky, must happen before constraint
-        # terms try to access auxdata but after
-        # combined mods have been created that
-        # set the aux data
-        for k in sorted(self.config.par_map.keys()):
-            parset = self.config.param_set(k)
-            if hasattr(parset, 'pdf_type'):  # is constrained
-                self.config.auxdata += parset.auxdata
-                self.config.auxdata_order.append(k)
-
         mega_mods, _nominal_rates = self._create_nominal_and_modifiers(
             self.config, self.spec
         )
@@ -310,6 +300,16 @@ class Model(object):
             nominal_rates=_nominal_rates,
             batch_size=self.batch_size,
         )
+
+        # this is tricky, must happen before constraint
+        # terms try to access auxdata but after
+        # combined mods have been created that
+        # set the aux data
+        for k in sorted(self.config.par_map.keys()):
+            parset = self.config.param_set(k)
+            if hasattr(parset, 'pdf_type'):  # is constrained
+                self.config.auxdata += parset.auxdata
+                self.config.auxdata_order.append(k)
 
         self.constraints_gaussian = gaussian_constraint_combined(
             self.config, batch_size=self.batch_size

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -291,16 +291,6 @@ class Model(object):
         # build up our representation of the specification
         self.config = _ModelConfig(self.spec, **config_kwargs)
 
-        mega_mods, _nominal_rates = self._create_nominal_and_modifiers(
-            self.config, self.spec
-        )
-        self.main_model = MainModel(
-            self.config,
-            mega_mods=mega_mods,
-            nominal_rates=_nominal_rates,
-            batch_size=self.batch_size,
-        )
-
         # this is tricky, must happen before constraint
         # terms try to access auxdata but after
         # combined mods have been created that
@@ -310,6 +300,16 @@ class Model(object):
             if hasattr(parset, 'pdf_type'):  # is constrained
                 self.config.auxdata += parset.auxdata
                 self.config.auxdata_order.append(k)
+
+        mega_mods, _nominal_rates = self._create_nominal_and_modifiers(
+            self.config, self.spec
+        )
+        self.main_model = MainModel(
+            self.config,
+            mega_mods=mega_mods,
+            nominal_rates=_nominal_rates,
+            batch_size=self.batch_size,
+        )
 
         self.constraints_gaussian = gaussian_constraint_combined(
             self.config, batch_size=self.batch_size

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -473,6 +473,10 @@ class Model(object):
     def _modifications(self, pars):
         return self.main_model._modifications(pars)
 
+    @property
+    def nominal_rates(self, pars):
+        return self.main_model.nominal_rates
+
     def expected_actualdata(self, pars):
         return self.main_model.expected_actualdata(pars)
 

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -470,6 +470,12 @@ class Model(object):
             return auxdata[0]
         return auxdata
 
+    def _modifications(self, pars):
+        return self.main_model._modifications(pars)
+
+    def expected_actualdata(self, pars):
+        return self.main_model.expected_actualdata(pars)
+
     def expected_data(self, pars, include_auxdata=True):
         tensorlib, _ = get_backend()
         pars = tensorlib.astensor(pars)


### PR DESCRIPTION
# Description

NB: This is progress towards Statisfactory.

This is a cute refactoring that, only through moving some code blocks around, basically puts the "main model" of histfactory on equal footing with the constraint pdfs.

i.e. a histfactory model can be viewed as a "joint pdf" of three subpdfs

`p(data,pars) =  p_main(maindata, pars) * p_gaus(gausdata,pars) * p_pois(poisdata,pars)`

```
        self.main_model = MainModel(
            self.config,
            mega_mods=mega_mods,
            nominal_rates=_nominal_rates,
            batch_size=self.batch_size,
        )
     
        ... snip ...

        self.constraints_gaussian = gaussian_constraint_combined(
            self.config, batch_size=self.batch_size
        )
        self.constraints_poisson = poisson_constraint_combined(
            self.config, batch_size=self.batch_size
        )
```

each of which provides the `logpdf` interface, also it decouples exactly how the ingredients of the  main model get created. possibilities are

* from JSON
* from some other source, e.g. columnar analysis / differentiable upstream

this will connect with the early work on #501 (simultaneous.py)

Commit message

```
* introduce _MainModel and _ConstraintModel as sub pdf object
* prepares towards integration with prob prog ML libraries and statisfactory
* keeps around forwarding methods to be non-API breaking, expected to be remove when convenient
```