### PR TITLE
perf: Effectively remove the use of self.astensor() in tensor backend calls

### DIFF
--- a/src/pyhf/interpolators/code0.py
+++ b/src/pyhf/interpolators/code0.py
@@ -57,7 +57,7 @@ class code0(object):
         tensorlib, _ = get_backend()
         self._precompute_alphasets(tensorlib.shape(alphasets))
         where_alphasets_positive = tensorlib.where(
-            tensorlib.astensor(alphasets > 0), self.mask_on, self.mask_off
+            alphasets > 0, self.mask_on, self.mask_off
         )
 
         # s: set under consideration (i.e. the modifier)

--- a/src/pyhf/interpolators/code0.py
+++ b/src/pyhf/interpolators/code0.py
@@ -57,7 +57,7 @@ class code0(object):
         tensorlib, _ = get_backend()
         self._precompute_alphasets(tensorlib.shape(alphasets))
         where_alphasets_positive = tensorlib.where(
-            alphasets > 0, self.mask_on, self.mask_off
+            tensorlib.astensor(alphasets > 0), self.mask_on, self.mask_off
         )
 
         # s: set under consideration (i.e. the modifier)

--- a/src/pyhf/interpolators/code0.py
+++ b/src/pyhf/interpolators/code0.py
@@ -71,8 +71,11 @@ class code0(object):
             'sa,shb->shab', alphasets, self.deltas_dn
         )
 
-        masks = tensorlib.einsum(
-            'sa,shb->shab', where_alphasets_positive, self.broadcast_helper
+        masks = tensorlib.astensor(
+            tensorlib.einsum(
+                'sa,shb->shab', where_alphasets_positive, self.broadcast_helper
+            ),
+            dtype="bool",
         )
 
         return tensorlib.where(masks, alphas_times_deltas_up, alphas_times_deltas_dn)

--- a/src/pyhf/interpolators/code1.py
+++ b/src/pyhf/interpolators/code1.py
@@ -76,7 +76,7 @@ class code1(object):
         tensorlib, _ = get_backend()
         self._precompute_alphasets(tensorlib.shape(alphasets))
         where_alphasets_positive = tensorlib.where(
-            tensorlib.astensor(alphasets > 0), self.mask_on, self.mask_off
+            alphasets > 0, self.mask_on, self.mask_off
         )
 
         # s: set under consideration (i.e. the modifier)

--- a/src/pyhf/interpolators/code1.py
+++ b/src/pyhf/interpolators/code1.py
@@ -86,8 +86,11 @@ class code1(object):
         exponents = tensorlib.einsum(
             'sa,shb->shab', tensorlib.abs(alphasets), self.broadcast_helper
         )
-        masks = tensorlib.einsum(
-            'sa,shb->shab', where_alphasets_positive, self.broadcast_helper
+        masks = tensorlib.astensor(
+            tensorlib.einsum(
+                'sa,shb->shab', where_alphasets_positive, self.broadcast_helper
+            ),
+            dtype="bool",
         )
 
         bases = tensorlib.where(masks, self.bases_up, self.bases_dn)

--- a/src/pyhf/interpolators/code1.py
+++ b/src/pyhf/interpolators/code1.py
@@ -76,7 +76,7 @@ class code1(object):
         tensorlib, _ = get_backend()
         self._precompute_alphasets(tensorlib.shape(alphasets))
         where_alphasets_positive = tensorlib.where(
-            alphasets > 0, self.mask_on, self.mask_off
+            tensorlib.astensor(alphasets > 0), self.mask_on, self.mask_off
         )
 
         # s: set under consideration (i.e. the modifier)

--- a/src/pyhf/interpolators/code2.py
+++ b/src/pyhf/interpolators/code2.py
@@ -91,11 +91,17 @@ class code2(object):
             'sa,shb->shab', alphasets + self.mask_off, self.b_minus_2a
         )
 
-        masks_gt1 = tensorlib.einsum(
-            'sa,shb->shab', where_alphasets_gt1, self.broadcast_helper
+        masks_gt1 = tensorlib.astensor(
+            tensorlib.einsum(
+                'sa,shb->shab', where_alphasets_gt1, self.broadcast_helper
+            ),
+            dtype="bool",
         )
-        masks_not_lt1 = tensorlib.einsum(
-            'sa,shb->shab', where_alphasets_not_lt1, self.broadcast_helper
+        masks_not_lt1 = tensorlib.astensor(
+            tensorlib.einsum(
+                'sa,shb->shab', where_alphasets_not_lt1, self.broadcast_helper
+            ),
+            dtype="bool",
         )
 
         # first, build a result where:

--- a/src/pyhf/interpolators/code2.py
+++ b/src/pyhf/interpolators/code2.py
@@ -69,12 +69,12 @@ class code2(object):
 
         # select where alpha > 1
         where_alphasets_gt1 = tensorlib.where(
-            tensorlib.astensor(alphasets > 1), self.mask_on, self.mask_off
+            alphasets > 1, self.mask_on, self.mask_off
         )
 
         # select where alpha >= -1
         where_alphasets_not_lt1 = tensorlib.where(
-            tensorlib.astensor(alphasets >= -1), self.mask_on, self.mask_off
+            alphasets >= -1, self.mask_on, self.mask_off
         )
 
         # s: set under consideration (i.e. the modifier)

--- a/src/pyhf/interpolators/code2.py
+++ b/src/pyhf/interpolators/code2.py
@@ -69,12 +69,12 @@ class code2(object):
 
         # select where alpha > 1
         where_alphasets_gt1 = tensorlib.where(
-            alphasets > 1, self.mask_on, self.mask_off
+            tensorlib.astensor(alphasets > 1), self.mask_on, self.mask_off
         )
 
         # select where alpha >= -1
         where_alphasets_not_lt1 = tensorlib.where(
-            alphasets >= -1, self.mask_on, self.mask_off
+            tensorlib.astensor(alphasets >= -1), self.mask_on, self.mask_off
         )
 
         # s: set under consideration (i.e. the modifier)

--- a/src/pyhf/interpolators/code4.py
+++ b/src/pyhf/interpolators/code4.py
@@ -168,7 +168,7 @@ class code4(object):
 
         # select where alpha >= alpha0 and produce the mask
         where_alphasets_gtalpha0 = tensorlib.where(
-            alphasets >= self.__alpha0, self.mask_on, self.mask_off
+            tensorlib.astensor(alphasets >= self.__alpha0), self.mask_on, self.mask_off
         )
         masks_gtalpha0 = tensorlib.einsum(
             'sa,shb->shab', where_alphasets_gtalpha0, self.broadcast_helper
@@ -176,7 +176,7 @@ class code4(object):
 
         # select where alpha > -alpha0 ["not(alpha <= -alpha0)"] and produce the mask
         where_alphasets_not_ltalpha0 = tensorlib.where(
-            alphasets > -self.__alpha0, self.mask_on, self.mask_off
+            tensorlib.astensor(alphasets > -self.__alpha0), self.mask_on, self.mask_off
         )
         masks_not_ltalpha0 = tensorlib.einsum(
             'sa,shb->shab', where_alphasets_not_ltalpha0, self.broadcast_helper
@@ -192,7 +192,7 @@ class code4(object):
         # for |alpha| >= alpha0, we want to raise the bases to the exponent=alpha
         # and for |alpha| < alpha0, we want to raise the bases to the exponent=1
         masked_exponents = tensorlib.where(
-            exponents >= self.__alpha0, exponents, self.ones
+            tensorlib.astensor(exponents >= self.__alpha0), exponents, self.ones
         )
         # we need to produce the terms of alpha^i for summing up
         alphasets_powers = tensorlib.stack(

--- a/src/pyhf/interpolators/code4.py
+++ b/src/pyhf/interpolators/code4.py
@@ -170,16 +170,22 @@ class code4(object):
         where_alphasets_gtalpha0 = tensorlib.where(
             alphasets >= self.__alpha0, self.mask_on, self.mask_off
         )
-        masks_gtalpha0 = tensorlib.einsum(
-            'sa,shb->shab', where_alphasets_gtalpha0, self.broadcast_helper
+        masks_gtalpha0 = tensorlib.astensor(
+            tensorlib.einsum(
+                'sa,shb->shab', where_alphasets_gtalpha0, self.broadcast_helper
+            ),
+            dtype="bool",
         )
 
         # select where alpha > -alpha0 ["not(alpha <= -alpha0)"] and produce the mask
         where_alphasets_not_ltalpha0 = tensorlib.where(
             alphasets > -self.__alpha0, self.mask_on, self.mask_off
         )
-        masks_not_ltalpha0 = tensorlib.einsum(
-            'sa,shb->shab', where_alphasets_not_ltalpha0, self.broadcast_helper
+        masks_not_ltalpha0 = tensorlib.astensor(
+            tensorlib.einsum(
+                'sa,shb->shab', where_alphasets_not_ltalpha0, self.broadcast_helper
+            ),
+            dtype="bool",
         )
 
         # s: set under consideration (i.e. the modifier)

--- a/src/pyhf/interpolators/code4.py
+++ b/src/pyhf/interpolators/code4.py
@@ -168,7 +168,7 @@ class code4(object):
 
         # select where alpha >= alpha0 and produce the mask
         where_alphasets_gtalpha0 = tensorlib.where(
-            tensorlib.astensor(alphasets >= self.__alpha0), self.mask_on, self.mask_off
+            alphasets >= self.__alpha0, self.mask_on, self.mask_off
         )
         masks_gtalpha0 = tensorlib.einsum(
             'sa,shb->shab', where_alphasets_gtalpha0, self.broadcast_helper
@@ -176,7 +176,7 @@ class code4(object):
 
         # select where alpha > -alpha0 ["not(alpha <= -alpha0)"] and produce the mask
         where_alphasets_not_ltalpha0 = tensorlib.where(
-            tensorlib.astensor(alphasets > -self.__alpha0), self.mask_on, self.mask_off
+            alphasets > -self.__alpha0, self.mask_on, self.mask_off
         )
         masks_not_ltalpha0 = tensorlib.einsum(
             'sa,shb->shab', where_alphasets_not_ltalpha0, self.broadcast_helper
@@ -192,7 +192,7 @@ class code4(object):
         # for |alpha| >= alpha0, we want to raise the bases to the exponent=alpha
         # and for |alpha| < alpha0, we want to raise the bases to the exponent=1
         masked_exponents = tensorlib.where(
-            tensorlib.astensor(exponents >= self.__alpha0), exponents, self.ones
+            exponents >= self.__alpha0, exponents, self.ones
         )
         # we need to produce the terms of alpha^i for summing up
         alphasets_powers = tensorlib.stack(

--- a/src/pyhf/modifiers/histosys.py
+++ b/src/pyhf/modifiers/histosys.py
@@ -71,7 +71,7 @@ class histosys_combined(object):
         if not self.param_viewer.index_selection:
             return
         tensorlib, _ = get_backend()
-        self.histosys_mask = tensorlib.astensor(self._histosys_mask)
+        self.histosys_mask = tensorlib.astensor(self._histosys_mask, dtype="bool")
         self.histosys_default = tensorlib.zeros(self.histosys_mask.shape)
         if self.batch_size is None:
             self.indices = tensorlib.reshape(

--- a/src/pyhf/modifiers/lumi.py
+++ b/src/pyhf/modifiers/lumi.py
@@ -69,4 +69,8 @@ class lumi_combined(object):
         else:
             results_lumi = tensorlib.einsum('msab,xa->msab', self.lumi_mask, lumis)
 
-        return tensorlib.where(self.lumi_mask, results_lumi, self.lumi_default)
+        return tensorlib.where(
+            tensorlib.astensor(self.lumi_mask, dtype="bool"),
+            results_lumi,
+            self.lumi_default,
+        )

--- a/src/pyhf/modifiers/lumi.py
+++ b/src/pyhf/modifiers/lumi.py
@@ -52,6 +52,7 @@ class lumi_combined(object):
         self.lumi_mask = tensorlib.tile(
             tensorlib.astensor(self._lumi_mask), (1, 1, self.batch_size or 1, 1)
         )
+        self.lumi_mask_bool = tensorlib.astensor(self.lumi_mask, dtype="bool")
         self.lumi_default = tensorlib.ones(self.lumi_mask.shape)
 
     def apply(self, pars):
@@ -69,8 +70,4 @@ class lumi_combined(object):
         else:
             results_lumi = tensorlib.einsum('msab,xa->msab', self.lumi_mask, lumis)
 
-        return tensorlib.where(
-            tensorlib.astensor(self.lumi_mask, dtype="bool"),
-            results_lumi,
-            self.lumi_default,
-        )
+        return tensorlib.where(self.lumi_mask_bool, results_lumi, self.lumi_default)

--- a/src/pyhf/modifiers/normfactor.py
+++ b/src/pyhf/modifiers/normfactor.py
@@ -51,6 +51,9 @@ class normfactor_combined(object):
         self.normfactor_mask = tensorlib.tile(
             tensorlib.astensor(self._normfactor_mask), (1, 1, self.batch_size or 1, 1)
         )
+        self.normfactor_mask_bool = tensorlib.astensor(
+            self.normfactor_mask, dtype="bool"
+        )
         self.normfactor_default = tensorlib.ones(self.normfactor_mask.shape)
 
     def apply(self, pars):
@@ -73,8 +76,6 @@ class normfactor_combined(object):
             )
 
         results_normfactor = tensorlib.where(
-            tensorlib.astensor(self.normfactor_mask, dtype="bool"),
-            results_normfactor,
-            self.normfactor_default,
+            self.normfactor_mask_bool, results_normfactor, self.normfactor_default
         )
         return results_normfactor

--- a/src/pyhf/modifiers/normfactor.py
+++ b/src/pyhf/modifiers/normfactor.py
@@ -48,9 +48,8 @@ class normfactor_combined(object):
         tensorlib, _ = get_backend()
         if not self.param_viewer.index_selection:
             return
-        self.normfactor_mask = tensorlib.astensor(self._normfactor_mask)
         self.normfactor_mask = tensorlib.tile(
-            self.normfactor_mask, (1, 1, self.batch_size or 1, 1)
+            tensorlib.astensor(self._normfactor_mask), (1, 1, self.batch_size or 1, 1)
         )
         self.normfactor_default = tensorlib.ones(self.normfactor_mask.shape)
 
@@ -74,6 +73,8 @@ class normfactor_combined(object):
             )
 
         results_normfactor = tensorlib.where(
-            self.normfactor_mask, results_normfactor, self.normfactor_default
+            tensorlib.astensor(self.normfactor_mask, dtype="bool"),
+            results_normfactor,
+            self.normfactor_default,
         )
         return results_normfactor

--- a/src/pyhf/modifiers/normsys.py
+++ b/src/pyhf/modifiers/normsys.py
@@ -69,9 +69,9 @@ class normsys_combined(object):
         if not self.param_viewer.index_selection:
             return
         tensorlib, _ = get_backend()
-        self.normsys_mask = tensorlib.astensor(self._normsys_mask)
         self.normsys_mask = tensorlib.tile(
-            self.normsys_mask, (1, 1, self.batch_size or 1, 1)
+            tensorlib.astensor(self._normsys_mask, dtype="bool"),
+            (1, 1, self.batch_size or 1, 1),
         )
         self.normsys_default = tensorlib.ones(self.normsys_mask.shape)
         if self.batch_size is None:

--- a/src/pyhf/modifiers/shapefactor.py
+++ b/src/pyhf/modifiers/shapefactor.py
@@ -118,9 +118,9 @@ class shapefactor_combined(object):
         if not self.param_viewer.index_selection:
             return
         tensorlib, _ = get_backend()
-        self.shapefactor_mask = tensorlib.astensor(self._shapefactor_mask, dtype="bool")
         self.shapefactor_mask = tensorlib.tile(
-            self.shapefactor_mask, (1, 1, self.batch_size or 1, 1)
+            tensorlib.astensor(self._shapefactor_mask, dtype="bool"),
+            (1, 1, self.batch_size or 1, 1),
         )
         self.access_field = tensorlib.astensor(self._access_field, dtype='int')
 

--- a/src/pyhf/modifiers/shapefactor.py
+++ b/src/pyhf/modifiers/shapefactor.py
@@ -118,7 +118,7 @@ class shapefactor_combined(object):
         if not self.param_viewer.index_selection:
             return
         tensorlib, _ = get_backend()
-        self.shapefactor_mask = tensorlib.astensor(self._shapefactor_mask)
+        self.shapefactor_mask = tensorlib.astensor(self._shapefactor_mask, dtype="bool")
         self.shapefactor_mask = tensorlib.tile(
             self.shapefactor_mask, (1, 1, self.batch_size or 1, 1)
         )

--- a/src/pyhf/modifiers/shapesys.py
+++ b/src/pyhf/modifiers/shapesys.py
@@ -81,7 +81,7 @@ class shapesys_combined(object):
         tensorlib, _ = get_backend()
         if not self.param_viewer.index_selection:
             return
-        self.shapesys_mask = tensorlib.astensor(self._shapesys_mask)
+        self.shapesys_mask = tensorlib.astensor(self._shapesys_mask, dtype="bool")
         self.shapesys_mask = tensorlib.tile(
             self.shapesys_mask, (1, 1, self.batch_size or 1, 1)
         )

--- a/src/pyhf/modifiers/staterror.py
+++ b/src/pyhf/modifiers/staterror.py
@@ -76,7 +76,7 @@ class staterror_combined(object):
         if not self.param_viewer.index_selection:
             return
         tensorlib, _ = get_backend()
-        self.staterror_mask = tensorlib.astensor(self._staterror_mask)
+        self.staterror_mask = tensorlib.astensor(self._staterror_mask, dtype="bool")
         self.staterror_mask = tensorlib.tile(
             self.staterror_mask, (1, 1, self.batch_size or 1, 1)
         )

--- a/src/pyhf/tensor/common.py
+++ b/src/pyhf/tensor/common.py
@@ -17,10 +17,10 @@ class _TensorViewer(object):
         self.batch_size = batch_size
 
         self.partition_indices = indices
-        a = default_backend.astensor(
+        _concat_indices = default_backend.astensor(
             default_backend.concatenate(self.partition_indices), dtype='int'
         )
-        self._sorted_indices = default_backend.tolist(a.argsort())
+        self._sorted_indices = default_backend.tolist(_concat_indices.argsort())
 
         self._precompute()
         events.subscribe('tensorlib_changed')(self._precompute)

--- a/src/pyhf/tensor/common.py
+++ b/src/pyhf/tensor/common.py
@@ -45,9 +45,15 @@ class _TensorViewer(object):
     def split(self, data):
         tensorlib, _ = get_backend()
         if len(tensorlib.shape(data)) == 1:
-            return [tensorlib.gather(data, idx) for idx in self.partition_indices]
+            return [
+                tensorlib.gather(data, tensorlib.astensor(idx, dtype='int'))
+                for idx in self.partition_indices
+            ]
         data = tensorlib.einsum('...j->j...', tensorlib.astensor(data))
         return [
-            tensorlib.einsum('j...->...j', tensorlib.gather(data, idx))
+            tensorlib.einsum(
+                'j...->...j',
+                tensorlib.gather(data, tensorlib.astensor(idx, dtype='int')),
+            )
             for idx in self.partition_indices
         ]

--- a/src/pyhf/tensor/mxnet_backend.py
+++ b/src/pyhf/tensor/mxnet_backend.py
@@ -36,7 +36,6 @@ class mxnet_backend(object):
         Returns:
             MXNet NDArray: A clipped `tensor`
         """
-        tensor_in = self.astensor(tensor_in)
         return nd.clip(tensor_in, min_value, max_value)
 
     def tile(self, tensor_in, repeats):
@@ -91,9 +90,6 @@ class mxnet_backend(object):
         Returns:
             MXNet NDArray: The outer product.
         """
-        tensor_in_1 = self.astensor(tensor_in_1)
-        tensor_in_2 = self.astensor(tensor_in_2)
-
         tensor_1_shape = tensor_in_1.shape
         tensor_2_shape = tensor_in_2.shape
         if len(tensor_1_shape) == 1:
@@ -156,7 +152,6 @@ class mxnet_backend(object):
         Returns:
             MXNet NDArray: ndarray of the sum over the axes.
         """
-        tensor_in = self.astensor(tensor_in)
         if axis is None or tensor_in.shape == nd.array([]).size:
             return nd.sum(tensor_in)
         return nd.sum(tensor_in, axis)
@@ -172,13 +167,11 @@ class mxnet_backend(object):
         Returns:
             MXNet NDArray: ndarray of the product over the axes.
         """
-        tensor_in = self.astensor(tensor_in)
         if axis is None:
             return nd.prod(tensor_in)
         return nd.prod(tensor_in, axis)
 
     def abs(self, tensor):
-        tensor = self.astensor(tensor)
         return nd.abs(tensor)
 
     def ones(self, shape):
@@ -217,8 +210,6 @@ class mxnet_backend(object):
         Returns:
             MXNet NDArray: First array elements raised to powers from second array.
         """
-        tensor_in_1 = self.astensor(tensor_in_1)
-        tensor_in_2 = self.astensor(tensor_in_2)
         return nd.power(tensor_in_1, tensor_in_2)
 
     def sqrt(self, tensor_in):
@@ -231,7 +222,6 @@ class mxnet_backend(object):
         Returns:
             MXNet NDArray: Element-wise square-root value.
         """
-        tensor_in = self.astensor(tensor_in)
         return nd.sqrt(tensor_in)
 
     def divide(self, tensor_in_1, tensor_in_2):
@@ -245,8 +235,6 @@ class mxnet_backend(object):
         Returns:
             MXNet NDArray: Element-wise division of the input arrays.
         """
-        tensor_in_1 = self.astensor(tensor_in_1)
-        tensor_in_2 = self.astensor(tensor_in_2)
         return nd.divide(tensor_in_1, tensor_in_2)
 
     def log(self, tensor_in):
@@ -259,7 +247,6 @@ class mxnet_backend(object):
         Returns:
             MXNet NDArray: Element-wise Natural logarithmic value.
         """
-        tensor_in = self.astensor(tensor_in)
         return nd.log(tensor_in)
 
     def exp(self, tensor_in):
@@ -272,7 +259,6 @@ class mxnet_backend(object):
         Returns:
             MXNet NDArray: Element-wise exponential value.
         """
-        tensor_in = self.astensor(tensor_in)
         return nd.exp(tensor_in)
 
     def stack(self, sequence, axis=0):
@@ -317,9 +303,6 @@ class mxnet_backend(object):
         Returns:
             MXNet NDArray: The result of the mask being applied to the tensors.
         """
-        mask = self.astensor(mask)
-        tensor_in_1 = self.astensor(tensor_in_1)
-        tensor_in_2 = self.astensor(tensor_in_2)
         return nd.add(
             nd.multiply(mask, tensor_in_1),
             nd.multiply(nd.subtract(1, mask), tensor_in_2),
@@ -362,7 +345,6 @@ class mxnet_backend(object):
         Returns:
             MXNet NDArray: The sequence broadcast together.
         """
-        args = [self.astensor(arg) for arg in args]
         max_dim = max(map(len, args))
         try:
             assert not [arg for arg in args if 1 < len(arg) < max_dim]
@@ -405,8 +387,6 @@ class mxnet_backend(object):
         raise NotImplementedError("mxnet::einsum is not implemented.")
 
     def poisson_logpdf(self, n, lam):
-        n = self.astensor(n)
-        lam = self.astensor(lam)
         return n * nd.log(lam) - lam - nd.gammaln(n + 1.0)
 
     def poisson(self, n, lam):
@@ -433,9 +413,6 @@ class mxnet_backend(object):
         Returns:
             MXNet NDArray: Value of the continous approximation to Poisson(n|lam)
         """
-        n = self.astensor(n)
-        lam = self.astensor(lam)
-
         # This is currently copied directly from PyTorch's source until a better
         # way can be found to do this in MXNet
         # https://github.com/pytorch/pytorch/blob/39520ffec15ab7e97691fed048de1832e83785e8/torch/distributions/poisson.py#L59-L63
@@ -476,10 +453,6 @@ class mxnet_backend(object):
         Returns:
             MXNet NDArray: Value of Normal(x|mu, sigma).
         """
-        x = self.astensor(x)
-        mu = self.astensor(mu)
-        sigma = self.astensor(sigma)
-
         # This is currently copied directly from PyTorch's source until a better
         # way can be found to do this in MXNet
         # https://github.com/pytorch/pytorch/blob/39520ffec15ab7e97691fed048de1832e83785e8/torch/distributions/normal.py#L70-L76
@@ -509,7 +482,4 @@ class mxnet_backend(object):
         log.warning(
             'normal_cdf currently uses SciPy stats until pure MXNet distribuiton support is available.'
         )
-        x = self.astensor(x).asnumpy()
-        mu = self.astensor(mu).asnumpy()
-        sigma = self.astensor(sigma).asnumpy()
         return self.astensor(norm.cdf(x, loc=mu, scale=sigma))

--- a/src/pyhf/tensor/mxnet_backend.py
+++ b/src/pyhf/tensor/mxnet_backend.py
@@ -399,10 +399,13 @@ class mxnet_backend(object):
 
             >>> import pyhf
             >>> pyhf.set_backend(pyhf.tensor.mxnet_backend())
-            >>> pyhf.tensorlib.poisson(5., 6.)
+            >>> values = pyhf.tensorlib.astensor([5., 9.])
+            >>> rates = pyhf.tensorlib.astensor([6., 8.])
+            >>> pyhf.tensorlib.poisson(values, rates)
             <BLANKLINE>
-            [0.16062315]
-            <NDArray 1 @cpu(0)>
+            [0.16062315 0.12407687]
+            <NDArray 2 @cpu(0)>
+
 
         Args:
             n (Number or Tensor): The value at which to evaluate the approximation to the Poisson distribution p.m.f.
@@ -440,10 +443,13 @@ class mxnet_backend(object):
 
             >>> import pyhf
             >>> pyhf.set_backend(pyhf.tensor.mxnet_backend())
-            >>> pyhf.tensorlib.normal(0.5, 0., 1.)
+            >>> values = pyhf.tensorlib.astensor([0.5, 2.0])
+            >>> means = pyhf.tensorlib.astensor([0., 2.3])
+            >>> sigmas = pyhf.tensorlib.astensor([1., 0.8])
+            >>> pyhf.tensorlib.normal(values, means, sigmas)
             <BLANKLINE>
-            [0.35206532]
-            <NDArray 1 @cpu(0)>
+            [0.35206532 0.4648189 ]
+            <NDArray 2 @cpu(0)>
 
         Args:
             x (Number or Tensor): The value at which to evaluate the Normal distribution p.d.f.
@@ -470,6 +476,12 @@ class mxnet_backend(object):
             <BLANKLINE>
             [0.7881446]
             <NDArray 1 @cpu(0)>
+            >>> values = pyhf.tensorlib.astensor([0.8, 2.0])
+            >>> pyhf.tensorlib.normal_cdf(values)
+            <BLANKLINE>
+            [0.7881446  0.97724986]
+            <NDArray 2 @cpu(0)>
+
 
         Args:
             x (`tensor` or `float`): The observed value of the random variable to evaluate the CDF for
@@ -482,4 +494,7 @@ class mxnet_backend(object):
         log.warning(
             'normal_cdf currently uses SciPy stats until pure MXNet distribuiton support is available.'
         )
+        x = self.astensor(x).asnumpy()
+        mu = self.astensor(mu).asnumpy()
+        sigma = self.astensor(sigma).asnumpy()
         return self.astensor(norm.cdf(x, loc=mu, scale=sigma))

--- a/src/pyhf/tensor/mxnet_backend.py
+++ b/src/pyhf/tensor/mxnet_backend.py
@@ -303,10 +303,7 @@ class mxnet_backend(object):
         Returns:
             MXNet NDArray: The result of the mask being applied to the tensors.
         """
-        return nd.add(
-            nd.multiply(mask, tensor_in_1),
-            nd.multiply(nd.subtract(1, mask), tensor_in_2),
-        )
+        return nd.where(mask, tensor_in_1, tensor_in_2)
 
     def concatenate(self, sequence, axis=0):
         """

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -91,8 +91,6 @@ class numpy_backend(object):
             raise
 
     def outer(self, tensor_in_1, tensor_in_2):
-        tensor_in_1 = self.astensor(tensor_in_1)
-        tensor_in_2 = self.astensor(tensor_in_2)
         return np.outer(tensor_in_1, tensor_in_2)
 
     def gather(self, tensor, indices):

--- a/src/pyhf/tensor/numpy_backend.py
+++ b/src/pyhf/tensor/numpy_backend.py
@@ -239,6 +239,10 @@ class numpy_backend(object):
             >>> pyhf.set_backend(pyhf.tensor.numpy_backend())
             >>> pyhf.tensorlib.poisson(5., 6.)
             0.16062314104797995
+            >>> values = pyhf.tensorlib.astensor([5., 9.])
+            >>> rates = pyhf.tensorlib.astensor([6., 8.])
+            >>> pyhf.tensorlib.poisson(values, rates)
+            array([0.16062314, 0.12407692])
 
         Args:
             n (`tensor` or `float`): The value at which to evaluate the approximation to the Poisson distribution p.m.f.
@@ -278,6 +282,11 @@ class numpy_backend(object):
             >>> pyhf.set_backend(pyhf.tensor.numpy_backend())
             >>> pyhf.tensorlib.normal(0.5, 0., 1.)
             0.3520653267642995
+            >>> values = pyhf.tensorlib.astensor([0.5, 2.0])
+            >>> means = pyhf.tensorlib.astensor([0., 2.3])
+            >>> sigmas = pyhf.tensorlib.astensor([1., 0.8])
+            >>> pyhf.tensorlib.normal(values, means, sigmas)
+            array([0.35206533, 0.46481887])
 
         Args:
             x (`tensor` or `float`): The value at which to evaluate the Normal distribution p.d.f.
@@ -299,6 +308,9 @@ class numpy_backend(object):
             >>> pyhf.set_backend(pyhf.tensor.numpy_backend())
             >>> pyhf.tensorlib.normal_cdf(0.8)
             0.7881446014166034
+            >>> values = pyhf.tensorlib.astensor([0.8, 2.0])
+            >>> pyhf.tensorlib.normal_cdf(values)
+            array([0.7881446 , 0.97724987])
 
         Args:
             x (`tensor` or `float`): The observed value of the random variable to evaluate the CDF for

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -141,7 +141,7 @@ class pytorch_backend(object):
         return torch.stack(sequence, dim=axis)
 
     def where(self, mask, tensor_in_1, tensor_in_2):
-        return torch.where(mask.type(torch.BoolTensor), tensor_in_1, tensor_in_2)
+        return torch.where(mask, tensor_in_1, tensor_in_2)
 
     def concatenate(self, sequence, axis=0):
         """

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -96,8 +96,7 @@ class pytorch_backend(object):
         return tensor[indices.type(torch.LongTensor)]
 
     def boolean_mask(self, tensor, mask):
-        mask = self.astensor(mask, dtype='bool')
-        return torch.masked_select(tensor, mask)
+        return torch.masked_select(tensor, mask.type(torch.BoolTensor))
 
     def reshape(self, tensor, newshape):
         return torch.reshape(tensor, newshape)

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -31,7 +31,6 @@ class pytorch_backend(object):
         Returns:
             PyTorch tensor: A clipped `tensor`
         """
-        tensor_in = self.astensor(tensor_in)
         return torch.clamp(tensor_in, min_value, max_value)
 
     def tolist(self, tensor_in):
@@ -65,8 +64,6 @@ class pytorch_backend(object):
         return tensor_in.repeat(repeats)
 
     def outer(self, tensor_in_1, tensor_in_2):
-        tensor_in_1 = self.astensor(tensor_in_1)
-        tensor_in_2 = self.astensor(tensor_in_2)
         return torch.ger(tensor_in_1, tensor_in_2)
 
     def astensor(self, tensor_in, dtype='float'):
@@ -109,7 +106,6 @@ class pytorch_backend(object):
         return tuple(map(int, tensor.shape))
 
     def sum(self, tensor_in, axis=None):
-        tensor_in = self.astensor(tensor_in)
         return (
             torch.sum(tensor_in)
             if (axis is None or tensor_in.shape == torch.Size([]))
@@ -117,11 +113,9 @@ class pytorch_backend(object):
         )
 
     def product(self, tensor_in, axis=None):
-        tensor_in = self.astensor(tensor_in)
         return torch.prod(tensor_in) if axis is None else torch.prod(tensor_in, axis)
 
     def abs(self, tensor):
-        tensor = self.astensor(tensor)
         return torch.abs(tensor)
 
     def ones(self, shape):
@@ -131,25 +125,18 @@ class pytorch_backend(object):
         return torch.Tensor(torch.zeros(shape))
 
     def power(self, tensor_in_1, tensor_in_2):
-        tensor_in_1 = self.astensor(tensor_in_1)
-        tensor_in_2 = self.astensor(tensor_in_2)
         return torch.pow(tensor_in_1, tensor_in_2)
 
     def sqrt(self, tensor_in):
-        tensor_in = self.astensor(tensor_in)
         return torch.sqrt(tensor_in)
 
     def divide(self, tensor_in_1, tensor_in_2):
-        tensor_in_1 = self.astensor(tensor_in_1)
-        tensor_in_2 = self.astensor(tensor_in_2)
         return torch.div(tensor_in_1, tensor_in_2)
 
     def log(self, tensor_in):
-        tensor_in = self.astensor(tensor_in)
         return torch.log(tensor_in)
 
     def exp(self, tensor_in):
-        tensor_in = self.astensor(tensor_in)
         return torch.exp(tensor_in)
 
     def stack(self, sequence, axis=0):
@@ -157,8 +144,6 @@ class pytorch_backend(object):
 
     def where(self, mask, tensor_in_1, tensor_in_2):
         mask = self.astensor(mask).type(torch.FloatTensor)
-        tensor_in_1 = self.astensor(tensor_in_1)
-        tensor_in_2 = self.astensor(tensor_in_2)
         return mask * tensor_in_1 + (1 - mask) * tensor_in_2
 
     def concatenate(self, sequence, axis=0):
@@ -199,7 +184,6 @@ class pytorch_backend(object):
             list of Tensors: The sequence broadcast together.
         """
 
-        args = [self.astensor(arg) for arg in args]
         max_dim = max(map(len, args))
         try:
             assert not [arg for arg in args if 1 < len(arg) < max_dim]
@@ -224,12 +208,9 @@ class pytorch_backend(object):
         Returns:
             tensor: the calculation based on the Einstein summation convention
         """
-        ops = tuple(self.astensor(op) for op in operands)
-        return torch.einsum(subscripts, ops)
+        return torch.einsum(subscripts, operands)
 
     def poisson_logpdf(self, n, lam):
-        n = self.astensor(n)
-        lam = self.astensor(lam)
         return torch.distributions.Poisson(lam).log_prob(n)
 
     def poisson(self, n, lam):
@@ -256,14 +237,9 @@ class pytorch_backend(object):
         Returns:
             PyTorch FloatTensor: Value of the continous approximation to Poisson(n|lam)
         """
-        n = self.astensor(n)
-        lam = self.astensor(lam)
         return torch.exp(torch.distributions.Poisson(lam).log_prob(n))
 
     def normal_logpdf(self, x, mu, sigma):
-        x = self.astensor(x)
-        mu = self.astensor(mu)
-        sigma = self.astensor(sigma)
         normal = torch.distributions.Normal(mu, sigma)
         return normal.log_prob(x)
 
@@ -290,9 +266,6 @@ class pytorch_backend(object):
         Returns:
             PyTorch FloatTensor: Value of Normal(x|mu, sigma)
         """
-        x = self.astensor(x)
-        mu = self.astensor(mu)
-        sigma = self.astensor(sigma)
         normal = torch.distributions.Normal(mu, sigma)
         return self.exp(normal.log_prob(x))
 
@@ -315,9 +288,6 @@ class pytorch_backend(object):
         Returns:
             PyTorch FloatTensor: The CDF
         """
-        x = self.astensor(x)
-        mu = self.astensor(mu)
-        sigma = self.astensor(sigma)
         normal = torch.distributions.Normal(mu, sigma)
         return normal.cdf(x)
 

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -143,8 +143,8 @@ class pytorch_backend(object):
         return torch.stack(sequence, dim=axis)
 
     def where(self, mask, tensor_in_1, tensor_in_2):
-        mask = self.astensor(mask).type(torch.FloatTensor)
-        return mask * tensor_in_1 + (1 - mask) * tensor_in_2
+        mask = mask.type(torch.BoolTensor)
+        return torch.where(mask, tensor_in_1, tensor_in_2)
 
     def concatenate(self, sequence, axis=0):
         """

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -95,7 +95,7 @@ class pytorch_backend(object):
         return tensor[indices.type(torch.LongTensor)]
 
     def boolean_mask(self, tensor, mask):
-        return torch.masked_select(tensor, mask.type(torch.BoolTensor))
+        return torch.masked_select(tensor, mask)
 
     def reshape(self, tensor, newshape):
         return torch.reshape(tensor, newshape)

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -223,10 +223,12 @@ class pytorch_backend(object):
 
             >>> import pyhf
             >>> pyhf.set_backend(pyhf.tensor.pytorch_backend())
-            >>> pyhf.tensorlib.poisson([5.], [6.])
-            tensor([0.1606])
             >>> pyhf.tensorlib.poisson(5., 6.)
-            tensor([0.1606])
+            tensor(0.1606)
+            >>> values = pyhf.tensorlib.astensor([5., 9.])
+            >>> rates = pyhf.tensorlib.astensor([6., 8.])
+            >>> pyhf.tensorlib.poisson(values, rates)
+            tensor([0.1606, 0.1241])
 
         Args:
             n (`tensor` or `float`): The value at which to evaluate the approximation to the Poisson distribution p.m.f.
@@ -253,10 +255,13 @@ class pytorch_backend(object):
 
             >>> import pyhf
             >>> pyhf.set_backend(pyhf.tensor.pytorch_backend())
-            >>> pyhf.tensorlib.normal([0.5], [0.], [1.])
-            tensor([0.3521])
             >>> pyhf.tensorlib.normal(0.5, 0., 1.)
-            tensor([0.3521])
+            tensor(0.3521)
+            >>> values = pyhf.tensorlib.astensor([0.5, 2.0])
+            >>> means = pyhf.tensorlib.astensor([0., 2.3])
+            >>> sigmas = pyhf.tensorlib.astensor([1., 0.8])
+            >>> pyhf.tensorlib.normal(values, means, sigmas)
+            tensor([0.3521, 0.4648])
 
         Args:
             x (`tensor` or `float`): The value at which to evaluate the Normal distribution p.d.f.
@@ -277,8 +282,11 @@ class pytorch_backend(object):
 
             >>> import pyhf
             >>> pyhf.set_backend(pyhf.tensor.pytorch_backend())
-            >>> pyhf.tensorlib.normal_cdf([0.8])
-            tensor([0.7881])
+            >>> pyhf.tensorlib.normal_cdf(0.8)
+            tensor(0.7881)
+            >>> values = pyhf.tensorlib.astensor([0.8, 2.0])
+            >>> pyhf.tensorlib.normal_cdf(values)
+            tensor([0.7881, 0.9772])
 
         Args:
             x (`tensor` or `float`): The observed value of the random variable to evaluate the CDF for

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -142,8 +142,7 @@ class pytorch_backend(object):
         return torch.stack(sequence, dim=axis)
 
     def where(self, mask, tensor_in_1, tensor_in_2):
-        mask = mask.type(torch.BoolTensor)
-        return torch.where(mask, tensor_in_1, tensor_in_2)
+        return torch.where(mask.type(torch.BoolTensor), tensor_in_1, tensor_in_2)
 
     def concatenate(self, sequence, axis=0):
         """

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -269,7 +269,7 @@ class pytorch_backend(object):
         normal = torch.distributions.Normal(mu, sigma)
         return self.exp(normal.log_prob(x))
 
-    def normal_cdf(self, x, mu=[0.0], sigma=[1.0]):
+    def normal_cdf(self, x, mu=0.0, sigma=1.0):
         """
         The cumulative distribution function for the Normal distribution
 

--- a/src/pyhf/tensor/pytorch_backend.py
+++ b/src/pyhf/tensor/pytorch_backend.py
@@ -92,7 +92,6 @@ class pytorch_backend(object):
         return tensor
 
     def gather(self, tensor, indices):
-        indices = self.astensor(indices, dtype='int')
         return tensor[indices.type(torch.LongTensor)]
 
     def boolean_mask(self, tensor, mask):

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -37,7 +37,6 @@ class tensorflow_backend(object):
         Returns:
             TensorFlow Tensor: A clipped `tensor`
         """
-        tensor_in = self.astensor(tensor_in)
         if min_value is None:
             min_value = tf.reduce_min(tensor_in)
         if max_value is None:
@@ -98,8 +97,6 @@ class tensorflow_backend(object):
             raise
 
     def outer(self, tensor_in_1, tensor_in_2):
-        tensor_in_1 = self.astensor(tensor_in_1)
-        tensor_in_2 = self.astensor(tensor_in_2)
         tensor_in_1 = (
             tensor_in_1
             if tensor_in_1.dtype != tf.bool
@@ -154,7 +151,6 @@ class tensorflow_backend(object):
         return tensor
 
     def sum(self, tensor_in, axis=None):
-        tensor_in = self.astensor(tensor_in)
         return (
             tf.reduce_sum(tensor_in)
             if (axis is None or tensor_in.shape == tf.TensorShape([]))
@@ -162,7 +158,6 @@ class tensorflow_backend(object):
         )
 
     def product(self, tensor_in, axis=None):
-        tensor_in = self.astensor(tensor_in)
         return (
             tf.reduce_prod(tensor_in)
             if axis is None
@@ -170,7 +165,6 @@ class tensorflow_backend(object):
         )
 
     def abs(self, tensor):
-        tensor = self.astensor(tensor)
         return tf.abs(tensor)
 
     def ones(self, shape):
@@ -180,12 +174,9 @@ class tensorflow_backend(object):
         return tf.zeros(shape)
 
     def power(self, tensor_in_1, tensor_in_2):
-        tensor_in_1 = self.astensor(tensor_in_1)
-        tensor_in_2 = self.astensor(tensor_in_2)
         return tf.pow(tensor_in_1, tensor_in_2)
 
     def sqrt(self, tensor_in):
-        tensor_in = self.astensor(tensor_in)
         return tf.sqrt(tensor_in)
 
     def shape(self, tensor):
@@ -195,25 +186,18 @@ class tensorflow_backend(object):
         return tf.reshape(tensor, newshape)
 
     def divide(self, tensor_in_1, tensor_in_2):
-        tensor_in_1 = self.astensor(tensor_in_1)
-        tensor_in_2 = self.astensor(tensor_in_2)
         return tf.divide(tensor_in_1, tensor_in_2)
 
     def log(self, tensor_in):
-        tensor_in = self.astensor(tensor_in)
         return tf.math.log(tensor_in)
 
     def exp(self, tensor_in):
-        tensor_in = self.astensor(tensor_in)
         return tf.exp(tensor_in)
 
     def stack(self, sequence, axis=0):
         return tf.stack(sequence, axis=axis)
 
     def where(self, mask, tensor_in_1, tensor_in_2):
-        mask = self.astensor(mask)
-        tensor_in_1 = self.astensor(tensor_in_1)
-        tensor_in_2 = self.astensor(tensor_in_2)
         return mask * tensor_in_1 + (1 - mask) * tensor_in_2
 
     def concatenate(self, sequence, axis=0):
@@ -251,7 +235,6 @@ class tensorflow_backend(object):
         Returns:
             list of Tensors: The sequence broadcast together.
         """
-        args = [self.astensor(arg) for arg in args]
         max_dim = max(map(lambda arg: arg.shape[0], args))
         try:
             assert not [arg for arg in args if 1 < arg.shape[0] < max_dim]
@@ -313,8 +296,6 @@ class tensorflow_backend(object):
         Returns:
             TensorFlow Tensor: Value of the continous approximation to log(Poisson(n|lam))
         """
-        n = self.astensor(n)
-        lam = self.astensor(lam)
         return tfp.distributions.Poisson(lam).log_prob(n)
 
     def poisson(self, n, lam):
@@ -344,8 +325,6 @@ class tensorflow_backend(object):
         Returns:
             TensorFlow Tensor: Value of the continous approximation to Poisson(n|lam)
         """
-        n = self.astensor(n)
-        lam = self.astensor(lam)
         return tf.exp(tfp.distributions.Poisson(lam).log_prob(n))
 
     def normal_logpdf(self, x, mu, sigma):
@@ -374,9 +353,6 @@ class tensorflow_backend(object):
         Returns:
             TensorFlow Tensor: Value of log(Normal(x|mu, sigma))
         """
-        x = self.astensor(x)
-        mu = self.astensor(mu)
-        sigma = self.astensor(sigma)
         normal = tfp.distributions.Normal(mu, sigma)
         return normal.log_prob(x)
 
@@ -406,9 +382,6 @@ class tensorflow_backend(object):
         Returns:
             TensorFlow Tensor: Value of Normal(x|mu, sigma)
         """
-        x = self.astensor(x)
-        mu = self.astensor(mu)
-        sigma = self.astensor(sigma)
         normal = tfp.distributions.Normal(mu, sigma)
         return normal.prob(x)
 
@@ -436,9 +409,6 @@ class tensorflow_backend(object):
         Returns:
             TensorFlow Tensor: The CDF
         """
-        x = self.astensor(x)
-        mu = self.astensor(mu)
-        sigma = self.astensor(sigma)
         normal = tfp.distributions.Normal(mu, sigma)
         return normal.cdf(x)
 

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -285,7 +285,13 @@ class tensorflow_backend(object):
             >>> with sess.as_default():
             ...     sess.run(pyhf.tensorlib.poisson_logpdf(5., 6.))
             ...
-            array([-1.8286943], dtype=float32)
+            -1.8286943
+            >>> values = pyhf.tensorlib.astensor([5., 9.])
+            >>> rates = pyhf.tensorlib.astensor([6., 8.])
+            >>> with sess.as_default():
+            ...     sess.run(pyhf.tensorlib.poisson_logpdf(values, rates))
+            ...
+            array([-1.8286943, -2.086854 ], dtype=float32)
 
         Args:
             n (`tensor` or `float`): The value at which to evaluate the approximation to the Poisson distribution p.m.f.
@@ -314,7 +320,13 @@ class tensorflow_backend(object):
             >>> with sess.as_default():
             ...     sess.run(pyhf.tensorlib.poisson(5., 6.))
             ...
-            array([0.16062315], dtype=float32)
+            0.16062315
+            >>> values = pyhf.tensorlib.astensor([5., 9.])
+            >>> rates = pyhf.tensorlib.astensor([6., 8.])
+            >>> with sess.as_default():
+            ...     sess.run(pyhf.tensorlib.poisson(values, rates))
+            ...
+            array([0.16062315, 0.12407687], dtype=float32)
 
         Args:
             n (`tensor` or `float`): The value at which to evaluate the approximation to the Poisson distribution p.m.f.
@@ -343,7 +355,14 @@ class tensorflow_backend(object):
             >>> with sess.as_default():
             ...     sess.run(pyhf.tensorlib.normal_logpdf(0.5, 0., 1.))
             ...
-            array([-1.0439385], dtype=float32)
+            -1.0439385
+            >>> values = pyhf.tensorlib.astensor([0.5, 2.0])
+            >>> means = pyhf.tensorlib.astensor([0., 2.3])
+            >>> sigmas = pyhf.tensorlib.astensor([1., 0.8])
+            >>> with sess.as_default():
+            ...     sess.run(pyhf.tensorlib.normal_logpdf(values, means, sigmas))
+            ...
+            array([-1.0439385, -0.7661075], dtype=float32)
 
         Args:
             x (`tensor` or `float`): The value at which to evaluate the Normal distribution p.d.f.
@@ -372,7 +391,14 @@ class tensorflow_backend(object):
             >>> with sess.as_default():
             ...     sess.run(pyhf.tensorlib.normal(0.5, 0., 1.))
             ...
-            array([0.35206532], dtype=float32)
+            0.35206532
+            >>> values = pyhf.tensorlib.astensor([0.5, 2.0])
+            >>> means = pyhf.tensorlib.astensor([0., 2.3])
+            >>> sigmas = pyhf.tensorlib.astensor([1., 0.8])
+            >>> with sess.as_default():
+            ...     sess.run(pyhf.tensorlib.normal(values, means, sigmas))
+            ...
+            array([0.35206532, 0.46481887], dtype=float32)
 
         Args:
             x (`tensor` or `float`): The value at which to evaluate the Normal distribution p.d.f.
@@ -399,7 +425,12 @@ class tensorflow_backend(object):
             >>> with sess.as_default():
             ...   sess.run(pyhf.tensorlib.normal_cdf(0.8))
             ...
-            array([0.7881446], dtype=float32)
+            0.7881446
+            >>> values = pyhf.tensorlib.astensor([0.8, 2.0])
+            >>> with sess.as_default():
+            ...   sess.run(pyhf.tensorlib.normal_cdf(values))
+            ...
+            array([0.7881446 , 0.97724986], dtype=float32)
 
         Args:
             x (`tensor` or `float`): The observed value of the random variable to evaluate the CDF for

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -110,7 +110,7 @@ class tensorflow_backend(object):
         return tf.einsum('i,j->ij', tensor_in_1, tensor_in_2)
 
     def gather(self, tensor, indices):
-        return tf.gather(tensor, indices)
+        return tf.compat.v2.gather(tensor, indices)
 
     def boolean_mask(self, tensor, mask):
         return tf.boolean_mask(tensor, mask)

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -199,7 +199,7 @@ class tensorflow_backend(object):
 
     def where(self, mask, tensor_in_1, tensor_in_2):
         mask = tf.cast(mask, tf.bool)
-        return tf.compat.v1.where(mask, tensor_in_1, tensor_in_2)
+        return tf.compat.v2.where(mask, tensor_in_1, tensor_in_2)
 
     def concatenate(self, sequence, axis=0):
         """

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -198,8 +198,8 @@ class tensorflow_backend(object):
         return tf.stack(sequence, axis=axis)
 
     def where(self, mask, tensor_in_1, tensor_in_2):
-        mask = self.astensor(mask)
-        return mask * tensor_in_1 + (1 - mask) * tensor_in_2
+        mask = tf.cast(mask, tf.bool)
+        return tf.compat.v1.where(mask, tensor_in_1, tensor_in_2)
 
     def concatenate(self, sequence, axis=0):
         """

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -198,7 +198,7 @@ class tensorflow_backend(object):
         return tf.stack(sequence, axis=axis)
 
     def where(self, mask, tensor_in_1, tensor_in_2):
-        return tf.compat.v2.where(tf.cast(mask, tf.bool), tensor_in_1, tensor_in_2)
+        return tf.compat.v2.where(mask, tensor_in_1, tensor_in_2)
 
     def concatenate(self, sequence, axis=0):
         """

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -198,8 +198,7 @@ class tensorflow_backend(object):
         return tf.stack(sequence, axis=axis)
 
     def where(self, mask, tensor_in_1, tensor_in_2):
-        mask = tf.cast(mask, tf.bool)
-        return tf.compat.v2.where(mask, tensor_in_1, tensor_in_2)
+        return tf.compat.v2.where(tf.cast(mask, tf.bool), tensor_in_1, tensor_in_2)
 
     def concatenate(self, sequence, axis=0):
         """

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -198,6 +198,7 @@ class tensorflow_backend(object):
         return tf.stack(sequence, axis=axis)
 
     def where(self, mask, tensor_in_1, tensor_in_2):
+        mask = self.astensor(mask)
         return mask * tensor_in_1 + (1 - mask) * tensor_in_2
 
     def concatenate(self, sequence, axis=0):

--- a/src/pyhf/utils.py
+++ b/src/pyhf/utils.py
@@ -116,7 +116,9 @@ def qmu(mu, data, pdf, init_pars, par_bounds):
         loglambdav, data, pdf, init_pars, par_bounds
     )
     qmu = loglambdav(mubhathat, data, pdf) - loglambdav(muhatbhat, data, pdf)
-    qmu = tensorlib.where(muhatbhat[pdf.config.poi_index] > mu, [0], qmu)
+    qmu = tensorlib.where(
+        tensorlib.astensor(muhatbhat[pdf.config.poi_index] > mu), [0], qmu
+    )
     return qmu
 
 

--- a/src/pyhf/utils.py
+++ b/src/pyhf/utils.py
@@ -117,9 +117,7 @@ def qmu(mu, data, pdf, init_pars, par_bounds):
     )
     qmu = loglambdav(mubhathat, data, pdf) - loglambdav(muhatbhat, data, pdf)
     qmu = tensorlib.where(
-        tensorlib.astensor(muhatbhat[pdf.config.poi_index] > mu),
-        tensorlib.astensor([0]),
-        qmu,
+        muhatbhat[pdf.config.poi_index] > mu, tensorlib.astensor([0]), qmu
     )
     return qmu
 

--- a/src/pyhf/utils.py
+++ b/src/pyhf/utils.py
@@ -117,7 +117,9 @@ def qmu(mu, data, pdf, init_pars, par_bounds):
     )
     qmu = loglambdav(mubhathat, data, pdf) - loglambdav(muhatbhat, data, pdf)
     qmu = tensorlib.where(
-        tensorlib.astensor(muhatbhat[pdf.config.poi_index] > mu), [0], qmu
+        tensorlib.astensor(muhatbhat[pdf.config.poi_index] > mu),
+        tensorlib.astensor([0]),
+        qmu,
     )
     return qmu
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,7 +98,7 @@ def backend(request):
     # actual execution here, after all checks is done
     pyhf.set_backend(*request.param)
     if isinstance(pyhf.tensorlib, pyhf.tensor.tensorflow_backend):
-        tf.reset_default_graph()
+        tf.compat.v1.reset_default_graph()
         pyhf.tensorlib.session = tf.Session()
 
     yield request.param

--- a/tests/test_combined_modifiers.py
+++ b/tests/test_combined_modifiers.py
@@ -1,4 +1,3 @@
-from pyhf.pdf import _ModelConfig
 from pyhf.modifiers.histosys import histosys_combined
 from pyhf.modifiers.normsys import normsys_combined
 from pyhf.modifiers.lumi import lumi_combined

--- a/tests/test_probability.py
+++ b/tests/test_probability.py
@@ -53,17 +53,13 @@ def test_joint(backend):
 
 
 def test_independent(backend):
-    tensorlib, _ = backend
+    tb, _ = backend
     result = probability.Independent(
-        probability.Poisson(tensorlib.astensor([10.0, 10.0]))
-    ).log_prob(tensorlib.astensor([2.0, 3.0]))
+        probability.Poisson(tb.astensor([10.0, 10.0]))
+    ).log_prob(tb.astensor([2.0, 3.0]))
 
-    p1 = probability.Poisson(tensorlib.astensor([10.0])).log_prob(
-        tensorlib.astensor(2.0)
+    p1 = probability.Poisson(tb.astensor([10.0])).log_prob(tb.astensor(2.0))
+    p2 = probability.Poisson(tb.astensor([10.0])).log_prob(tb.astensor(3.0))
+    assert tb.tolist(probability.Simultaneous._joint_logpdf([p1, p2]))[0] == tb.tolist(
+        result
     )
-    p2 = probability.Poisson(tensorlib.astensor([10.0])).log_prob(
-        tensorlib.astensor(3.0)
-    )
-    assert tensorlib.tolist(probability.Simultaneous._joint_logpdf([p1, p2]))[
-        0
-    ] == tensorlib.tolist(result)

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -326,7 +326,6 @@ def test_pdf_eval(backend):
     }
     pdf = pyhf.Model(spec)
     data = source['bindata']['data'] + pdf.config.auxdata
-    data = pyhf.tensorlib.astensor(data)
     assert pytest.approx([-17.648827643136507], rel=5e-5) == pyhf.tensorlib.tolist(
         pdf.logpdf(pdf.config.suggested_init(), data)
     )

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -58,7 +58,11 @@ def test_complex_tensor_ops(backend):
         1,
     ]
     assert tb.tolist(
-        tb.where(tb.astensor([1, 0, 1]), tb.astensor([1, 1, 1]), tb.astensor([2, 2, 2]))
+        tb.where(
+            tb.astensor([1, 0, 1], dtype="bool"),
+            tb.astensor([1, 1, 1]),
+            tb.astensor([2, 2, 2]),
+        )
     ) == [1, 2, 1]
 
 

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -326,14 +326,9 @@ def test_pdf_eval(backend):
     }
     pdf = pyhf.Model(spec)
     data = source['bindata']['data'] + pdf.config.auxdata
-    print(f"data: {data}, data type: {type(data)}")
     data = pyhf.tensorlib.astensor(data)
-    print(f"data: {data}, data type: {type(data)}")
-    print(
-        f"suggested_init: {pdf.config.suggested_init()}, type: {type(pdf.config.suggested_init())}"
-    )
     assert pytest.approx([-17.648827643136507], rel=5e-5) == pyhf.tensorlib.tolist(
-        pdf.logpdf(pyhf.tensorlib.astensor(pdf.config.suggested_init()), data)
+        pdf.logpdf(pdf.config.suggested_init(), data)
     )
 
 


### PR DESCRIPTION
# Description

Resolves #295

Remove or reduce the guarding `self.astensor()` calls in the methods of the tensor backends. This makes it more explicit that tensors are required, move the responsibility to the user to format their data correctly, and should add a speedup by dramatically reducing the number of `self.astensor()` calls.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* perf: Remove all non-essential 'self.astensor' calls from the tensor backend methods
* Replace custom instances of 'where' with tensor library versions for TensorFlow, PyTorch, and MXNet backends
   - Uses: tf.compat.v2.where, torch.where, nd.where
* Make masks used in 'tensorlib.where' explicit bools
* docs: Update the docstring examples for the tensor backends
* test: Make all relevant arguments tensors in test_tensor.py
```