### PR TITLE
feat: Simultaneous pdf class

### DIFF
--- a/src/pyhf/probability.py
+++ b/src/pyhf/probability.py
@@ -1,4 +1,5 @@
 from . import get_backend
+from .tensor.common import TensorViewer
 
 
 class Poisson(object):
@@ -24,11 +25,11 @@ class Normal(object):
 
 
 class Independent(object):
-    '''
+    """
     A probability density corresponding to the joint
     distribution of a batch of identically distributed random
     numbers.
-    '''
+    """
 
     def __init__(self, batched_pdf, batch_size=None):
         self.batch_size = batch_size
@@ -38,6 +39,17 @@ class Independent(object):
         tensorlib, _ = get_backend()
         _log_prob = self._pdf.log_prob(value)
         return tensorlib.sum(_log_prob, axis=-1)
+
+
+class Simultaneous(object):
+    def __init__(self, pdfobjs, indices):
+        self.tv = TensorViewer(indices)
+        self.pdfobjs = pdfobjs
+
+    def log_prob(self, data):
+        constituent_data = self.tv.split(data)
+        pdfvals = [p.log_prob(d) for p, d in zip(self.pdfobjs, constituent_data)]
+        return joint_logpdf(pdfvals)
 
 
 def joint_logpdf(terms):

--- a/src/pyhf/tensor/common.py
+++ b/src/pyhf/tensor/common.py
@@ -1,0 +1,48 @@
+from .. import default_backend, get_backend
+from .. import events
+
+
+class TensorViewer(object):
+    def __init__(self, indices):
+        # self.partition_indices has the "target" indices
+        # of the stitched vector. In order to  .gather()
+        # an concatennation of source arrays into the
+        # desired form, one needs to gather on the "sorted"
+        # indices
+        # >>> source = np.asarray([9,8,7,6])
+        # >>> target = np.asarray([2,1,3,0])
+        # >>> source[target.argsort()]
+        # array([6, 8, 9, 7])
+
+        self.partition_indices = indices
+        a = default_backend.astensor(
+            default_backend.concatenate(self.partition_indices), dtype='int'
+        )
+        self._sorted_indices = default_backend.tolist(a.argsort())
+
+        self._precompute()
+        events.subscribe('tensorlib_changed')(self._precompute)
+
+    def _precompute(self):
+        tensorlib, _ = get_backend()
+        self.sorted_indices = tensorlib.astensor(self._sorted_indices)
+
+    def stitch(self, data):
+        tensorlib, _ = get_backend()
+        assert len(self.partition_indices) == len(data)
+
+        data = tensorlib.concatenate(data, axis=-1)
+        data = tensorlib.einsum('...j->j...', data)
+        stitched = tensorlib.gather(data, tensorlib.astensor(self.sorted_indices))
+        stitched = tensorlib.einsum('...j->j...', stitched)
+        return stitched
+
+    def split(self, data):
+        tensorlib, _ = get_backend()
+        data = tensorlib.astensor(data)
+        data = tensorlib.einsum('...j->j...', tensorlib.astensor(data))
+        split = [
+            tensorlib.einsum('...j->j...', tensorlib.gather(data, idx))
+            for idx in self.partition_indices
+        ]
+        return split

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -95,7 +95,8 @@ class pytorch_backend(object):
         return tensor
 
     def gather(self, tensor, indices):
-        return torch.take(tensor, indices.type(torch.LongTensor))
+        indices = self.astensor(indices, dtype='int')
+        return tensor[indices.type(torch.LongTensor)]
 
     def boolean_mask(self, tensor, mask):
         mask = self.astensor(mask, dtype='bool')


### PR DESCRIPTION
# Description

a demo PR against `add_probability_module` #551 showing how we will arrive at a pyfitcore like API


# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* extends pyhf.probability to have a joint pdf class pyhf.Simultaneous
* adapts pdf evaluation code to be thing layer around the pdf(pars).log_prob(data) pattern.
```