### PR TITLE
ci: Test example notebooks separately

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,11 +42,33 @@ jobs:
         check-manifest
     - name: Test with pytest
       run: |
-        python -m pytest -r sx --ignore tests/benchmarks/
+        python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/test_notebooks.py
     - name: Run benchmarks
       if: github.event_name == 'schedule' && matrix.python-version == 3.7
       run: |
         python -m pytest -r sx --benchmark-sort=mean tests/benchmarks/test_benchmark.py
+
+  notebooks:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        pip install --ignore-installed -U -q --no-cache-dir -e .[complete]
+        pip list
+    - name: Test example notebooks
+      run: |
+        python -m pytest -r sx tests/test_notebooks.py
 
   docs:
 


### PR DESCRIPTION
# Description

Test the example notebooks separately from the source code so that the test will finish faster. This also isolated the source code testing from the example documentation testing.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Test the example notebooks in a separate GitHub Action to isolate the source code tests from example documentation tests and speedup total testing
```
