### PR TITLE
fix: 1 bin lumi validation test

### DIFF
--- a/src/pyhf/exceptions/__init__.py
+++ b/src/pyhf/exceptions/__init__.py
@@ -68,3 +68,15 @@ class InvalidOptimizer(Exception):
     """
     InvalidOptimizer is raised when trying to set using an optimizer that does not exist.
     """
+
+
+class InvalidPdfParameters(Exception):
+    """
+    InvalidPdfParameters is raised when trying to evaluate a pdf with invalid parameters.
+    """
+
+
+class InvalidPdfData(Exception):
+    """
+    InvalidPdfData is raised when trying to evaluate a pdf with invalid data.
+    """

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -539,29 +539,22 @@ class Model(object):
             tensorlib, _ = get_backend()
             pars, data = tensorlib.astensor(pars), tensorlib.astensor(data)
             # Verify parameter and data shapes
-            try:
-                if pars.shape[-1] != len(self.config.suggested_init()):
-                    raise ValueError
-            except ValueError:
-                log.error(
+            if pars.shape[-1] != len(self.config.suggested_init()):
+                raise ValueError(
                     'eval failed as pars has len {} but {} was expected'.format(
                         pars.shape[-1], len(self.config.suggested_init())
                     )
                 )
-                raise
-            try:
-                if data.shape[-1] != self.nominal_rates.shape[-1] + len(
-                    self.config.auxdata
-                ):
-                    raise ValueError
-            except ValueError:
-                log.error(
+
+            if data.shape[-1] != self.nominal_rates.shape[-1] + len(
+                self.config.auxdata
+            ):
+                raise ValueError(
                     'eval failed as data has len {} but {} was expected'.format(
                         data.shape[-1],
                         self.nominal_rates.shape[-1] + len(self.config.auxdata),
                     )
                 )
-                raise
 
             actual_data = self.main_model._dataprojection(data)
             aux_data = self.constraint_model._dataprojection(data)

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -540,7 +540,7 @@ class Model(object):
             pars, data = tensorlib.astensor(pars), tensorlib.astensor(data)
             # Verify parameter and data shapes
             if pars.shape[-1] != len(self.config.suggested_init()):
-                raise ValueError(
+                raise exceptions.InvalidPdfParameters(
                     'eval failed as pars has len {} but {} was expected'.format(
                         pars.shape[-1], len(self.config.suggested_init())
                     )
@@ -549,7 +549,7 @@ class Model(object):
             if data.shape[-1] != self.nominal_rates.shape[-1] + len(
                 self.config.auxdata
             ):
-                raise ValueError(
+                raise exceptions.InvalidPdfData(
                     'eval failed as data has len {} but {} was expected'.format(
                         data.shape[-1],
                         self.nominal_rates.shape[-1] + len(self.config.auxdata),

--- a/src/pyhf/pdf.py
+++ b/src/pyhf/pdf.py
@@ -538,6 +538,30 @@ class Model(object):
         try:
             tensorlib, _ = get_backend()
             pars, data = tensorlib.astensor(pars), tensorlib.astensor(data)
+            # Verify parameter and data shapes
+            try:
+                if pars.shape[-1] != len(self.config.suggested_init()):
+                    raise ValueError
+            except ValueError:
+                log.error(
+                    'eval failed as pars has len {} but {} was expected'.format(
+                        pars.shape[-1], len(self.config.suggested_init())
+                    )
+                )
+                raise
+            try:
+                if data.shape[-1] != self.nominal_rates.shape[-1] + len(
+                    self.config.auxdata
+                ):
+                    raise ValueError
+            except ValueError:
+                log.error(
+                    'eval failed as data has len {} but {} was expected'.format(
+                        data.shape[-1],
+                        self.nominal_rates.shape[-1] + len(self.config.auxdata),
+                    )
+                )
+                raise
 
             actual_data = self.main_model._dataprojection(data)
             aux_data = self.constraint_model._dataprojection(data)

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -29,23 +29,6 @@ def test_pdf_inputs(backend):
     )
 
 
-def test_invalid_pdf_data():
-    source = {
-        "binning": [2, -0.5, 1.5],
-        "bindata": {"data": [55.0], "bkg": [50.0], "bkgerr": [7.0], "sig": [10.0]},
-    }
-    pdf = pyhf.simplemodels.hepdata_like(
-        source['bindata']['sig'], source['bindata']['bkg'], source['bindata']['bkgerr']
-    )
-
-    pars = pdf.config.suggested_init()
-    data = source['bindata']['data'] + [10.0] + pdf.config.auxdata
-
-    with pytest.raises(ValueError) as excinfo:
-        pdf.logpdf(pars, data)
-    assert "eval failed as data has len" in str(excinfo.value)
-
-
 def test_invalid_pdf_pars():
     source = {
         "binning": [2, -0.5, 1.5],
@@ -58,9 +41,24 @@ def test_invalid_pdf_pars():
     pars = pdf.config.suggested_init() + [1.0]
     data = source['bindata']['data'] + pdf.config.auxdata
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(pyhf.exceptions.InvalidPdfParameters):
         pdf.logpdf(pars, data)
-    assert "eval failed as pars has len" in str(excinfo.value)
+
+
+def test_invalid_pdf_data():
+    source = {
+        "binning": [2, -0.5, 1.5],
+        "bindata": {"data": [55.0], "bkg": [50.0], "bkgerr": [7.0], "sig": [10.0]},
+    }
+    pdf = pyhf.simplemodels.hepdata_like(
+        source['bindata']['sig'], source['bindata']['bkg'], source['bindata']['bkgerr']
+    )
+
+    pars = pdf.config.suggested_init()
+    data = source['bindata']['data'] + [10.0] + pdf.config.auxdata
+
+    with pytest.raises(pyhf.exceptions.InvalidPdfData):
+        pdf.logpdf(pars, data)
 
 
 @pytest.mark.fail_mxnet

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -29,6 +29,60 @@ def test_pdf_inputs(backend):
     )
 
 
+def test_invalid_pdf_inputs():
+    with open('validation/data/1bin_example1.json') as read_json:
+        source = json.load(read_json)
+    spec = {
+        "channels": [
+            {
+                "name": "channel1",
+                "samples": [
+                    {
+                        "data": [20.0, 10.0],
+                        "modifiers": [
+                            {"data": None, "name": "mu", "type": "normfactor"}
+                        ],
+                        "name": "signal",
+                    },
+                    {
+                        "data": [100.0, 0.0],
+                        "modifiers": [{"data": None, "name": "lumi", "type": "lumi"}],
+                        "name": "background1",
+                    },
+                    {
+                        "data": [0.0, 100.0],
+                        "modifiers": [{"data": None, "name": "lumi", "type": "lumi"}],
+                        "name": "background2",
+                    },
+                ],
+            }
+        ],
+        "parameters": [
+            {
+                "auxdata": [1.0],
+                "bounds": [[0.0, 10.0]],
+                "inits": [1.0],
+                "name": "lumi",
+                "sigmas": [0.1],
+            }
+        ],
+    }
+
+    pdf = pyhf.Model(spec)
+    pars = pdf.config.suggested_init()
+
+    if 'channels' in source:
+        data = []
+        for c in pdf.config.channels:
+            data += source['channels'][c]['bindata']['data']
+        data = data + pdf.config.auxdata
+    else:
+        data = source['bindata']['data'] + pdf.config.auxdata
+
+    with pytest.raises(ValueError):
+        pdf.logpdf(pars, data)
+
+
 @pytest.mark.fail_mxnet
 def test_pdf_basicapi_tests(backend):
     source = {

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -79,8 +79,9 @@ def test_invalid_pdf_inputs():
     else:
         data = source['bindata']['data'] + pdf.config.auxdata
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as excinfo:
         pdf.logpdf(pars, data)
+    assert "eval failed as data has len" in str(excinfo.value)
 
 
 @pytest.mark.fail_mxnet

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -84,19 +84,19 @@ def spec_1bin_lumi(source=source_1bin_example1()):
                 "name": "channel1",
                 "samples": [
                     {
-                        "data": [20.0, 10.0],
+                        "data": [20.0],
                         "modifiers": [
                             {"data": None, "name": "mu", "type": "normfactor"}
                         ],
                         "name": "signal",
                     },
                     {
-                        "data": [100.0, 0.0],
+                        "data": [100.0],
                         "modifiers": [{"data": None, "name": "lumi", "type": "lumi"}],
                         "name": "background1",
                     },
                     {
-                        "data": [0.0, 100.0],
+                        "data": [0.0],
                         "modifiers": [{"data": None, "name": "lumi", "type": "lumi"}],
                         "name": "background2",
                     },
@@ -120,8 +120,8 @@ def spec_1bin_lumi(source=source_1bin_example1()):
 def expected_result_1bin_lumi(mu=1.0):
     if mu == 1:
         expected_result = {
-            "exp": [0.00905976, 0.0357287, 0.12548957, 0.35338293, 0.69589171],
-            "obs": 0.00941757,
+            "exp": [0.01060338, 0.04022273, 0.13614217, 0.37078321, 0.71104119],
+            "obs": 0.01047275,
         }
     return expected_result
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -77,7 +77,7 @@ def setup_1bin_shapesys(
 
 
 @pytest.fixture(scope='module')
-def spec_1bin_lumi(source=source_1bin_example1()):
+def spec_1bin_lumi():
     spec = {
         "channels": [
             {
@@ -129,7 +129,7 @@ def expected_result_1bin_lumi(mu=1.0):
 @pytest.fixture(scope='module')
 def setup_1bin_lumi(
     source=source_1bin_example1(),
-    spec=spec_1bin_lumi(source_1bin_example1()),
+    spec=spec_1bin_lumi(),
     mu=1,
     expected_result=expected_result_1bin_lumi(1.0),
     config={'init_pars': 2, 'par_bounds': 2},


### PR DESCRIPTION
# Description

Resolves #554 

As `expected_result_1bin_lumi` is a 1 bin test it should not have 2 bins, which it erroneously had added in PR #352 .

This was caught by @lukasheinrich in PR #553, and is getting pulled out here.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* fix: Use 1 bin (instead of 2 bins) in the spec used in 'expected_result_1bin_lumi' to match the naming of the test
   - This revises an error in PR #352
* feat: Verify parameter and data shapes during call to pdf.logpdf
* feat: Add exception classes for invalid pdf inputs
* test: Add tests for the input shape of the pdf parameters and data
```
