### PR TITLE
ci: Use Codecov GitHub Action to report coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,4 +10,7 @@ exclude_lines =
     if __name__ == .__main__.:
 ignore_errors = True
 omit =
+    binder/*
+    docker/*
     tests/*
+    validation/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,13 @@
+[run]
+branch = True
+source = src/pyhf
+
+[report]
+exclude_lines =
+    if self.debug:
+    pragma: no cover
+    raise NotImplementedError
+    if __name__ == .__main__.:
+ignore_errors = True
+omit =
+    tests/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,13 @@ jobs:
       run: |
         python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/test_notebooks.py
     - name: Upload coverage to Codecov
-      if: github.event_name == 'pull_request' && matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
+      if: github.event_name == 'push' && matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
+      uses: codecov/codecov-action@master
+      with:
+        token: ${{secrets.CODECOV_TOKEN}}
+        file: ./coverage.xml
+    - name: Upload coverage to Codecov
+      if: github.event.pull_request.merged && matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
       uses: codecov/codecov-action@master
       with:
         token: ${{secrets.CODECOV_TOKEN}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
       uses: codecov/codecov-action@master
       with:
         token: ${{secrets.CODECOV_TOKEN}}
+        file: ./coverage.xml
     - name: Run benchmarks
       if: github.event_name == 'schedule' && matrix.python-version == 3.7
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI/CD
 on:
   push:
   pull_request:
-    types: [opened, synchronize, closed]
   # Run daily at 0:01 UTC
   schedule:
   - cron:  '1 0 * * *'
@@ -45,10 +44,10 @@ jobs:
       run: |
         python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/test_notebooks.py
     - name: Upload coverage to Codecov
-      if: (github.event_name == 'push' || github.event.pull_request.merged) && matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
+      if: github.event_name == 'push' && matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
       uses: codecov/codecov-action@master
       with:
-        token: ${{secrets.CODECOV_TOKEN}}
+        token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
     - name: Run benchmarks
       if: github.event_name == 'schedule' && matrix.python-version == 3.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI/CD
 on:
   push:
   pull_request:
-    types: [edited, closed]
+    types: [opened, synchronize, closed]
   # Run daily at 0:01 UTC
   schedule:
   - cron:  '1 0 * * *'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Test with pytest
       run: |
         python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/test_notebooks.py
-    - name: Upload coverage to Codecov
+    - name: Report coverage with Codecov
       if: github.event_name == 'push' && matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
       uses: codecov/codecov-action@master
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI/CD
 on:
   push:
   pull_request:
+    types: [edited, closed]
   # Run daily at 0:01 UTC
   schedule:
   - cron:  '1 0 * * *'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,13 +45,7 @@ jobs:
       run: |
         python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/test_notebooks.py
     - name: Upload coverage to Codecov
-      if: github.event_name == 'push' && matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
-      uses: codecov/codecov-action@master
-      with:
-        token: ${{secrets.CODECOV_TOKEN}}
-        file: ./coverage.xml
-    - name: Upload coverage to Codecov
-      if: github.event.pull_request.merged && matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
+      if: (github.event_name == 'push' || github.event.pull_request.merged) && matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
       uses: codecov/codecov-action@master
       with:
         token: ${{secrets.CODECOV_TOKEN}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,11 @@ jobs:
     - name: Test with pytest
       run: |
         python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/test_notebooks.py
+    - name: Upload coverage to Codecov
+      if: github.event_name == 'pull_request' && matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
+      uses: codecov/codecov-action@master
+      with:
+        token: ${{secrets.CODECOV_TOKEN}}
     - name: Run benchmarks
       if: github.event_name == 'schedule' && matrix.python-version == 3.7
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ __pycache__
 \#*#
 .#*
 .coverage*
+!.coveragerc
 coverage*
 
 *.swp

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ __pycache__
 \#*#
 .#*
 .coverage*
+coverage*
 
 *.swp
 *.map

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
   - check-manifest || travis_terminate 1
   - python -m pytest -r sx --ignore tests/benchmarks/ --ignore tests/test_notebooks.py
   - if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then black --check --diff --verbose .; fi
-after_success: if [[ $TRAVIS_PYTHON_VERSION == '3.7' ]]; then coveralls; fi
+after_success: skip
 
 # always test (on both 'push' and 'pr' builds in Travis)
 # test docs on 'pr' builds and 'push' builds on master and on docs branches
@@ -44,12 +44,10 @@ jobs:
     python: '3.6'
     script:
       - python -m pytest tests/test_notebooks.py
-    after_success: skip
   - name: "Python 3.7 Notebook Tests"
     python: '3.7'
     script:
       - python -m pytest tests/test_notebooks.py
-    after_success: skip
   - stage: benchmark
     python: '3.7'
     before_install:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![GitHub Actions Status](https://github.com/diana-hep/pyhf/workflows/CI/CD/badge.svg)](https://github.com/diana-hep/pyhf/actions)
 [![Docker Automated](https://img.shields.io/docker/automated/pyhf/pyhf.svg)](https://hub.docker.com/r/pyhf/pyhf/)
 [![Coverage Status](https://coveralls.io/repos/github/diana-hep/pyhf/badge.svg?branch=master)](https://coveralls.io/github/diana-hep/pyhf?branch=master)
+[![Code Coverage](https://codecov.io/gh/diana-hep/pyhf/graph/badge.svg?branch=master)](https://codecov.io/gh/diana-hep/pyhf?branch=master)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/diana-hep/pyhf.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/diana-hep/pyhf/latest/files/)
 [![CodeFactor](https://www.codefactor.io/repository/github/diana-hep/pyhf/badge)](https://www.codefactor.io/repository/github/diana-hep/pyhf)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![Travis Build Status](https://travis-ci.org/diana-hep/pyhf.svg?branch=master)](https://travis-ci.org/diana-hep/pyhf)
 [![GitHub Actions Status](https://github.com/diana-hep/pyhf/workflows/CI/CD/badge.svg)](https://github.com/diana-hep/pyhf/actions)
 [![Docker Automated](https://img.shields.io/docker/automated/pyhf/pyhf.svg)](https://hub.docker.com/r/pyhf/pyhf/)
-[![Coverage Status](https://coveralls.io/repos/github/diana-hep/pyhf/badge.svg?branch=master)](https://coveralls.io/github/diana-hep/pyhf?branch=master)
 [![Code Coverage](https://codecov.io/gh/diana-hep/pyhf/graph/badge.svg?branch=master)](https://codecov.io/gh/diana-hep/pyhf?branch=master)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/diana-hep/pyhf.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/diana-hep/pyhf/latest/files/)
 [![CodeFactor](https://www.codefactor.io/repository/github/diana-hep/pyhf/badge)](https://www.codefactor.io/repository/github/diana-hep/pyhf)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --ignore=setup.py --ignore=validation/ --ignore=binder/ --cov=pyhf --cov-report=term-missing --cov-config=.coveragerc --cov-report html --cov-report xml --doctest-modules --doctest-glob='*.rst'
+addopts = --ignore=setup.py --ignore=validation/ --ignore=binder/ --cov=pyhf --cov-report=term-missing --cov-config=.coveragerc --cov-report xml --doctest-modules --doctest-glob='*.rst'

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --ignore=setup.py --ignore=validation/ --ignore=binder/ --cov=pyhf --cov-report=term-missing --cov-config=.coveragerc --cov-report html --cov-report html --doctest-modules --doctest-glob='*.rst'
+addopts = --ignore=setup.py --ignore=validation/ --ignore=binder/ --cov=pyhf --cov-report=term-missing --cov-config=.coveragerc --cov-report html --cov-report xml --doctest-modules --doctest-glob='*.rst'

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ extras_require = {
         'pytest-mock',
         'pytest-benchmark[histogram]',
         'pytest-console-scripts',
-        'python-coveralls',
         'coverage>=4.0',  # coveralls
         'matplotlib',
         'jupyter',


### PR DESCRIPTION
# Description

Drop Coveralls in favor of [Codecov's GitHub Action](https://github.com/codecov/codecov-action) to report code coverage. [![Code Coverage](https://codecov.io/gh/diana-hep/pyhf/graph/badge.svg?branch=master)](https://codecov.io/gh/diana-hep/pyhf?branch=master)

Adds a generic [`.coveragerc`](https://gist.github.com/codecov-io/bf15bde2c7db1a011b6e)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* ci: Drop Coveralls in favor of Codecov
         - Drop 'python-coveralls' library dependency
* ci: Use Codecov's GitHub Action to upload coverage and avoid 'codecov' library dependency
         - Uses an XML report format
         - Add a generic .coveragerc as recommended.
```
