### PR TITLE
fix: Add upper bound on TensorFlow Probability to avoid TensorFlow compatibility conflict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as readme_md
 extras_require = {
     'tensorflow': [
         'tensorflow~=1.14',
-        'tensorflow-probability~=0.5',
+        'tensorflow-probability~=0.5,<0.8',
         'numpy<=1.14.5,>=1.14.0',  # Lower of 1.14.0 instead of 1.13.3 to ensure doctest pass
     ],
     'torch': ['torch~=1.2'],


### PR DESCRIPTION
# Description

Add an upper bound of [TensorFlow Probability `v0.7`](https://github.com/tensorflow/probability/releases/tag/v0.7). This is a temporary fix as the releases schedule of TensorFlow `v1.15` and [TensorFlow `v2.0`](https://github.com/tensorflow/tensorflow/releases/tag/v2.0.0) were not properly synced.

[TensorFlow `v2.0`](https://github.com/tensorflow/tensorflow/releases/tag/v2.0.0) was released first, but at its release time Tensorflow `v1.15` was still a release candidate ([`v1.15.0-rc2`](https://github.com/tensorflow/tensorflow/releases/tag/v1.15.0-rc2)). [TensorFlow Probability `v0.8`](https://github.com/tensorflow/probability/releases/tag/v0.8) was then released to support TensorFlow `v2.0`, but it only supports TensorFlow `v2.0` and TensorFlow `v1.15` which wasn't released at time of its release. As such, [the compatibility mode requirements try to install TFP `v0.8` with TF `v1.14` and fails](https://github.com/diana-hep/pyhf/runs/244065549#step:8:11).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add an upper bound of TensorFlow Probability v0.7 to avoid TF and TFP release conflict as TF v1.15 is not out yet
```
