### PR TITLE
feat: extend pdf API with expected_data method

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -45,8 +45,8 @@ Making Models from PDFs
    Model
    _ModelConfig
 
-Tensor Backends
----------------
+Backends
+--------
 
 The computational backends that :code:`pyhf` provides interfacing for the vector-based calculations.
 
@@ -61,7 +61,6 @@ The computational backends that :code:`pyhf` provides interfacing for the vector
    numpy_backend.numpy_backend
    pytorch_backend.pytorch_backend
    tensorflow_backend.tensorflow_backend
-   common.TensorViewer
 
 Optimizers
 ----------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -45,8 +45,8 @@ Making Models from PDFs
    Model
    _ModelConfig
 
-Backends
---------
+Tensor Backends
+---------------
 
 The computational backends that :code:`pyhf` provides interfacing for the vector-based calculations.
 
@@ -61,6 +61,7 @@ The computational backends that :code:`pyhf` provides interfacing for the vector
    numpy_backend.numpy_backend
    pytorch_backend.pytorch_backend
    tensorflow_backend.tensorflow_backend
+   common.TensorViewer
 
 Optimizers
 ----------

--- a/src/pyhf/constraints.py
+++ b/src/pyhf/constraints.py
@@ -246,7 +246,7 @@ class poisson_constraint_combined(object):
         return prob.Independent(prob.Poisson(pois_rates), batch_size=self.batch_size)
 
     def logpdf(self, auxdata, pars):
-        """	
+        """
         Args:
             auxdata (`tensor`): The auxiliary data (a subset of the full data in a HistFactory model)
             pars (`tensor`): The model parameters

--- a/src/pyhf/constraints.py
+++ b/src/pyhf/constraints.py
@@ -82,11 +82,12 @@ class gaussian_constraint_combined(object):
         self.access_field = tensorlib.astensor(self._access_field, dtype='int')
 
     def make_pdf(self, pars):
-        """	
-        Args:	
-            pars (`tensor`): The model parameters	
-        Returns:	
-            pdf: The pdf object for the Normal Constraint	
+        """
+        Args:
+            pars (`tensor`): The model parameters
+
+        Returns:
+            pdf: The pdf object for the Normal Constraint
         """
         tensorlib, _ = get_backend()
         if not self.param_viewer.index_selection:
@@ -118,6 +119,7 @@ class gaussian_constraint_combined(object):
         Args:
             auxdata (`tensor`): The auxiliary data (a subset of the full data in a HistFactory model)
             pars (`tensor`): The model parameters
+
         Returns:
             log pdf value: The log of the pdf value of the Normal constraints
         """
@@ -210,11 +212,12 @@ class poisson_constraint_combined(object):
         self.batched_factors = tensorlib.astensor(self._batched_factors)
 
     def make_pdf(self, pars):
-        """	
-        Args:	
-            pars (`tensor`): The model parameters	
-        Returns:	
-            pdf: the pdf object for the Poisson Constraint	
+        """
+        Args:
+            pars (`tensor`): The model parameters
+
+        Returns:
+            pdf: the pdf object for the Poisson Constraint
         """
         tensorlib, _ = get_backend()
         if not self.param_viewer.index_selection:
@@ -244,11 +247,12 @@ class poisson_constraint_combined(object):
 
     def logpdf(self, auxdata, pars):
         """	
-        Args:	
-            auxdata (`tensor`): The auxiliary data (a subset of the full data in a HistFactory model)	
-            pars (`tensor`): The model parameters	
-        Returns:	
-            log pdf value: The log of the pdf value of the Poisson constraints	
+        Args:
+            auxdata (`tensor`): The auxiliary data (a subset of the full data in a HistFactory model)
+            pars (`tensor`): The model parameters
+
+        Returns:
+            log pdf value: The log of the pdf value of the Poisson constraints
         """
         tensorlib, _ = get_backend()
         pdf = self.make_pdf(pars)

--- a/src/pyhf/constraints.py
+++ b/src/pyhf/constraints.py
@@ -263,5 +263,4 @@ class poisson_constraint_combined(object):
                 else tensorlib.astensor(0.0)[0]
             )
         auxdata = tensorlib.astensor(auxdata)
-        result = pdf.log_prob(tensorlib.gather(auxdata, self.poisson_data))
-        return result
+        return pdf.log_prob(tensorlib.gather(auxdata, self.poisson_data))

--- a/src/pyhf/constraints.py
+++ b/src/pyhf/constraints.py
@@ -82,6 +82,12 @@ class gaussian_constraint_combined(object):
         self.access_field = tensorlib.astensor(self._access_field, dtype='int')
 
     def make_pdf(self, pars):
+        """	
+        Args:	
+            pars (`tensor`): The model parameters	
+        Returns:	
+            pdf: The pdf object for the Normal Constraint	
+        """
         tensorlib, _ = get_backend()
         if not self.param_viewer.index_selection:
             return None
@@ -103,30 +109,15 @@ class gaussian_constraint_combined(object):
         if self.batch_size is None:
             normal_means = normal_means[0]
 
-        result = prob.Independent(
+        return prob.Independent(
             prob.Normal(normal_means, self.sigmas), batch_size=self.batch_size
         )
-        return result
-
-    def logpdf(self, auxdata, pars):
-        tensorlib, _ = get_backend()
-        pdf = self.make_pdf(pars)
-        if pdf is None:
-            return (
-                tensorlib.zeros(self.batch_size)
-                if self.batch_size is not None
-                else tensorlib.astensor(0.0)[0]
-            )
-        auxdata = tensorlib.astensor(auxdata)
-        result = pdf.log_prob(tensorlib.gather(auxdata, self.normal_data))
-        return result
 
     def logpdf(self, auxdata, pars):
         """
         Args:
             auxdata (`tensor`): The auxiliary data (a subset of the full data in a HistFactory model)
             pars (`tensor`): The model parameters
-
         Returns:
             log pdf value: The log of the pdf value of the Normal constraints
         """
@@ -138,7 +129,8 @@ class gaussian_constraint_combined(object):
                 if self.batch_size is not None
                 else tensorlib.astensor(0.0)[0]
             )
-        return pdf.log_prob(self._dataprojection(auxdata))
+        auxdata = tensorlib.astensor(auxdata)
+        return pdf.log_prob(tensorlib.gather(auxdata, self.normal_data))
 
 
 class poisson_constraint_combined(object):
@@ -218,6 +210,12 @@ class poisson_constraint_combined(object):
         self.batched_factors = tensorlib.astensor(self._batched_factors)
 
     def make_pdf(self, pars):
+        """	
+        Args:	
+            pars (`tensor`): The model parameters	
+        Returns:	
+            pdf: the pdf object for the Poisson Constraint	
+        """
         tensorlib, _ = get_backend()
         if not self.param_viewer.index_selection:
             return None
@@ -242,10 +240,16 @@ class poisson_constraint_combined(object):
         if self.batch_size is None:
             pois_rates = pois_rates[0]
         # pdf pars are done, now get data and compute
-        result = prob.Independent(prob.Poisson(pois_rates), batch_size=self.batch_size)
-        return result
+        return prob.Independent(prob.Poisson(pois_rates), batch_size=self.batch_size)
 
     def logpdf(self, auxdata, pars):
+        """	
+        Args:	
+            auxdata (`tensor`): The auxiliary data (a subset of the full data in a HistFactory model)	
+            pars (`tensor`): The model parameters	
+        Returns:	
+            log pdf value: The log of the pdf value of the Poisson constraints	
+        """
         tensorlib, _ = get_backend()
         pdf = self.make_pdf(pars)
         if pdf is None:

--- a/src/pyhf/parameters/paramsets.py
+++ b/src/pyhf/parameters/paramsets.py
@@ -1,6 +1,3 @@
-from .. import get_backend
-
-
 class paramset(object):
     def __init__(self, **kwargs):
         self.n_parameters = kwargs.pop('n_parameters')
@@ -21,9 +18,6 @@ class constrained_by_normal(paramset):
         if sigmas:
             self.sigmas = sigmas
 
-    def expected_data(self, pars):
-        return pars
-
 
 class constrained_by_poisson(paramset):
     def __init__(self, **kwargs):
@@ -31,16 +25,3 @@ class constrained_by_poisson(paramset):
         self.pdf_type = 'poisson'
         self.auxdata = kwargs.pop('auxdata')
         self.factors = kwargs.pop('factors')
-
-    def expected_data(self, pars):
-        tensorlib, _ = get_backend()
-        sh = tensorlib.shape(pars)
-        # if batched, tile the factors as they only depend on background uncertainty
-        if len(sh) > 1:
-            fc = tensorlib.tile(
-                tensorlib.reshape(tensorlib.astensor(self.factors), (1, -1)), (sh[0], 1)
-            )
-            return pars * fc
-        return tensorlib.product(
-            tensorlib.stack([pars, tensorlib.astensor(self.factors)]), axis=0
-        )

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -516,34 +516,6 @@ class Model(object):
         return self.make_pdf(pars).pdfobjs[0].log_prob(maindata)
 
     def make_pdf(self, pars):
-        tensorlib, _ = get_backend()
-        # if self._pdf and self._lastpars == tensorlib.tolist(pars):
-        #     return self._pdf
-        pars = tensorlib.astensor(pars)
-        # self._lastpars = tensorlib.tolist(pars)
-
-        bindata = self.nominal_rates.shape[-1]
-        cut = bindata
-        total_size = bindata + len(self.config.auxdata)
-        pos = list(range(total_size))
-
-        pdfobjs = []
-        indices = []
-
-        mainpdf = self.main_model.make_pdf(pars)
-        pdfobjs.append(mainpdf)
-        indices.append(pos[:cut])
-
-        constraint = self.constraint_model.make_pdf(pars)
-        if constraint:
-            pdfobjs.append(constraint)
-            indices.append(pos[cut:])
-
-        simpdf = prob.Simultaneous(pdfobjs, indices)
-        # self._pdf = simpdf
-        return simpdf
-
-    def make_pdf(self, pars):
         """
         Args:
             pars (`tensor`): The model parameters

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -200,6 +200,15 @@ class _ConstraintModel(object):
         assert self.constraints_poisson.batch_size == self.batch_size
 
     def make_pdf(self, pars):
+        """
+        Args:
+            pars (`tensor`): The model parameters
+
+        Returns:
+            pdf: A distribution object implementing the constraint pdf of HistFactory.
+                 Either a Poissonn, a Gaussian or a joint pdf of both depending on the
+                 constraints used in the specification.
+        """
         indices = []
         pdfobjs = []
 
@@ -326,8 +335,6 @@ class _MainModel(object):
 
 class Model(object):
     def __init__(self, spec, batch_size=None, **config_kwargs):
-        self._pdf = None
-        self._lastpars = None
         self.batch_size = batch_size
         self.spec = copy.deepcopy(spec)  # may get modified by config
         self.schema = config_kwargs.pop('schema', 'model.json')

--- a/src/pyhf/probability.py
+++ b/src/pyhf/probability.py
@@ -1,5 +1,5 @@
 from . import get_backend
-from .tensor.common import TensorViewer
+from .tensor.common import _TensorViewer
 
 
 class Poisson(object):
@@ -52,7 +52,7 @@ class Independent(object):
 
 class Simultaneous(object):
     def __init__(self, pdfobjs, indices):
-        self.tv = TensorViewer(indices)
+        self.tv = _TensorViewer(indices)
         self.pdfobjs = pdfobjs
 
     def log_prob(self, data):

--- a/src/pyhf/probability.py
+++ b/src/pyhf/probability.py
@@ -33,7 +33,7 @@ class Normal(object):
 class Independent(object):
     """
     A probability density corresponding to the joint
-    likelihood of a batch of identically distributed random
+    distribution of a batch of identically distributed random
     numbers.
     """
 

--- a/src/pyhf/probability.py
+++ b/src/pyhf/probability.py
@@ -12,6 +12,9 @@ class Poisson(object):
         n = tensorlib.astensor(value)
         return tensorlib.poisson_logpdf(n, self.lam)
 
+    def expected_data(self):
+        return self.lam
+
 
 class Normal(object):
     def __init__(self, loc, scale):
@@ -23,17 +26,23 @@ class Normal(object):
         tensorlib, _ = get_backend()
         return tensorlib.normal_logpdf(value, self.mu, self.sigma)
 
+    def expected_data(self):
+        return self.mu
+
 
 class Independent(object):
     """
     A probability density corresponding to the joint
-    distribution of a batch of identically distributed random
+    likelihood of a batch of identically distributed random
     numbers.
     """
 
     def __init__(self, batched_pdf, batch_size=None):
         self.batch_size = batch_size
         self._pdf = batched_pdf
+
+    def expected_data(self):
+        return self._pdf.expected_data()
 
     def log_prob(self, value):
         tensorlib, _ = get_backend()
@@ -50,6 +59,10 @@ class Simultaneous(object):
         constituent_data = self.tv.split(data)
         pdfvals = [p.log_prob(d) for p, d in zip(self.pdfobjs, constituent_data)]
         return joint_logpdf(pdfvals)
+
+    def expected_data(self):
+        tostitch = [p.expected_data() for p in self.pdfobjs]
+        return self.tv.stitch(tostitch)
 
 
 def joint_logpdf(terms):

--- a/src/pyhf/tensor/common.py
+++ b/src/pyhf/tensor/common.py
@@ -2,7 +2,7 @@ from .. import default_backend, get_backend
 from .. import events
 
 
-class TensorViewer(object):
+class _TensorViewer(object):
     def __init__(self, indices):
         # self.partition_indices has the "target" indices
         # of the stitched vector. In order to  .gather()

--- a/src/pyhf/tensor/common.py
+++ b/src/pyhf/tensor/common.py
@@ -32,17 +32,20 @@ class TensorViewer(object):
         assert len(self.partition_indices) == len(data)
 
         data = tensorlib.concatenate(data, axis=-1)
+        # move event axis up front
         data = tensorlib.einsum('...j->j...', data)
-        stitched = tensorlib.gather(data, tensorlib.astensor(self.sorted_indices))
-        stitched = tensorlib.einsum('...j->j...', stitched)
+        stitched = tensorlib.gather(
+            data, tensorlib.astensor(self.sorted_indices, dtype='int')
+        )
+        stitched = tensorlib.einsum('j...->...j', stitched)
         return stitched
 
     def split(self, data):
         tensorlib, _ = get_backend()
         data = tensorlib.astensor(data)
-        data = tensorlib.einsum('...j->j...', tensorlib.astensor(data))
+        data = tensorlib.einsum('...j->j...', data)
         split = [
-            tensorlib.einsum('...j->j...', tensorlib.gather(data, idx))
+            tensorlib.einsum('j...->...j', tensorlib.gather(data, idx))
             for idx in self.partition_indices
         ]
         return split

--- a/src/pyhf/tensor/common.py
+++ b/src/pyhf/tensor/common.py
@@ -37,8 +37,7 @@ class TensorViewer(object):
         stitched = tensorlib.gather(
             data, tensorlib.astensor(self.sorted_indices, dtype='int')
         )
-        stitched = tensorlib.einsum('j...->...j', stitched)
-        return stitched
+        return tensorlib.einsum('j...->...j', stitched)
 
     def split(self, data):
         tensorlib, _ = get_backend()


### PR DESCRIPTION
# Description

* patch against #553 that uses extends the basic pdf API to include expectation values and thus cleans up a lot of `expected_data` calls
* should still be passing tests and not break any APIs