### PR TITLE
docs: Use LGTM code quality badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 [![Travis Build Status](https://travis-ci.org/diana-hep/pyhf.svg?branch=master)](https://travis-ci.org/diana-hep/pyhf)
 [![GitHub Actions Status](https://github.com/diana-hep/pyhf/workflows/CI/CD/badge.svg)](https://github.com/diana-hep/pyhf/actions)
 [![Docker Automated](https://img.shields.io/docker/automated/pyhf/pyhf.svg)](https://hub.docker.com/r/pyhf/pyhf/)
-[![Coverage Status](https://coveralls.io/repos/github/diana-hep/pyhf/badge.svg?branch=master)](https://coveralls.io/github/diana-hep/pyhf?branch=master) [![Code Health](https://landscape.io/github/diana-hep/pyhf/master/landscape.svg?style=flat)](https://landscape.io/github/diana-hep/pyhf/master)
+[![Coverage Status](https://coveralls.io/repos/github/diana-hep/pyhf/badge.svg?branch=master)](https://coveralls.io/github/diana-hep/pyhf?branch=master)
+[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/diana-hep/pyhf.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/diana-hep/pyhf/latest/files/)
 [![CodeFactor](https://www.codefactor.io/repository/github/diana-hep/pyhf/badge)](https://www.codefactor.io/repository/github/diana-hep/pyhf)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 


### PR DESCRIPTION
# Description

Given that [Semmle was acquired by GitHub](https://blog.semmle.com/secure-software-github-semmle/) and so LGTM is now going to become part of the GitHub toolchain in the coming months I've added LGTM to the code checks now. As it seems that Landscape's Code Health is no longer reliable then I think it makes sense to replace it with LGTM's Code Quality badge instead.

[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/diana-hep/pyhf.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/diana-hep/pyhf/latest/files/)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* docs: Drop landscape.io code health in favor of LGTM code quality summary badge
```
