### PR TITLE
fix: Address LGTM division alert

### DIFF
--- a/src/pyhf/commandline.py
+++ b/src/pyhf/commandline.py
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 # This is only needed for Python 2/3 compatibility
 def ensure_dirs(path):
     try:
-        os.makedirs(path, exist_ok=True)
+        os.makedirs(path, exist_ok=True)  # lgtm [py/call/wrong-named-argument]
     except TypeError:
         if not os.path.exists(path):
             os.makedirs(path)

--- a/src/pyhf/interpolators/code4.py
+++ b/src/pyhf/interpolators/code4.py
@@ -58,10 +58,10 @@ class code4(object):
                 [
                     15.0 / (16 * alpha0),
                     -15.0 / (16 * alpha0),
-                    -7.0 / 16,
-                    -7.0 / 16,
+                    -7.0 / 16.0,
+                    -7.0 / 16.0,
                     1.0 / 16 * alpha0,
-                    -1.0 / 16 * alpha0,
+                    -1.0 / 16.0 * alpha0,
                 ],
                 [
                     3.0 / (2 * math.pow(alpha0, 2)),
@@ -284,10 +284,10 @@ class _slow_code4(object):
                 [
                     15.0 / (16 * self.alpha0),
                     -15.0 / (16 * self.alpha0),
-                    -7.0 / 16,
-                    -7.0 / 16,
+                    -7.0 / 16.0,
+                    -7.0 / 16.0,
                     1.0 / 16 * self.alpha0,
-                    -1.0 / 16 * self.alpha0,
+                    -1.0 / 16.0 * self.alpha0,
                 ],
                 [
                     3.0 / (2 * math.pow(self.alpha0, 2)),


### PR DESCRIPTION
# Description

Address the following LGTM alert:

> Result of division may be truncated as its left and right arguments may both be integers.

and the following LGTM error:

> Keyword argument 'exist_ok' is not a supported parameter name of function makedirs.

The false error above is due to LGTM thinking that the codebase is Python 2 as we have say that it is in our `setup.py`

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Fix LGTM alert: Result of division may be truncated as its left and right arguments may both be integers
* Ingore LGTM error: Keyword argument 'exist_ok' is not a supported parameter name of function makedirs
   - This is a false error that will be irrelevant once Python 2 support is dropped
```
