### PR TITLE
docs: Add copyright holders to license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -175,17 +175,6 @@
 
    END OF TERMS AND CONDITIONS
 
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
    Copyright 2018 pyhf Developers
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018 Lukas Heinrich, Matthew Feickert, Giordon Stark
+   Copyright 2018 pyhf Developers
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2018 Lukas Heinrich, Matthew Feickert, and Giordon Stark
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018 Lukas Heinrich, Matthew Feickert, and Giordon Stark
+   Copyright 2018 Lukas Heinrich, Matthew Feickert, Giordon Stark
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/setup.py
+++ b/setup.py
@@ -85,8 +85,8 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     url='https://github.com/diana-hep/pyhf',
-    author='Lukas Heinrich',
-    author_email='lukas.heinrich@cern.ch',
+    author='Lukas Heinrich, Matthew Feickert, Giordon Stark',
+    author_email='lukas.heinrich@cern.ch, matthew.feickert@cern.ch, gstark@cern.ch',
     license='Apache',
     keywords='physics fitting numpy scipy tensorflow pytorch mxnet dask',
     classifiers=[


### PR DESCRIPTION
# Description

Add the pyhf authors to the Apache license. This should have been done at license creation, but was missed, as it isn't done automatically by GitHub for Apache as it is for BSD3 and MIT.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add pyhf author names to setup.py
* Add the pyhf developers to the Apache license as the copyright holders
```
