### PR TITLE
revert: Remove skip of NumPy+Minuit 200 bin benchmark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,8 @@ jobs:
         python -m pytest -r sx --ignore tests/benchmarks/
     - name: Run benchmarks
       if: github.event_name == 'schedule' && matrix.python-version == 3.7
-      # FIXME: numpy_minuit-200_bins excluded due to speed regression from PR #553. c.f. Issue #572
       run: |
-        python -m pytest -r sx --benchmark-sort=mean tests/benchmarks/test_benchmark.py -k 'not numpy_minuit-200_bins'
+        python -m pytest -r sx --benchmark-sort=mean tests/benchmarks/test_benchmark.py
 
   docs:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,8 +64,7 @@ jobs:
     install:
       - pip install --ignore-installed -U -q --no-cache-dir -e .[complete]
       - pip freeze
-    # FIXME: numpy_minuit-200_bins excluded due to speed regression from PR #553. c.f. Issue #572
-    script: python -m pytest -r sx --benchmark-sort=mean tests/benchmarks/ -k 'not numpy_minuit-200_bins'
+    script: python -m pytest -r sx --benchmark-sort=mean tests/benchmarks/
     after_success: skip
   - stage: docs
     python: '3.7'


### PR DESCRIPTION
# Description

Effectively revert PR #571 by removing the skip of NumPy+Minuit 200 bin benchmark.

This is contingent on PR #576 being merged into `master`.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* revert: Remove the skip of the NumPy+Minuit 200 bin benchmark test that was added in PR #571 to avoid CI failure due to a performance regression
```
