### PR TITLE
docs: Use consistent style in docstrings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,10 @@ jobs:
         pip list
         sudo apt-get update
         sudo apt-get -qq install pandoc
+    - name: Check docstrings
+      run: |
+        # Group 1 is related to docstrings
+        pydocstyle --select D1 src/pyhf/probability.py
     - name: Test and build docs
       run: |
         python -m doctest README.md

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ extras_require = {
         'pytest-mock',
         'pytest-benchmark[histogram]',
         'pytest-console-scripts',
+        'pydocstyle',
         'coverage>=4.0',  # coveralls
         'matplotlib',
         'jupyter',

--- a/src/pyhf/probability.py
+++ b/src/pyhf/probability.py
@@ -126,12 +126,26 @@ class Normal(_SimpleDistributionMixin):
 
 class Independent(_SimpleDistributionMixin):
     """
-    A probability density corresponding to the joint
-    likelihood of a batch of identically distributed random
-    numbers.
+    A probability density corresponding to the joint distribution of a batch of
+    identically distributed random variables.
+
+    Example:
+        >>> import pyhf
+        >>> import numpy.random as random
+        >>> random.seed(0)
+        >>> rates = pyhf.tensorlib.astensor([10.0, 10.0])
+        >>> poissons = pyhf.probability.Poisson(rates)
+        >>> independent = pyhf.probability.Independent(poissons)
+        >>> independent.sample()
+        array([10, 11])
     """
 
     def __init__(self, batched_pdf, batch_size=None):
+        """
+        Args:
+            batched_pdf (`pyhf.probability` distribution): The batch of pdfs of the same type (e.g. Poisson)
+            batch_size (`int`): The size of the batch
+        """
         self.batch_size = batch_size
         self._pdf = batched_pdf
 

--- a/src/pyhf/probability.py
+++ b/src/pyhf/probability.py
@@ -211,7 +211,7 @@ class Simultaneous(object):
         Args:
 
             pdfobjs (`Distribution`): The constituent pdf objects
-            tensorview (`_TensorViewer`): The `_TensorViwer` defining the data composition
+            tensorview (`_TensorViewer`): The :code:`_TensorViewer` defining the data composition
             batch_size (`int`): The size of the batch
 
         """

--- a/src/pyhf/probability.py
+++ b/src/pyhf/probability.py
@@ -245,7 +245,7 @@ class Simultaneous(object):
         return self._pdfobjs[index]
 
     def expected_data(self):
-        """
+        r"""
         The expectation value of the probability density function.
 
         Returns:
@@ -256,7 +256,7 @@ class Simultaneous(object):
         return self.tv.stitch(tostitch)
 
     def sample(self, sample_shape=()):
-        """
+        r"""
         The collection of values sampled from the probability density function.
 
         Args:
@@ -269,7 +269,7 @@ class Simultaneous(object):
         return self.tv.stitch([p.sample(sample_shape) for p in self])
 
     def log_prob(self, value):
-        """
+        r"""
         The log of the probability density function at the given value.
 
         Args:

--- a/src/pyhf/probability.py
+++ b/src/pyhf/probability.py
@@ -260,7 +260,7 @@ class Simultaneous(object):
         The collection of values sampled from the probability density function.
 
         Args:
-            sample shale (`tuple`): The desired shape of the samples.
+            sample_shape (`tuple`): The shape of the sample to be returned
 
         Returns:
             Tensor: The values :math:`x \sim f(\theta)` where :math:`x` has shape :code:`sample_shape`

--- a/src/pyhf/probability.py
+++ b/src/pyhf/probability.py
@@ -195,10 +195,7 @@ class Simultaneous(object):
 
             pdfobjs (`Distribution`): The constituent pdf objects
             tensorview (`_TensorViewer`): The `_TensorViwer` defining the data composition
-
-
-        Returns:
-            data (`tensor`): The expected data
+            batch_size (`int`): The size of the batch
 
         """
         self.tv = tensorview
@@ -232,10 +229,10 @@ class Simultaneous(object):
 
     def expected_data(self):
         """
-        Compute mean data of the density
+        The expectation value of the probability density function.
 
         Returns:
-            data (`tensor`): The expected data
+            Tensor: The expectation value of the distribution :math:`\mathrm{E}\left[f(\theta)\right]`
 
         """
         tostitch = [p.expected_data() for p in self]
@@ -243,26 +240,26 @@ class Simultaneous(object):
 
     def sample(self, sample_shape=()):
         """
-        Sample data from the density.
+        The collection of values sampled from the probability density function.
 
         Args:
             sample shale (`tuple`): The desired shape of the samples.
 
         Returns:
-            samples (`tensor`): The samples
+            Tensor: The values :math:`x \sim f(\theta)` where :math:`x` has shape :code:`sample_shape`
 
         """
         return self.tv.stitch([p.sample(sample_shape) for p in self])
 
     def log_prob(self, value):
         """
-        Compute the log density value for observed data.
+        The log of the probability density function at the given value.
 
         Args:
-            data (`tensor`): The observed value
+            value (`tensor`): The observed value
 
         Returns:
-            value (`float` or `tensor`): The log density value
+            Tensor: The value of :math:`\log(f\left(x\middle|\theta\right))` for :math:`x=`:code:`value`
 
         """
         constituent_data = self.tv.split(value)

--- a/src/pyhf/probability.py
+++ b/src/pyhf/probability.py
@@ -1,3 +1,4 @@
+"""The probability density function module."""
 from . import get_backend
 
 
@@ -29,7 +30,7 @@ class _SimpleDistributionMixin(object):
 
     def sample(self, sample_shape=()):
         r"""
-        The collection of values sampled from the probability density function
+        The collection of values sampled from the probability density function.
 
         Args:
             sample_shape (`tuple`): The shape of the sample to be returned
@@ -51,12 +52,13 @@ class Poisson(_SimpleDistributionMixin):
         >>> pyhf.probability.Poisson(rates)
         <pyhf.probability.Poisson object at 0x...>
 
-    Args:
-        rate (`tensor` or `float`): The mean of the Poisson distribution (the expected number of events)
-
     """
 
     def __init__(self, rate):
+        """
+        Args:
+            rate (`tensor` or `float`): The mean of the Poisson distribution (the expected number of events)
+        """
         tensorlib, _ = get_backend()
         self.rate = rate
         self._pdf = tensorlib.poisson_dist(rate)
@@ -89,14 +91,15 @@ class Normal(_SimpleDistributionMixin):
         >>> stds = pyhf.tensorlib.astensor([1, 0.5])
         >>> pyhf.probability.Normal(means, stds)
         <pyhf.probability.Normal object at 0x...>
-
-    Args:
-        loc (`tensor` or `float`): The mean of the Normal distribution
-        scale (`tensor` or `float`): The standard deviation of the Normal distribution
-
     """
 
     def __init__(self, loc, scale):
+        """
+        Args:
+            loc (`tensor` or `float`): The mean of the Normal distribution
+            scale (`tensor` or `float`): The standard deviation of the Normal distribution
+        """
+
         tensorlib, _ = get_backend()
         self.loc = loc
         self.scale = scale

--- a/src/pyhf/tensor/tensorflow_backend.py
+++ b/src/pyhf/tensor/tensorflow_backend.py
@@ -222,7 +222,9 @@ class tensorflow_backend(object):
 
             >>> import pyhf
             >>> import tensorflow as tf
-            >>> pyhf.set_backend(pyhf.tensor.tensorflow_backend(session=tf.Session()))
+            >>> sess = tf.Session()
+            ...
+            >>> pyhf.set_backend(pyhf.tensor.tensorflow_backend(session=sess))
             >>> tf.Session().run(pyhf.tensorlib.simple_broadcast(
             ...   pyhf.tensorlib.astensor([1]),
             ...   pyhf.tensorlib.astensor([2, 3, 4]),
@@ -421,7 +423,7 @@ class tensorflow_backend(object):
             >>> import tensorflow as tf
             >>> sess = tf.Session()
             ...
-            >>> pyhf.set_backend(pyhf.tensor.tensorflow_backend())
+            >>> pyhf.set_backend(pyhf.tensor.tensorflow_backend(session=sess))
             >>> with sess.as_default():
             ...   sess.run(pyhf.tensorlib.normal_cdf(0.8))
             ...
@@ -453,7 +455,7 @@ class tensorflow_backend(object):
             >>> import tensorflow as tf
             >>> sess = tf.Session()
             ...
-            >>> pyhf.set_backend(pyhf.tensor.tensorflow_backend())
+            >>> pyhf.set_backend(pyhf.tensor.tensorflow_backend(session=sess))
             >>> rates = pyhf.tensorlib.astensor([5, 8])
             >>> values = pyhf.tensorlib.astensor([4, 9])
             >>> poissons = pyhf.tensorlib.poisson_dist(rates)
@@ -481,7 +483,7 @@ class tensorflow_backend(object):
             >>> import tensorflow as tf
             >>> sess = tf.Session()
             ...
-            >>> pyhf.set_backend(pyhf.tensor.tensorflow_backend())
+            >>> pyhf.set_backend(pyhf.tensor.tensorflow_backend(session=sess))
             >>> means = pyhf.tensorlib.astensor([5, 8])
             >>> stds = pyhf.tensorlib.astensor([1, 0.5])
             >>> values = pyhf.tensorlib.astensor([4, 9])


### PR DESCRIPTION
# Description

Should be done _after_ PR #588 is merged.

Amend the docstrings added in PR #558.

- Some docstrings that were added in https://github.com/diana-hep/pyhf/commit/4e5acc3f8fc86da6f8e0cb0a795c24ab494c02de somehow got removed from the final PR
- For methods that are repeated across distributions use the same docstring for consistency
- Additionally fix some typos

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* docs: Amend the docstrings for the probability module to include missing docstrings and fix typos and enforce consistency
* tests: Add probability module to pydocstyle testing
```
