### PR TITLE
fix: Unhide test_normal by renaming redundant name to test_independent

### DIFF
--- a/tests/test_probability.py
+++ b/tests/test_probability.py
@@ -39,7 +39,7 @@ def test_joint(backend):
     )
 
 
-def test_normal(backend):
+def test_independent(backend):
     tensorlib, _ = backend
     result = probability.Independent(probability.Poisson([10.0, 10])).log_prob(
         [2.0, 3.0]


### PR DESCRIPTION
# Description

Resolves #568 

`test_normal` in `tests/test_probability` is hidden from pytest by an accidental renaming of `test_normal` which is actually testing the `Independent` class. As such, rename the second test to run both.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* fix: Rename the test_probability test that tests the Independent pdf class to test_independent to unhide test_normal from pytest
```
