### PR TITLE
ci: Drop Python 2.7 testing of notebooks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,11 +40,6 @@ env:
 
 jobs:
   include:
-  - name: "Python 2.7 Notebook Tests"
-    python: '2.7'
-    script:
-      - python -m pytest tests/test_notebooks.py
-    after_success: skip
   - name: "Python 3.6 Notebook Tests"
     python: '3.6'
     script:


### PR DESCRIPTION
# Description

Drop testing the notebooks in Python 2.7

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* ci: Drop testing the notebooks in Python 2.7 to avoid errors given the near horizon of Python 2's sunsetting
```
