### PR TITLE
ci: Use Travis CI only for Python 2.7 testing and releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macOS-latest]
-        python-version: [2.7, 3.6, 3.7]
+        python-version: [3.6, 3.7]
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI/CD
 on:
   push:
   pull_request:
-    types: [edited, closed]
+    types: [opened, synchronize, closed]
   # Run daily at 0:01 UTC
   schedule:
   - cron:  '1 0 * * *'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macOS-latest]
-        python-version: [3.6, 3.7]
+        python-version: [2.7, 3.6, 3.7]
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
+        flags: unittests
     - name: Run benchmarks
       if: github.event_name == 'schedule' && matrix.python-version == 3.7
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI/CD
 on:
   push:
   pull_request:
+    types: [edited, closed]
   # Run daily at 0:01 UTC
   schedule:
   - cron:  '1 0 * * *'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI/CD
 on:
   push:
   pull_request:
-    types: [opened, synchronize, closed]
   # Run daily at 0:01 UTC
   schedule:
   - cron:  '1 0 * * *'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,16 @@
+on:
+  pull_request:
+    # types: [closed]
+
+jobs:
+  binder:
+    name: Trigger Binder build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+      # if: github.event.pull_request.merged
+    - name: Trigger Binder build
+      run: |
+        # Use Binder build API to trigger repo2docker to build image on GKE and OVH Binder Federation clusters
+        bash binder/trigger_binder.sh https://gke.mybinder.org/build/gh/diana-hep/pyhf/master
+        bash binder/trigger_binder.sh https://ovh.mybinder.org/build/gh/diana-hep/pyhf/master

--- a/.github/workflows/merged.yml
+++ b/.github/workflows/merged.yml
@@ -1,6 +1,8 @@
+name: Merged PR
+
 on:
   pull_request:
-    # types: [closed]
+    types: [closed]
 
 jobs:
   binder:
@@ -8,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-      # if: github.event.pull_request.merged
+      if: github.event.pull_request.merged
     - name: Trigger Binder build
       run: |
         # Use Binder build API to trigger repo2docker to build image on GKE and OVH Binder Federation clusters

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,12 @@ script:
 after_success: if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then coveralls; fi
 
 # test Python 2.7 on 'pr' builds and 'push' builds on master
-# test docs on 'pr' builds and 'push' builds on master and on docs branches
-# benchmark and deploy to PyPI only when merged into master (those mereges are 'push' builds)
+# test docs and deploy to PyPI only when merged into master (those mereges are 'push' builds)
 stages:
   - name: test
     if: (branch = master) AND (NOT (branch =~ /^docs\//))
   - name: docs
-    if: (branch = master) OR (branch =~ /^docs\//)
+    if: (branch = master) AND (NOT (type IN (pull_request)))
   - name: binder
     if: (branch = master) AND (NOT (type IN (pull_request)))
   - name: deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ dist: xenial
 language: python
 cache: pip
 python:
-  - '2.7'
-  - '3.6'
   - '3.7'
 before_install:
   - sudo apt-get install libtcmalloc-minimal4
@@ -26,8 +24,6 @@ after_success: skip
 stages:
   - name: test
     if: NOT (branch =~ /^docs\//)
-  - name: benchmark
-    if: (branch = master) AND (NOT (type IN (pull_request)))
   - name: docs
     if: (branch = master) OR (branch =~ /^docs\//)
   - name: binder
@@ -40,25 +36,6 @@ env:
 
 jobs:
   include:
-  - name: "Python 3.6 Notebook Tests"
-    python: '3.6'
-    script:
-      - python -m pytest tests/test_notebooks.py
-  - name: "Python 3.7 Notebook Tests"
-    python: '3.7'
-    script:
-      - python -m pytest tests/test_notebooks.py
-  - stage: benchmark
-    python: '3.7'
-    before_install:
-      - sudo apt-get install libtcmalloc-minimal4
-      - export LD_PRELOAD="/usr/lib/libtcmalloc_minimal.so.4"
-      - pip install --upgrade pip setuptools wheel
-    install:
-      - pip install --ignore-installed -U -q --no-cache-dir -e .[complete]
-      - pip freeze
-    script: python -m pytest -r sx --benchmark-sort=mean tests/benchmarks/
-    after_success: skip
   - stage: docs
     python: '3.7'
     before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
   - pyflakes src
   - check-manifest || travis_terminate 1
   - python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/test_notebooks.py
-after_success: coveralls
+after_success: skip
 
 # test Python 2.7 on 'push' builds
 # test docs and deploy to PyPI only when merged into master (those mereges are 'push' builds)

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ env:
 
 jobs:
   include:
+  - name: "Python 2.7"
   - stage: docs
     python: '3.7'
     before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: xenial
 language: python
 cache: pip
 python:
-  - '3.7'
+  - '2.7'
 before_install:
   - sudo apt-get install libtcmalloc-minimal4
   - export LD_PRELOAD="/usr/lib/libtcmalloc_minimal.so.4"
@@ -15,8 +15,7 @@ script:
   - pyflakes src
   - check-manifest || travis_terminate 1
   - python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/test_notebooks.py
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then black --check --diff --verbose .; fi
-after_success: skip
+after_success: if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then coveralls; fi
 
 # always test (on both 'push' and 'pr' builds in Travis)
 # test docs on 'pr' builds and 'push' builds on master and on docs branches

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
   - pyflakes src
   - check-manifest || travis_terminate 1
   - python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/test_notebooks.py
-after_success: if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then coveralls; fi
+after_success: coveralls
 
 # test Python 2.7 on 'push' builds
 # test docs and deploy to PyPI only when merged into master (those mereges are 'push' builds)

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,12 @@ script:
   - python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/test_notebooks.py
 after_success: if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then coveralls; fi
 
-# always test (on both 'push' and 'pr' builds in Travis)
+# test Python 2.7 on 'pr' builds and 'push' builds on master
 # test docs on 'pr' builds and 'push' builds on master and on docs branches
 # benchmark and deploy to PyPI only when merged into master (those mereges are 'push' builds)
 stages:
   - name: test
-    if: NOT (branch =~ /^docs\//)
+    if: (branch = master) AND (NOT (branch =~ /^docs\//))
   - name: docs
     if: (branch = master) OR (branch =~ /^docs\//)
   - name: binder

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ stages:
     if: NOT (type IN (pull_request))
   - name: docs
     if: (branch = master) AND (NOT (type IN (pull_request)))
-  - name: binder
-    if: (branch = master) AND (NOT (type IN (pull_request)))
   - name: deploy
 
 env:
@@ -58,15 +56,6 @@ jobs:
       local_dir: docs/_build/html
       on:
         branch: master
-  - stage: binder
-    python: '3.7'
-    before_install: skip
-    install: skip
-    script:
-      # Use Binder build API to trigger repo2docker to build image on GKE and OVH Binder Federation clusters
-      - bash binder/trigger_binder.sh https://gke.mybinder.org/build/gh/diana-hep/pyhf/"${TRAVIS_BRANCH}"
-      - bash binder/trigger_binder.sh https://ovh.mybinder.org/build/gh/diana-hep/pyhf/"${TRAVIS_BRANCH}"
-    after_success: skip
   - stage: deploy
     # Tests deployment to PyPI for all commits to master
     name: "TestPyPI deploy"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,11 @@ script:
   - python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/test_notebooks.py
 after_success: if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then coveralls; fi
 
-# test Python 2.7 on 'pr' builds and 'push' builds on master
+# test Python 2.7 on 'push' builds
 # test docs and deploy to PyPI only when merged into master (those mereges are 'push' builds)
 stages:
   - name: test
-    if: (branch = master) AND (NOT (branch =~ /^docs\//))
+    if: NOT (type IN (pull_request))
   - name: docs
     if: (branch = master) AND (NOT (type IN (pull_request)))
   - name: binder


### PR DESCRIPTION
# Description

~~Do all testing in GitHub Actions and then have Travis CI be responsible for releases.~~ The setup action for Python 2.7 seems to be broken at the moment, so still use Travis for Python 2.7 testing. At the moment this still requires Travis CI to run one version of the test suite as Coveralls needs to be run.

~~Perhaps this is a good time to try to figure out how to get Coveralls to run in GitHub Actions as well.~~ Changed from Coveralls to Codecov in PR #598 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

~~* ci: Have GitHub Actions be responsible for all testing and benchmarks~~
~~* ci: Migrate Coveralls to GitHub Actions~~

```
* ci: Have GitHub Actions be responsible for all Python 3 testing (Travis CI only tests Python 2.7)
   - Travis CI is still responsible for releases
* ci: Add merged workflow to GitHub Actions
* ci: Migrate Binder build trigger from Travis CI to GitHub Actions
```
