### PR TITLE
fix: Avoid benchmark timeout in CI systems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,7 @@ jobs:
       run: |
         python -m pytest -r sx --ignore tests/benchmarks/
     - name: Run benchmarks
-      # if: github.event_name == 'schedule' && matrix.python-version == 3.7
-      if: matrix.python-version == 3.7
+      if: github.event_name == 'schedule' && matrix.python-version == 3.7
       # FIXME: numpy_minuit-200_bins excluded due to speed regression from PR #553
       run: |
         python -m pytest -r sx --benchmark-sort=mean tests/benchmarks/test_benchmark.py -k 'not numpy_minuit-200_bins'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         python -m pytest -r sx --ignore tests/benchmarks/
     - name: Run benchmarks
       if: github.event_name == 'schedule' && matrix.python-version == 3.7
-      # FIXME: numpy_minuit-200_bins excluded due to speed regression from PR #553
+      # FIXME: numpy_minuit-200_bins excluded due to speed regression from PR #553. c.f. Issue #572
       run: |
         python -m pytest -r sx --benchmark-sort=mean tests/benchmarks/test_benchmark.py -k 'not numpy_minuit-200_bins'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,8 @@ jobs:
       run: |
         python -m pytest -r sx --ignore tests/benchmarks/
     - name: Run benchmarks
-      if: github.event_name == 'schedule' && matrix.python-version == 3.7
+      # if: github.event_name == 'schedule' && matrix.python-version == 3.7
+      if: matrix.python-version == 3.7
       # FIXME: numpy_minuit-200_bins excluded due to speed regression from PR #553
       run: |
         python -m pytest -r sx --benchmark-sort=mean tests/benchmarks/test_benchmark.py -k 'not numpy_minuit-200_bins'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,9 @@ jobs:
         python -m pytest -r sx --ignore tests/benchmarks/
     - name: Run benchmarks
       if: github.event_name == 'schedule' && matrix.python-version == 3.7
+      # FIXME: numpy_minuit-200_bins excluded due to speed regression from PR #553
       run: |
-        python -m pytest -r sx tests/benchmarks/test_benchmark.py
+        python -m pytest -r sx --benchmark-sort=mean tests/benchmarks/test_benchmark.py -k 'not numpy_minuit-200_bins'
 
   docs:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,7 @@ stages:
   - name: test
     if: NOT (branch =~ /^docs\//)
   - name: benchmark
-    # if: (branch = master) AND (NOT (type IN (pull_request)))
-    if: NOT (branch =~ /^docs\//)
+    if: (branch = master) AND (NOT (type IN (pull_request)))
   - name: docs
     if: (branch = master) OR (branch =~ /^docs\//)
   - name: binder

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ jobs:
     install:
       - pip install --ignore-installed -U -q --no-cache-dir -e .[complete]
       - pip freeze
-    script: python -m pytest -r sx --benchmark-sort=mean tests/benchmarks/
+    script: python -m pytest -r sx --benchmark-sort=mean tests/benchmarks/ -k 'not numpy_minuit-200_bins'
     after_success: skip
   - stage: docs
     python: '3.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,7 @@ jobs:
     install:
       - pip install --ignore-installed -U -q --no-cache-dir -e .[complete]
       - pip freeze
+    # FIXME: numpy_minuit-200_bins excluded due to speed regression from PR #553. c.f. Issue #572
     script: python -m pytest -r sx --benchmark-sort=mean tests/benchmarks/ -k 'not numpy_minuit-200_bins'
     after_success: skip
   - stage: docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ stages:
   - name: test
     if: NOT (branch =~ /^docs\//)
   - name: benchmark
-    if: (branch = master) AND (NOT (type IN (pull_request)))
+    # if: (branch = master) AND (NOT (type IN (pull_request)))
+    if: NOT (branch =~ /^docs\//)
   - name: docs
     if: (branch = master) OR (branch =~ /^docs\//)
   - name: binder

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,6 @@ def reset_backend():
     ],
 )
 def backend(request):
-    param = request.param
     # a better way to get the id? all the backends we have so far for testing
     param_ids = request._fixturedef.ids
     # the backend we're using: numpy, tensorflow, etc...


### PR DESCRIPTION
# Description

A speed regression was introduced in PR #553 that caused the benchmark tests with the Minuit optimizer to take too long for 200 bins and cause the CI systems to timeout and fail. This is avoided here by using the [pytest keyword expression CLI flag of  `-k`](http://doc.pytest.org/en/latest/example/markers.html#using-k-expr-to-select-tests-based-on-their-name) to skip the 200 bin Minuit test.
    
From `man pytest`:
    
```
SPECIFYING TESTS / SELECTING TESTS
       Several test run options:

          ...
          py.test -k stringexpr # only run tests with names that match the
                                # "string expression", e.g. "MyClass and not method"
                                # will select TestMyClass.test_something
                                # but not TestMyClass.test_method_simple
```

Skipping `numpy_minuit-200_bins` saves enough time that the CI systems finish. As tests of this see
- GitHub Actions: [run 227963902](https://github.com/diana-hep/pyhf/runs/227963902)
- Travis CI: [build 586874638](https://travis-ci.org/diana-hep/pyhf/builds/586874638)

where the benchmarks were run and passed.

# Checklist Before Requesting Reviewer

- [ ] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* fix: Use the pytest keyword expression CLI flag -k to skip running the the 200 bin Minuit benchmark test to avoid time out errors in the CI systems due to speed regression introduced in PR #553
   - c.f. 'man pytest' and http://doc.pytest.org/en/latest/example/markers.html#using-k-expr-to-select-tests-based-on-their-name for more information on the keyword expression CLI flag
```
