### PR TITLE
ci: Add MacOS testing environment to GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,16 @@ jobs:
         pip install --ignore-installed -U -q --no-cache-dir -e .[complete]
         pip list
     - name: Lint with Pyflakes
+      if: matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
       run: |
         pyflakes src
         check-manifest
     - name: Lint with Black
+      if: matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
       run: |
         black --check --diff --verbose .
     - name: Check MANIFEST
+      if: matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
       run: |
         check-manifest
     - name: Test with pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        platform: [ubuntu-latest]
+        platform: [ubuntu-latest, macOS-latest]
         python-version: [3.6, 3.7]
     runs-on: ${{ matrix.platform }}
 


### PR DESCRIPTION
# Description

[Now that the MacOS environment seems to play nice with Python](https://github.com/actions/setup-python/issues/13) it can be incorporated into the testing suite. Additionally, avoid linting the same code multiple times by just giving this responsibility to Python 3.7 on Ubuntu.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* ci: Add MacOS testing environment to GitHub Actions CI
* ci: Lint only on Python 3.7 in the Ubuntu testing environment to avoid linting the same code multiple times
```
