### PR TITLE
test: Add regression test on ATLAS sbottom public likelihood

### DIFF
--- a/docs/governance/ROADMAP.md
+++ b/docs/governance/ROADMAP.md
@@ -44,7 +44,7 @@ The roadmap will be executed over mostly Quarter 3 of 2019 through Quarter 1 of 
    - [ ] Write submission to [JOSS](https://joss.theoj.org/) (Issue #502) and write submission to [pyOpenSci](https://www.pyopensci.org/) [2019-Q4 → 2020-Q2]
    - [ ] Contribute to [IRIS-HEP Analysis Systems Milestones](https://docs.google.com/spreadsheets/d/1VKpHlQWXu_p8AUv5E5H_BzqF_i7hh2Z-Id0XPwNHu8o/edit#gid=1864915304) "[Initial roadmap for ecosystem coherency](https://github.com/iris-hep/project-milestones/issues/8)" and "[Initial roadmap for high-level cyberinfrastructure components of analysis system](https://github.com/iris-hep/project-milestones/issues/11)" [2019-Q4 → 2020-Q2]
 2. **Revision and Maintenance**
-   - [ ] Add tests using HEPData published sbottom likelihoods (Issue #518) [2019-Q3]
+   - [x] Add tests using HEPData published sbottom likelihoods (Issue #518) [2019-Q3]
    - [x] Add CI with GitHub Actions and Azure Pipelines (PR #527, Issue #517) [2019-Q3]
    - [ ] Investigate rewrite of pytest fixtures to use modern pytest (Issue #370) [2019-Q3 → 2019-Q4]
    - [ ] Factorize out the statistical fitting portion into `pyhf/stats/__init__.py` (PR #531) [2019-Q3 → 2019-Q4]

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -4,6 +4,7 @@ import tarfile
 import json
 import os
 import pyhf
+import numpy as np
 
 
 # curl -sL https://www.hepdata.net/record/resource/997020?view=true
@@ -68,13 +69,18 @@ def test_sbottom_regionA(regionA_bkgonly_json, regionA_signal_patch_json):
     CLs_obs = result[0].tolist()[0]
     CLs_exp = result[-1].ravel().tolist()
     assert CLs_obs == pytest.approx(0.24443635754482018, rel=1e-6)
-    assert CLs_exp == pytest.approx(
-        [
-            0.09022521939741368,
-            0.19378411715432514,
-            0.3843236961508878,
-            0.6557759457699649,
-            0.8910421945189615,
-        ],
-        rel=1e-6,
+    assert np.all(
+        np.isclose(
+            np.array(CLs_exp),
+            np.array(
+                [
+                    0.09022521939741368,
+                    0.19378411715432514,
+                    0.3843236961508878,
+                    0.6557759457699649,
+                    0.8910421945189615,
+                ]
+            ),
+            rtol=1e-6,
+        )
     )

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1,9 +1,9 @@
-import pyhf
+import pytest
 import requests
 import tarfile
 import json
 import os
-import pytest
+import pyhf
 
 
 # def test_sbottom_download():
@@ -27,6 +27,7 @@ import pytest
 
 @pytest.fixture(scope='module')
 def sbottom_likelihoods_download():
+    """Download the sbottom likelihoods tarball from HEPData"""
     sbottom_HEPData_URL = "https://www.hepdata.net/record/resource/997020?view=true"
     targz_filename = "sbottom_workspaces.tar.gz"
     # Download the tar.gz of the likelihoods
@@ -44,6 +45,7 @@ def sbottom_likelihoods_download():
 
 @pytest.fixture(scope='module')
 def regionA_bkgonly_json(sbottom_likelihoods_download):
+    """Extract the background only model from sbottom Region A"""
     tarfile = sbottom_likelihoods_download
     bkgonly_json_data = (
         tarfile.extractfile(tarfile.getmember("RegionA/BkgOnly.json"))
@@ -55,6 +57,7 @@ def regionA_bkgonly_json(sbottom_likelihoods_download):
 
 @pytest.fixture(scope='module')
 def regionA_signal_patch_json(sbottom_likelihoods_download):
+    """Extract a signal model from sbottom Region A"""
     tarfile = sbottom_likelihoods_download
     signal_patch_json_data = (
         tarfile.extractfile(tarfile.getmember("RegionA/patch.sbottom_1300_205_60.json"))
@@ -64,7 +67,7 @@ def regionA_signal_patch_json(sbottom_likelihoods_download):
     return json.loads(signal_patch_json_data)
 
 
-def test_gzip_file(regionA_bkgonly_json, regionA_signal_patch_json):
+def test_sbottom_regionA(regionA_bkgonly_json, regionA_signal_patch_json):
     bkg_json = regionA_bkgonly_json
     signal_json = regionA_signal_patch_json
     workspace = pyhf.workspace.Workspace(bkg_json)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -34,6 +34,30 @@ def regionA_bkgonly_json(sbottom_likelihoods_download):
 
 
 @pytest.fixture(scope='module')
+def regionB_bkgonly_json(sbottom_likelihoods_download):
+    """Extract the background only model from sbottom Region B"""
+    tarfile = sbottom_likelihoods_download
+    bkgonly_json = (
+        tarfile.extractfile(tarfile.getmember("RegionB/BkgOnly.json"))
+        .read()
+        .decode("utf8")
+    )
+    return json.loads(bkgonly_json)
+
+
+@pytest.fixture(scope='module')
+def regionC_bkgonly_json(sbottom_likelihoods_download):
+    """Extract the background only model from sbottom Region C"""
+    tarfile = sbottom_likelihoods_download
+    bkgonly_json = (
+        tarfile.extractfile(tarfile.getmember("RegionC/BkgOnly.json"))
+        .read()
+        .decode("utf8")
+    )
+    return json.loads(bkgonly_json)
+
+
+@pytest.fixture(scope='module')
 def regionA_signal_patch_json(sbottom_likelihoods_download):
     """Extract a signal model from sbottom Region A"""
     tarfile = sbottom_likelihoods_download
@@ -45,11 +69,47 @@ def regionA_signal_patch_json(sbottom_likelihoods_download):
     return json.loads(signal_patch_json)
 
 
-def test_sbottom_regionA(regionA_bkgonly_json, regionA_signal_patch_json):
-    workspace = pyhf.workspace.Workspace(regionA_bkgonly_json)
+@pytest.fixture(scope='module')
+def regionB_signal_patch_json(sbottom_likelihoods_download):
+    """Extract a signal model from sbottom Region B"""
+    tarfile = sbottom_likelihoods_download
+    signal_patch_json = (
+        tarfile.extractfile(tarfile.getmember("RegionB/patch.sbottom_1000_205_60.json"))
+        .read()
+        .decode("utf8")
+    )
+    return json.loads(signal_patch_json)
+
+
+@pytest.fixture(scope='module')
+def regionC_signal_patch_json(sbottom_likelihoods_download):
+    """Extract a signal model from sbottom Region C"""
+    tarfile = sbottom_likelihoods_download
+    signal_patch_json = (
+        tarfile.extractfile(tarfile.getmember("RegionC/patch.sbottom_1000_205_60.json"))
+        .read()
+        .decode("utf8")
+    )
+    return json.loads(signal_patch_json)
+
+
+def calculate_CLs(bkgonly_json, signal_patch_json):
+    """
+    Calculate the observed CLs and the expected CLs band from a background only
+    and signal patch.
+
+    Args:
+        bkgonly_json
+        signal_patch_json
+
+    Returns:
+        CLs_obs: The observed CLs value
+        CLs_exp: List of the expected CLs value band
+    """
+    workspace = pyhf.workspace.Workspace(bkgonly_json)
     model = workspace.model(
         measurement_name=None,
-        patches=[regionA_signal_patch_json],
+        patches=[signal_patch_json],
         modifier_settings={
             'normsys': {'interpcode': 'code4'},
             'histosys': {'interpcode': 'code4p'},
@@ -58,8 +118,11 @@ def test_sbottom_regionA(regionA_bkgonly_json, regionA_signal_patch_json):
     result = pyhf.utils.hypotest(
         1.0, workspace.data(model), model, qtilde=True, return_expected_set=True
     )
-    CLs_obs = result[0].tolist()[0]
-    CLs_exp = result[-1].ravel().tolist()
+    return result[0].tolist()[0], result[-1].ravel().tolist()
+
+
+def test_sbottom_regionA(regionA_bkgonly_json, regionA_signal_patch_json):
+    CLs_obs, CLs_exp = calculate_CLs(regionA_bkgonly_json, regionA_signal_patch_json)
     assert CLs_obs == pytest.approx(0.2444363575448201, rel=1e-5)
     assert np.all(
         np.isclose(

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -162,6 +162,7 @@ def test_sbottom_regionC_1000_205_60(
         sbottom_regionC_bkgonly_json, sbottom_regionC_1000_205_60_patch_json
     )
     assert CLs_obs == pytest.approx(0.9424009499519606, rel=1e-5)
+    # TODO: Lower tolerance to 1e-5 once Python 2.7 is dropped
     assert np.all(
         np.isclose(
             np.array(CLs_exp),
@@ -174,6 +175,6 @@ def test_sbottom_regionC_1000_205_60(
                     0.9971958190844394,
                 ]
             ),
-            rtol=1e-5,
+            rtol=1e-4,
         )
     )

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -57,7 +57,7 @@ def regionC_bkgonly_json(sbottom_likelihoods_download):
     return json.loads(bkgonly_json)
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture()
 def regionA_signal_patch_json(sbottom_likelihoods_download):
     """Extract a signal model from sbottom Region A"""
     tarfile = sbottom_likelihoods_download
@@ -69,7 +69,7 @@ def regionA_signal_patch_json(sbottom_likelihoods_download):
     return json.loads(signal_patch_json)
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture()
 def regionB_signal_patch_json(sbottom_likelihoods_download):
     """Extract a signal model from sbottom Region B"""
     tarfile = sbottom_likelihoods_download
@@ -81,7 +81,7 @@ def regionB_signal_patch_json(sbottom_likelihoods_download):
     return json.loads(signal_patch_json)
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture()
 def regionC_signal_patch_json(sbottom_likelihoods_download):
     """Extract a signal model from sbottom Region C"""
     tarfile = sbottom_likelihoods_download

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -51,19 +51,19 @@ def regionA_signal_patch_json(sbottom_likelihoods_download):
 
 
 def test_sbottom_regionA(regionA_bkgonly_json, regionA_signal_patch_json):
-    bkg_json = regionA_bkgonly_json
-    signal_json = regionA_signal_patch_json
-    workspace = pyhf.workspace.Workspace(bkg_json)
-    patched = workspace.model(
+    bkg_only = regionA_bkgonly_json
+    signal_patch = regionA_signal_patch_json
+    workspace = pyhf.workspace.Workspace(bkg_only)
+    model = workspace.model(
         measurement_name=None,
-        patches=[signal_json],
+        patches=[signal_patch],
         modifier_settings={
             'normsys': {'interpcode': 'code4'},
             'histosys': {'interpcode': 'code4p'},
         },
     )
     result = pyhf.utils.hypotest(
-        1.0, workspace.data(patched), patched, qtilde=True, return_expected_set=True
+        1.0, workspace.data(model), model, qtilde=True, return_expected_set=True
     )
     CLs_obs = result[0].tolist()[0]
     CLs_exp = result[-1].ravel().tolist()

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -26,57 +26,16 @@ def sbottom_likelihoods_download():
     os.remove(targz_filename)
 
 
-def extract_json_from_tarfile(tarfile, json_name):
-    json_file = tarfile.extractfile(tarfile.getmember(json_name)).read().decode("utf8")
-    return json.loads(json_file)
+# Factory as fixture pattern
+@pytest.fixture
+def get_json_from_tarfile():
+    def _get_json_from_tarfile(tarfile, json_name):
+        json_file = (
+            tarfile.extractfile(tarfile.getmember(json_name)).read().decode("utf8")
+        )
+        return json.loads(json_file)
 
-
-@pytest.fixture(scope='module')
-def sbottom_regionA_bkgonly_json(sbottom_likelihoods_download):
-    """Extract the background only model from sbottom Region A"""
-    return extract_json_from_tarfile(
-        sbottom_likelihoods_download, "RegionA/BkgOnly.json"
-    )
-
-
-@pytest.fixture(scope='module')
-def sbottom_regionB_bkgonly_json(sbottom_likelihoods_download):
-    """Extract the background only model from sbottom Region B"""
-    return extract_json_from_tarfile(
-        sbottom_likelihoods_download, "RegionB/BkgOnly.json"
-    )
-
-
-@pytest.fixture(scope='module')
-def sbottom_regionC_bkgonly_json(sbottom_likelihoods_download):
-    """Extract the background only model from sbottom Region C"""
-    return extract_json_from_tarfile(
-        sbottom_likelihoods_download, "RegionC/BkgOnly.json"
-    )
-
-
-@pytest.fixture()
-def sbottom_regionA_1300_205_60_patch_json(sbottom_likelihoods_download):
-    """Extract a signal model from sbottom Region A"""
-    return extract_json_from_tarfile(
-        sbottom_likelihoods_download, "RegionA/patch.sbottom_1300_205_60.json"
-    )
-
-
-@pytest.fixture()
-def sbottom_regionB_1000_205_60_patch_json(sbottom_likelihoods_download):
-    """Extract a signal model from sbottom Region B"""
-    return extract_json_from_tarfile(
-        sbottom_likelihoods_download, "RegionB/patch.sbottom_1000_205_60.json"
-    )
-
-
-@pytest.fixture()
-def sbottom_regionC_1000_205_60_patch_json(sbottom_likelihoods_download):
-    """Extract a signal model from sbottom Region C"""
-    return extract_json_from_tarfile(
-        sbottom_likelihoods_download, "RegionC/patch.sbottom_1000_205_60.json"
-    )
+    return _get_json_from_tarfile
 
 
 def calculate_CLs(bkgonly_json, signal_patch_json):
@@ -108,8 +67,14 @@ def calculate_CLs(bkgonly_json, signal_patch_json):
 
 
 def test_sbottom_regionA_1300_205_60(
-    sbottom_regionA_bkgonly_json, sbottom_regionA_1300_205_60_patch_json
+    sbottom_likelihoods_download, get_json_from_tarfile
 ):
+    sbottom_regionA_bkgonly_json = get_json_from_tarfile(
+        sbottom_likelihoods_download, "RegionA/BkgOnly.json"
+    )
+    sbottom_regionA_1300_205_60_patch_json = get_json_from_tarfile(
+        sbottom_likelihoods_download, "RegionA/patch.sbottom_1300_205_60.json"
+    )
     CLs_obs, CLs_exp = calculate_CLs(
         sbottom_regionA_bkgonly_json, sbottom_regionA_1300_205_60_patch_json
     )
@@ -132,8 +97,14 @@ def test_sbottom_regionA_1300_205_60(
 
 
 def test_sbottom_regionB_1000_205_60(
-    sbottom_regionB_bkgonly_json, sbottom_regionB_1000_205_60_patch_json
+    sbottom_likelihoods_download, get_json_from_tarfile
 ):
+    sbottom_regionB_bkgonly_json = get_json_from_tarfile(
+        sbottom_likelihoods_download, "RegionB/BkgOnly.json"
+    )
+    sbottom_regionB_1000_205_60_patch_json = get_json_from_tarfile(
+        sbottom_likelihoods_download, "RegionB/patch.sbottom_1000_205_60.json"
+    )
     CLs_obs, CLs_exp = calculate_CLs(
         sbottom_regionB_bkgonly_json, sbottom_regionB_1000_205_60_patch_json
     )
@@ -156,8 +127,14 @@ def test_sbottom_regionB_1000_205_60(
 
 
 def test_sbottom_regionC_1000_205_60(
-    sbottom_regionC_bkgonly_json, sbottom_regionC_1000_205_60_patch_json
+    sbottom_likelihoods_download, get_json_from_tarfile
 ):
+    sbottom_regionC_bkgonly_json = get_json_from_tarfile(
+        sbottom_likelihoods_download, "RegionC/BkgOnly.json"
+    )
+    sbottom_regionC_1000_205_60_patch_json = get_json_from_tarfile(
+        sbottom_likelihoods_download, "RegionC/patch.sbottom_1000_205_60.json"
+    )
     CLs_obs, CLs_exp = calculate_CLs(
         sbottom_regionC_bkgonly_json, sbottom_regionC_1000_205_60_patch_json
     )

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -32,7 +32,7 @@ def extract_json_from_tarfile(tarfile, json_name):
 
 
 @pytest.fixture(scope='module')
-def regionA_bkgonly_json(sbottom_likelihoods_download):
+def sbottom_regionA_bkgonly_json(sbottom_likelihoods_download):
     """Extract the background only model from sbottom Region A"""
     return extract_json_from_tarfile(
         sbottom_likelihoods_download, "RegionA/BkgOnly.json"
@@ -40,7 +40,7 @@ def regionA_bkgonly_json(sbottom_likelihoods_download):
 
 
 @pytest.fixture(scope='module')
-def regionB_bkgonly_json(sbottom_likelihoods_download):
+def sbottom_regionB_bkgonly_json(sbottom_likelihoods_download):
     """Extract the background only model from sbottom Region B"""
     return extract_json_from_tarfile(
         sbottom_likelihoods_download, "RegionB/BkgOnly.json"
@@ -48,7 +48,7 @@ def regionB_bkgonly_json(sbottom_likelihoods_download):
 
 
 @pytest.fixture(scope='module')
-def regionC_bkgonly_json(sbottom_likelihoods_download):
+def sbottom_regionC_bkgonly_json(sbottom_likelihoods_download):
     """Extract the background only model from sbottom Region C"""
     return extract_json_from_tarfile(
         sbottom_likelihoods_download, "RegionC/BkgOnly.json"
@@ -56,7 +56,7 @@ def regionC_bkgonly_json(sbottom_likelihoods_download):
 
 
 @pytest.fixture()
-def regionA_signal_patch_json(sbottom_likelihoods_download):
+def sbottom_regionA_1300_205_60_patch_json(sbottom_likelihoods_download):
     """Extract a signal model from sbottom Region A"""
     return extract_json_from_tarfile(
         sbottom_likelihoods_download, "RegionA/patch.sbottom_1300_205_60.json"
@@ -64,7 +64,7 @@ def regionA_signal_patch_json(sbottom_likelihoods_download):
 
 
 @pytest.fixture()
-def regionB_signal_patch_json(sbottom_likelihoods_download):
+def sbottom_regionB_1000_205_60_patch_json(sbottom_likelihoods_download):
     """Extract a signal model from sbottom Region B"""
     return extract_json_from_tarfile(
         sbottom_likelihoods_download, "RegionB/patch.sbottom_1000_205_60.json"
@@ -72,7 +72,7 @@ def regionB_signal_patch_json(sbottom_likelihoods_download):
 
 
 @pytest.fixture()
-def regionC_signal_patch_json(sbottom_likelihoods_download):
+def sbottom_regionC_1000_205_60_patch_json(sbottom_likelihoods_download):
     """Extract a signal model from sbottom Region C"""
     return extract_json_from_tarfile(
         sbottom_likelihoods_download, "RegionC/patch.sbottom_1000_205_60.json"
@@ -107,8 +107,12 @@ def calculate_CLs(bkgonly_json, signal_patch_json):
     return result[0].tolist()[0], result[-1].ravel().tolist()
 
 
-def test_sbottom_regionA(regionA_bkgonly_json, regionA_signal_patch_json):
-    CLs_obs, CLs_exp = calculate_CLs(regionA_bkgonly_json, regionA_signal_patch_json)
+def test_sbottom_regionA_1300_205_60(
+    sbottom_regionA_bkgonly_json, sbottom_regionA_1300_205_60_patch_json
+):
+    CLs_obs, CLs_exp = calculate_CLs(
+        sbottom_regionA_bkgonly_json, sbottom_regionA_1300_205_60_patch_json
+    )
     assert CLs_obs == pytest.approx(0.2444363575448201, rel=1e-5)
     assert np.all(
         np.isclose(
@@ -127,8 +131,12 @@ def test_sbottom_regionA(regionA_bkgonly_json, regionA_signal_patch_json):
     )
 
 
-def test_sbottom_regionB(regionB_bkgonly_json, regionB_signal_patch_json):
-    CLs_obs, CLs_exp = calculate_CLs(regionB_bkgonly_json, regionB_signal_patch_json)
+def test_sbottom_regionB_1000_205_60(
+    sbottom_regionB_bkgonly_json, sbottom_regionB_1000_205_60_patch_json
+):
+    CLs_obs, CLs_exp = calculate_CLs(
+        sbottom_regionB_bkgonly_json, sbottom_regionB_1000_205_60_patch_json
+    )
     assert CLs_obs == pytest.approx(0.999346961987008, rel=1e-5)
     assert np.all(
         np.isclose(
@@ -147,8 +155,12 @@ def test_sbottom_regionB(regionB_bkgonly_json, regionB_signal_patch_json):
     )
 
 
-def test_sbottom_regionC(regionC_bkgonly_json, regionC_signal_patch_json):
-    CLs_obs, CLs_exp = calculate_CLs(regionC_bkgonly_json, regionC_signal_patch_json)
+def test_sbottom_regionC_1000_205_60(
+    sbottom_regionC_bkgonly_json, sbottom_regionC_1000_205_60_patch_json
+):
+    CLs_obs, CLs_exp = calculate_CLs(
+        sbottom_regionC_bkgonly_json, sbottom_regionC_1000_205_60_patch_json
+    )
     assert CLs_obs == pytest.approx(0.9424021663134358, rel=1e-5)
     # TODO: Lower tolerance to 1e-5 once Python 2.7 is dropped
     assert np.all(

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -96,6 +96,66 @@ def test_sbottom_regionA_1300_205_60(
     )
 
 
+def test_sbottom_regionA_1400_950_60(
+    sbottom_likelihoods_download, get_json_from_tarfile
+):
+    sbottom_regionA_bkgonly_json = get_json_from_tarfile(
+        sbottom_likelihoods_download, "RegionA/BkgOnly.json"
+    )
+    sbottom_regionA_1400_950_60_patch_json = get_json_from_tarfile(
+        sbottom_likelihoods_download, "RegionA/patch.sbottom_1400_950_60.json"
+    )
+    CLs_obs, CLs_exp = calculate_CLs(
+        sbottom_regionA_bkgonly_json, sbottom_regionA_1400_950_60_patch_json
+    )
+    assert CLs_obs == pytest.approx(0.0213732548585359, rel=1e-5)
+    assert np.all(
+        np.isclose(
+            np.array(CLs_exp),
+            np.array(
+                [
+                    0.0026446861433130,
+                    0.0139766677574991,
+                    0.0649728508540893,
+                    0.2364443957087021,
+                    0.5744835529584968,
+                ]
+            ),
+            rtol=1e-5,
+        )
+    )
+
+
+def test_sbottom_regionA_1500_850_60(
+    sbottom_likelihoods_download, get_json_from_tarfile
+):
+    sbottom_regionA_bkgonly_json = get_json_from_tarfile(
+        sbottom_likelihoods_download, "RegionA/BkgOnly.json"
+    )
+    sbottom_regionA_1500_850_60_patch_json = get_json_from_tarfile(
+        sbottom_likelihoods_download, "RegionA/patch.sbottom_1500_850_60.json"
+    )
+    CLs_obs, CLs_exp = calculate_CLs(
+        sbottom_regionA_bkgonly_json, sbottom_regionA_1500_850_60_patch_json
+    )
+    assert CLs_obs == pytest.approx(0.0453677409764101, rel=1e-5)
+    assert np.all(
+        np.isclose(
+            np.array(CLs_exp),
+            np.array(
+                [
+                    0.0059847029077065,
+                    0.0261035161266011,
+                    0.1009398575261459,
+                    0.3101988586187604,
+                    0.6553686728646031,
+                ]
+            ),
+            rtol=1e-5,
+        )
+    )
+
+
 def test_sbottom_regionB_1000_205_60(
     sbottom_likelihoods_download, get_json_from_tarfile
 ):

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -21,76 +21,57 @@ def sbottom_likelihoods_download():
     os.remove(targz_filename)
 
 
+def extract_json_from_tarfile(tarfile, json_name):
+    json_file = tarfile.extractfile(tarfile.getmember(json_name)).read().decode("utf8")
+    return json.loads(json_file)
+
+
 @pytest.fixture(scope='module')
 def regionA_bkgonly_json(sbottom_likelihoods_download):
     """Extract the background only model from sbottom Region A"""
-    tarfile = sbottom_likelihoods_download
-    bkgonly_json = (
-        tarfile.extractfile(tarfile.getmember("RegionA/BkgOnly.json"))
-        .read()
-        .decode("utf8")
+    return extract_json_from_tarfile(
+        sbottom_likelihoods_download, "RegionA/BkgOnly.json"
     )
-    return json.loads(bkgonly_json)
 
 
 @pytest.fixture(scope='module')
 def regionB_bkgonly_json(sbottom_likelihoods_download):
     """Extract the background only model from sbottom Region B"""
-    tarfile = sbottom_likelihoods_download
-    bkgonly_json = (
-        tarfile.extractfile(tarfile.getmember("RegionB/BkgOnly.json"))
-        .read()
-        .decode("utf8")
+    return extract_json_from_tarfile(
+        sbottom_likelihoods_download, "RegionB/BkgOnly.json"
     )
-    return json.loads(bkgonly_json)
 
 
 @pytest.fixture(scope='module')
 def regionC_bkgonly_json(sbottom_likelihoods_download):
     """Extract the background only model from sbottom Region C"""
-    tarfile = sbottom_likelihoods_download
-    bkgonly_json = (
-        tarfile.extractfile(tarfile.getmember("RegionC/BkgOnly.json"))
-        .read()
-        .decode("utf8")
+    return extract_json_from_tarfile(
+        sbottom_likelihoods_download, "RegionC/BkgOnly.json"
     )
-    return json.loads(bkgonly_json)
 
 
 @pytest.fixture()
 def regionA_signal_patch_json(sbottom_likelihoods_download):
     """Extract a signal model from sbottom Region A"""
-    tarfile = sbottom_likelihoods_download
-    signal_patch_json = (
-        tarfile.extractfile(tarfile.getmember("RegionA/patch.sbottom_1300_205_60.json"))
-        .read()
-        .decode("utf8")
+    return extract_json_from_tarfile(
+        sbottom_likelihoods_download, "RegionA/patch.sbottom_1300_205_60.json"
     )
-    return json.loads(signal_patch_json)
 
 
 @pytest.fixture()
 def regionB_signal_patch_json(sbottom_likelihoods_download):
     """Extract a signal model from sbottom Region B"""
-    tarfile = sbottom_likelihoods_download
-    signal_patch_json = (
-        tarfile.extractfile(tarfile.getmember("RegionB/patch.sbottom_1000_205_60.json"))
-        .read()
-        .decode("utf8")
+    return extract_json_from_tarfile(
+        sbottom_likelihoods_download, "RegionB/patch.sbottom_1000_205_60.json"
     )
-    return json.loads(signal_patch_json)
 
 
 @pytest.fixture()
 def regionC_signal_patch_json(sbottom_likelihoods_download):
     """Extract a signal model from sbottom Region C"""
-    tarfile = sbottom_likelihoods_download
-    signal_patch_json = (
-        tarfile.extractfile(tarfile.getmember("RegionC/patch.sbottom_1000_205_60.json"))
-        .read()
-        .decode("utf8")
+    return extract_json_from_tarfile(
+        sbottom_likelihoods_download, "RegionC/patch.sbottom_1000_205_60.json"
     )
-    return json.loads(signal_patch_json)
 
 
 def calculate_CLs(bkgonly_json, signal_patch_json):

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -46,12 +46,10 @@ def regionA_signal_patch_json(sbottom_likelihoods_download):
 
 
 def test_sbottom_regionA(regionA_bkgonly_json, regionA_signal_patch_json):
-    bkg_only = regionA_bkgonly_json
-    signal_patch = regionA_signal_patch_json
-    workspace = pyhf.workspace.Workspace(bkg_only)
+    workspace = pyhf.workspace.Workspace(regionA_bkgonly_json)
     model = workspace.model(
         measurement_name=None,
-        patches=[signal_patch],
+        patches=[regionA_signal_patch_json],
         modifier_settings={
             'normsys': {'interpcode': 'code4'},
             'histosys': {'interpcode': 'code4p'},

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -156,29 +156,29 @@ def test_sbottom_regionA_1500_850_60(
     )
 
 
-def test_sbottom_regionB_1500_850_60(
+def test_sbottom_regionB_1400_550_60(
     sbottom_likelihoods_download, get_json_from_tarfile
 ):
     sbottom_regionB_bkgonly_json = get_json_from_tarfile(
         sbottom_likelihoods_download, "RegionB/BkgOnly.json"
     )
-    sbottom_regionB_1500_850_60_patch_json = get_json_from_tarfile(
-        sbottom_likelihoods_download, "RegionB/patch.sbottom_1500_850_60.json"
+    sbottom_regionB_1400_550_60_patch_json = get_json_from_tarfile(
+        sbottom_likelihoods_download, "RegionB/patch.sbottom_1400_550_60.json"
     )
     CLs_obs, CLs_exp = calculate_CLs(
-        sbottom_regionB_bkgonly_json, sbottom_regionB_1500_850_60_patch_json
+        sbottom_regionB_bkgonly_json, sbottom_regionB_1400_550_60_patch_json
     )
-    assert CLs_obs == pytest.approx(0.9999893250416583, rel=1e-5)
+    assert CLs_obs == pytest.approx(0.9744675266677597, rel=1e-5)
     assert np.all(
         np.isclose(
             np.array(CLs_exp),
             np.array(
                 [
-                    0.9999682931142808,
-                    0.9999796235899027,
-                    0.9999893398756928,
-                    0.9999961574993774,
-                    0.999999261851925,
+                    0.9338879894557114,
+                    0.9569045303300702,
+                    0.9771296335437559,
+                    0.9916370124133669,
+                    0.9983701133999316,
                 ]
             ),
             rtol=1e-5,

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -6,23 +6,10 @@ import os
 import pyhf
 
 
-# def test_sbottom_download():
-#     # curl -sL hepdata.net/record/resourc…
-#     # | tar -O -xzv RegionA/BkgOnly.json
-#     # | pyhf cls --patch <(curl -sL hepdata.net/record/resourc…
-#     # | tar -O -xzv RegionA/patch.sbottom_1300_205_60.json)
-#     sbottom_HEPData_URL = "https://www.hepdata.net/record/resource/997020?view=true"
-#     response = requests.get(sbottom_HEPData_URL, stream=True)
-#     response.raise_for_status()
-#
-#     with open('/home/mcf/Code/GitHub/pyhf/output.gz', 'wb') as handle:
-#         for block in response.iter_content(1024):
-#             handle.write(block)
-#     # response.content is a GzipFile object
-#     # if downloaded with webbrowser is named HEPData_workspaces.tar.gz
-#     print(tarfile.is_tarfile(response.content))
-#     # tar_file = tarfile.open(name="archive", mode="r:gz", fileobj=response.content)
-#     # print(tar_file)
+# curl -sL https://www.hepdata.net/record/resource/997020?view=true
+# | tar -O -xzv RegionA/BkgOnly.json
+# | pyhf cls --patch <(curl -sL https://www.hepdata.net/record/resource/997020?view=true
+# | tar -O -xzv RegionA/patch.sbottom_1300_205_60.json)
 
 
 @pytest.fixture(scope='module')
@@ -30,10 +17,6 @@ def sbottom_likelihoods_download():
     """Download the sbottom likelihoods tarball from HEPData"""
     sbottom_HEPData_URL = "https://www.hepdata.net/record/resource/997020?view=true"
     targz_filename = "sbottom_workspaces.tar.gz"
-    # Download the tar.gz of the likelihoods
-    # file_path = os.path.join(tmp_path.strpath, sbottom_HEPData_URL)
-    # file_name = tmp_path.join(targz_filename)
-    # response = requests.get(tmp_path.join(sbottom_HEPData_URL), stream=True)
     response = requests.get(sbottom_HEPData_URL, stream=True)
     assert response.status_code == 200
     with open(targz_filename, 'wb') as file:
@@ -82,24 +65,15 @@ def test_sbottom_regionA(regionA_bkgonly_json, regionA_signal_patch_json):
     result = pyhf.utils.hypotest(
         1.0, workspace.data(patched), patched, qtilde=True, return_expected_set=True
     )
-    result = {'CLs_obs': result[0].tolist()[0], 'CLs_exp': result[-1].ravel().tolist()}
-    print(json.dumps(result, indent=4, sort_keys=True))
-
-    # command line
-    # {
-    #     "CLs_exp": [
-    #         0.09022521939741368,
-    #         0.19378411715432514,
-    #         0.3843236961508878,
-    #         0.6557759457699649,
-    #         0.8910421945189615
-    #     ],
-    #     "CLs_obs": 0.24443635754482018
-    # }
-    # pytest
-    # {'CLs_obs': 0.24443635754482018, 'CLs_exp': [0.09022521939741368, 0.19378411715432514, 0.3843236961508878, 0.6557759457699649, 0.8910421945189615]}
-
-    # print(s)
-    # TODO: Patch bkg_json with signal_json to create workspace
-    # Then validate
-    # assert pyhf.utils.validate(workspace, 'workspace.json')
+    CLs_obs = result[0].tolist()[0]
+    CLs_exp = result[-1].ravel().tolist()
+    assert CLs_obs == pytest.approx(0.24443635754482018)
+    assert CLs_exp == pytest.approx(
+        [
+            0.09022521939741368,
+            0.19378411715432514,
+            0.3843236961508878,
+            0.6557759457699649,
+            0.8910421945189615,
+        ]
+    )

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -62,7 +62,7 @@ def test_sbottom_regionA(regionA_bkgonly_json, regionA_signal_patch_json):
     )
     CLs_obs = result[0].tolist()[0]
     CLs_exp = result[-1].ravel().tolist()
-    assert CLs_obs == pytest.approx(0.2444363575448201, rel=1e-7)
+    assert CLs_obs == pytest.approx(0.2444363575448201, rel=1e-5)
     assert np.all(
         np.isclose(
             np.array(CLs_exp),
@@ -75,6 +75,6 @@ def test_sbottom_regionA(regionA_bkgonly_json, regionA_signal_patch_json):
                     0.8910421945189615,
                 ]
             ),
-            rtol=1e-7,
+            rtol=1e-5,
         )
     )

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -78,17 +78,17 @@ def test_sbottom_regionA_1300_205_60(
     CLs_obs, CLs_exp = calculate_CLs(
         sbottom_regionA_bkgonly_json, sbottom_regionA_1300_205_60_patch_json
     )
-    assert CLs_obs == pytest.approx(0.2444363575448201, rel=1e-5)
+    assert CLs_obs == pytest.approx(0.24443627759085326, rel=1e-5)
     assert np.all(
         np.isclose(
             np.array(CLs_exp),
             np.array(
                 [
-                    0.0902252193974136,
-                    0.1937841171543251,
-                    0.3843236961508878,
-                    0.6557759457699649,
-                    0.8910421945189615,
+                    0.09022509053507759,
+                    0.1937839194960632,
+                    0.38432344933992,
+                    0.6557757334303531,
+                    0.8910420971601081,
                 ]
             ),
             rtol=1e-5,
@@ -108,17 +108,17 @@ def test_sbottom_regionA_1400_950_60(
     CLs_obs, CLs_exp = calculate_CLs(
         sbottom_regionA_bkgonly_json, sbottom_regionA_1400_950_60_patch_json
     )
-    assert CLs_obs == pytest.approx(0.0213732548585359, rel=1e-5)
+    assert CLs_obs == pytest.approx(0.021373283911064852, rel=1e-5)
     assert np.all(
         np.isclose(
             np.array(CLs_exp),
             np.array(
                 [
-                    0.0026446861433130,
-                    0.0139766677574991,
-                    0.0649728508540893,
-                    0.2364443957087021,
-                    0.5744835529584968,
+                    0.002644707461012826,
+                    0.013976754489151644,
+                    0.06497313811425813,
+                    0.23644505123524753,
+                    0.5744843501873754,
                 ]
             ),
             rtol=1e-5,
@@ -138,15 +138,15 @@ def test_sbottom_regionA_1500_850_60(
     CLs_obs, CLs_exp = calculate_CLs(
         sbottom_regionA_bkgonly_json, sbottom_regionA_1500_850_60_patch_json
     )
-    assert CLs_obs == pytest.approx(0.0453677409764101, rel=1e-5)
+    assert CLs_obs == pytest.approx(0.04536774062150508, rel=1e-5)
     assert np.all(
         np.isclose(
             np.array(CLs_exp),
             np.array(
                 [
-                    0.0059847029077065,
-                    0.0261035161266011,
-                    0.1009398575261459,
+                    0.0059847029077065295,
+                    0.026103516126601122,
+                    0.10093985752614597,
                     0.3101988586187604,
                     0.6553686728646031,
                 ]
@@ -156,29 +156,29 @@ def test_sbottom_regionA_1500_850_60(
     )
 
 
-def test_sbottom_regionB_1000_205_60(
+def test_sbottom_regionB_1500_850_60(
     sbottom_likelihoods_download, get_json_from_tarfile
 ):
     sbottom_regionB_bkgonly_json = get_json_from_tarfile(
         sbottom_likelihoods_download, "RegionB/BkgOnly.json"
     )
-    sbottom_regionB_1000_205_60_patch_json = get_json_from_tarfile(
-        sbottom_likelihoods_download, "RegionB/patch.sbottom_1000_205_60.json"
+    sbottom_regionB_1500_850_60_patch_json = get_json_from_tarfile(
+        sbottom_likelihoods_download, "RegionB/patch.sbottom_1500_850_60.json"
     )
     CLs_obs, CLs_exp = calculate_CLs(
-        sbottom_regionB_bkgonly_json, sbottom_regionB_1000_205_60_patch_json
+        sbottom_regionB_bkgonly_json, sbottom_regionB_1500_850_60_patch_json
     )
-    assert CLs_obs == pytest.approx(0.999346961987008, rel=1e-5)
+    assert CLs_obs == pytest.approx(0.9999893250416583, rel=1e-5)
     assert np.all(
         np.isclose(
             np.array(CLs_exp),
             np.array(
                 [
-                    0.998057935502826,
-                    0.998751430736146,
-                    0.999346535249686,
-                    0.999764360117854,
-                    0.999954715109718,
+                    0.9999682931142808,
+                    0.9999796235899027,
+                    0.9999893398756928,
+                    0.9999961574993774,
+                    0.999999261851925,
                 ]
             ),
             rtol=1e-5,

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -161,20 +161,19 @@ def test_sbottom_regionC_1000_205_60(
     CLs_obs, CLs_exp = calculate_CLs(
         sbottom_regionC_bkgonly_json, sbottom_regionC_1000_205_60_patch_json
     )
-    assert CLs_obs == pytest.approx(0.9424021663134358, rel=1e-5)
-    # TODO: Lower tolerance to 1e-5 once Python 2.7 is dropped
+    assert CLs_obs == pytest.approx(0.9424009499519606, rel=1e-5)
     assert np.all(
         np.isclose(
             np.array(CLs_exp),
             np.array(
                 [
-                    0.8906506884676416,
-                    0.9280287127442725,
-                    0.9614301796189283,
-                    0.9857558128338463,
-                    0.9971959212073871,
+                    0.8906470732412857,
+                    0.9280262743211622,
+                    0.9614288407343238,
+                    0.9857553063165135,
+                    0.9971958190844394,
                 ]
             ),
-            rtol=1e-4,
+            rtol=1e-5,
         )
     )

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -25,24 +25,24 @@ def sbottom_likelihoods_download():
 def regionA_bkgonly_json(sbottom_likelihoods_download):
     """Extract the background only model from sbottom Region A"""
     tarfile = sbottom_likelihoods_download
-    bkgonly_json_data = (
+    bkgonly_json = (
         tarfile.extractfile(tarfile.getmember("RegionA/BkgOnly.json"))
         .read()
         .decode("utf8")
     )
-    return json.loads(bkgonly_json_data)
+    return json.loads(bkgonly_json)
 
 
 @pytest.fixture(scope='module')
 def regionA_signal_patch_json(sbottom_likelihoods_download):
     """Extract a signal model from sbottom Region A"""
     tarfile = sbottom_likelihoods_download
-    signal_patch_json_data = (
+    signal_patch_json = (
         tarfile.extractfile(tarfile.getmember("RegionA/patch.sbottom_1300_205_60.json"))
         .read()
         .decode("utf8")
     )
-    return json.loads(signal_patch_json_data)
+    return json.loads(signal_patch_json)
 
 
 def test_sbottom_regionA(regionA_bkgonly_json, regionA_signal_patch_json):

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -67,7 +67,7 @@ def test_sbottom_regionA(regionA_bkgonly_json, regionA_signal_patch_json):
     )
     CLs_obs = result[0].tolist()[0]
     CLs_exp = result[-1].ravel().tolist()
-    assert CLs_obs == pytest.approx(0.24443635754482018)
+    assert CLs_obs == pytest.approx(0.24443635754482018, rel=1e-6)
     assert CLs_exp == pytest.approx(
         [
             0.09022521939741368,
@@ -75,5 +75,6 @@ def test_sbottom_regionA(regionA_bkgonly_json, regionA_signal_patch_json):
             0.3843236961508878,
             0.6557759457699649,
             0.8910421945189615,
-        ]
+        ],
+        rel=1e-6,
     )

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -7,12 +7,6 @@ import pyhf
 import numpy as np
 
 
-# curl -sL https://www.hepdata.net/record/resource/997020?view=true
-# | tar -O -xzv RegionA/BkgOnly.json
-# | pyhf cls --patch <(curl -sL https://www.hepdata.net/record/resource/997020?view=true
-# | tar -O -xzv RegionA/patch.sbottom_1300_205_60.json)
-
-
 @pytest.fixture(scope='module')
 def sbottom_likelihoods_download():
     """Download the sbottom likelihoods tarball from HEPData"""
@@ -68,19 +62,19 @@ def test_sbottom_regionA(regionA_bkgonly_json, regionA_signal_patch_json):
     )
     CLs_obs = result[0].tolist()[0]
     CLs_exp = result[-1].ravel().tolist()
-    assert CLs_obs == pytest.approx(0.24443635754482018, rel=1e-6)
+    assert CLs_obs == pytest.approx(0.2444363575448201, rel=1e-7)
     assert np.all(
         np.isclose(
             np.array(CLs_exp),
             np.array(
                 [
-                    0.09022521939741368,
-                    0.19378411715432514,
+                    0.0902252193974136,
+                    0.1937841171543251,
                     0.3843236961508878,
                     0.6557759457699649,
                     0.8910421945189615,
                 ]
             ),
-            rtol=1e-6,
+            rtol=1e-7,
         )
     )

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -99,8 +99,8 @@ def calculate_CLs(bkgonly_json, signal_patch_json):
     and signal patch.
 
     Args:
-        bkgonly_json
-        signal_patch_json
+        bkgonly_json: The JSON for the background only model
+        signal_patch_json: The JSON Patch for the signal model
 
     Returns:
         CLs_obs: The observed CLs value
@@ -134,6 +134,46 @@ def test_sbottom_regionA(regionA_bkgonly_json, regionA_signal_patch_json):
                     0.3843236961508878,
                     0.6557759457699649,
                     0.8910421945189615,
+                ]
+            ),
+            rtol=1e-5,
+        )
+    )
+
+
+def test_sbottom_regionB(regionB_bkgonly_json, regionB_signal_patch_json):
+    CLs_obs, CLs_exp = calculate_CLs(regionB_bkgonly_json, regionB_signal_patch_json)
+    assert CLs_obs == pytest.approx(0.999346961987008, rel=1e-5)
+    assert np.all(
+        np.isclose(
+            np.array(CLs_exp),
+            np.array(
+                [
+                    0.998057935502826,
+                    0.998751430736146,
+                    0.999346535249686,
+                    0.999764360117854,
+                    0.999954715109718,
+                ]
+            ),
+            rtol=1e-5,
+        )
+    )
+
+
+def test_sbottom_regionC(regionC_bkgonly_json, regionC_signal_patch_json):
+    CLs_obs, CLs_exp = calculate_CLs(regionC_bkgonly_json, regionC_signal_patch_json)
+    assert CLs_obs == pytest.approx(0.9424021663134358, rel=1e-5)
+    assert np.all(
+        np.isclose(
+            np.array(CLs_exp),
+            np.array(
+                [
+                    0.8906506884676416,
+                    0.9280287127442725,
+                    0.9614301796189283,
+                    0.9857558128338463,
+                    0.9971959212073871,
                 ]
             ),
             rtol=1e-5,

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -67,8 +67,35 @@ def regionA_signal_patch_json(sbottom_likelihoods_download):
 def test_gzip_file(regionA_bkgonly_json, regionA_signal_patch_json):
     bkg_json = regionA_bkgonly_json
     signal_json = regionA_signal_patch_json
-    s = json.dumps(bkg_json, indent=4, sort_keys=True)
-    s = json.dumps(signal_json, indent=4, sort_keys=True)
+    workspace = pyhf.workspace.Workspace(bkg_json)
+    patched = workspace.model(
+        measurement_name=None,
+        patches=[signal_json],
+        modifier_settings={
+            'normsys': {'interpcode': 'code4'},
+            'histosys': {'interpcode': 'code4p'},
+        },
+    )
+    result = pyhf.utils.hypotest(
+        1.0, workspace.data(patched), patched, qtilde=True, return_expected_set=True
+    )
+    result = {'CLs_obs': result[0].tolist()[0], 'CLs_exp': result[-1].ravel().tolist()}
+    print(json.dumps(result, indent=4, sort_keys=True))
+
+    # command line
+    # {
+    #     "CLs_exp": [
+    #         0.09022521939741368,
+    #         0.19378411715432514,
+    #         0.3843236961508878,
+    #         0.6557759457699649,
+    #         0.8910421945189615
+    #     ],
+    #     "CLs_obs": 0.24443635754482018
+    # }
+    # pytest
+    # {'CLs_obs': 0.24443635754482018, 'CLs_exp': [0.09022521939741368, 0.19378411715432514, 0.3843236961508878, 0.6557759457699649, 0.8910421945189615]}
+
     # print(s)
     # TODO: Patch bkg_json with signal_json to create workspace
     # Then validate

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1,5 +1,6 @@
 import pytest
 import requests
+import hashlib
 import tarfile
 import json
 import os
@@ -14,8 +15,12 @@ def sbottom_likelihoods_download():
     targz_filename = "sbottom_workspaces.tar.gz"
     response = requests.get(sbottom_HEPData_URL, stream=True)
     assert response.status_code == 200
-    with open(targz_filename, 'wb') as file:
+    with open(targz_filename, "wb") as file:
         file.write(response.content)
+    assert (
+        hashlib.sha256(open(targz_filename, "rb").read()).hexdigest()
+        == "9089b0e5fabba335bea4c94545ccca8ddd21289feeab2f85e5bcc8bada37be70"
+    )
     # Open as a tarfile
     yield tarfile.open(targz_filename, "r:gz")
     os.remove(targz_filename)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1,0 +1,101 @@
+import pyhf
+import requests
+import tarfile
+import json
+import os
+import pytest
+import io
+
+
+# def test_sbottom_download():
+#     # curl -sL hepdata.net/record/resourc…
+#     # | tar -O -xzv RegionA/BkgOnly.json
+#     # | pyhf cls --patch <(curl -sL hepdata.net/record/resourc…
+#     # | tar -O -xzv RegionA/patch.sbottom_1300_205_60.json)
+#     sbottom_HEPData_URL = "https://www.hepdata.net/record/resource/997020?view=true"
+#     response = requests.get(sbottom_HEPData_URL, stream=True)
+#     response.raise_for_status()
+#
+#     with open('/home/mcf/Code/GitHub/pyhf/output.gz', 'wb') as handle:
+#         for block in response.iter_content(1024):
+#             handle.write(block)
+#     # response.content is a GzipFile object
+#     # if downloaded with webbrowser is named HEPData_workspaces.tar.gz
+#     print(tarfile.is_tarfile(response.content))
+#     # tar_file = tarfile.open(name="archive", mode="r:gz", fileobj=response.content)
+#     # print(tar_file)
+
+
+@pytest.fixture(scope='module')
+def sbottom_likelihoods_download(tmp_path):
+    sbottom_HEPData_URL = "https://www.hepdata.net/record/resource/997020?view=true"
+    targz_filename = "sbottom_workspaces.tar.gz"
+    # Download the tar.gz of the likelihoods
+    # file_path = os.path.join(tmp_path.strpath, sbottom_HEPData_URL)
+    file_name = tmp_path.join(targz_filename)
+    response = requests.get(tmp_path.join(sbottom_HEPData_URL), stream=True)
+    assert response.status_code == 200
+    with open(file_name, 'wb') as file:
+        file.write(response.content)
+    # Open as a tarfile
+    return tarfile.open(file_name, "r:gz")
+
+
+@pytest.fixture(scope='module')
+def regionA_bkgonly_json(sbottom_likelihoods_download):
+    tarfile = sbottom_likelihoods_download()
+    bkgonly_json_data = (
+        tarfile.extractfile(tarfile.getmember("RegionA/BkgOnly.json"))
+        .read()
+        .decode("utf8")
+    )
+    return json.loads(bkgonly_json_data)
+
+
+@pytest.fixture(scope='module')
+def regionA_signal_patch_json(sbottom_likelihoods_download):
+    tarfile = sbottom_likelihoods_download()
+    signal_patch_json_data = (
+        tarfile.extractfile(tarfile.getmember("RegionA/patch.sbottom_1300_205_60.json"))
+        .read()
+        .decode("utf8")
+    )
+    return json.loads(signal_patch_json_data)
+
+
+# def test_gzip_file():
+#     sbottom_HEPData_URL = "https://www.hepdata.net/record/resource/997020?view=true"
+#     targz_filename = "sbottom_workspaces.tar.gz"
+#     # Download the tar.gz of the likelihoods
+#     response = requests.get(sbottom_HEPData_URL, stream=True)
+#     assert response.status_code == 200
+#     with open(targz_filename, 'wb') as file:
+#         file.write(response.content)
+#     # Open as a tarfile and extrac the files
+#     tar = tarfile.open(targz_filename, "r:gz")
+#     bkgonly_json_data = (
+#         tar.extractfile(tar.getmember("RegionA/BkgOnly.json")).read().decode("utf8")
+#     )
+#     bkgonly_data = json.loads(bkgonly_json_data)
+#
+#     regionA_signal_json_data = (
+#         tar.extractfile(tar.getmember("RegionA/patch.sbottom_1300_205_60.json"))
+#         .read()
+#         .decode("utf8")
+#     )
+#     regionA_signal_data = json.loads(regionA_signal_json_data)
+#
+#     s = json.dumps(bkgonly_data, indent=4, sort_keys=True)
+#     print(s)
+
+
+def test_gzip_file(regionA_bkgonly_json, regionA_signal_patch_json):
+    bkg_json = regionA_bkgonly_json()
+    signal_json = regionA_signal_patch_json()
+    s = json.dumps(bkg_json, indent=4, sort_keys=True)
+    # print(s)
+    s = json.dumps(signal_json, indent=4, sort_keys=True)
+    print(s)
+
+
+test_gzip_file()

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -145,6 +145,7 @@ def test_sbottom_regionB(regionB_bkgonly_json, regionB_signal_patch_json):
 def test_sbottom_regionC(regionC_bkgonly_json, regionC_signal_patch_json):
     CLs_obs, CLs_exp = calculate_CLs(regionC_bkgonly_json, regionC_signal_patch_json)
     assert CLs_obs == pytest.approx(0.9424021663134358, rel=1e-5)
+    # TODO: Lower tolerance to 1e-5 once Python 2.7 is dropped
     assert np.all(
         np.isclose(
             np.array(CLs_exp),
@@ -157,6 +158,6 @@ def test_sbottom_regionC(regionC_bkgonly_json, regionC_signal_patch_json):
                     0.9971959212073871,
                 ]
             ),
-            rtol=1e-5,
+            rtol=1e-4,
         )
     )

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -186,32 +186,31 @@ def test_sbottom_regionB_1400_550_60(
     )
 
 
-def test_sbottom_regionC_1000_205_60(
+def test_sbottom_regionC_1600_850_60(
     sbottom_likelihoods_download, get_json_from_tarfile
 ):
     sbottom_regionC_bkgonly_json = get_json_from_tarfile(
         sbottom_likelihoods_download, "RegionC/BkgOnly.json"
     )
-    sbottom_regionC_1000_205_60_patch_json = get_json_from_tarfile(
-        sbottom_likelihoods_download, "RegionC/patch.sbottom_1000_205_60.json"
+    sbottom_regionC_1600_850_60_patch_json = get_json_from_tarfile(
+        sbottom_likelihoods_download, "RegionC/patch.sbottom_1600_850_60.json"
     )
     CLs_obs, CLs_exp = calculate_CLs(
-        sbottom_regionC_bkgonly_json, sbottom_regionC_1000_205_60_patch_json
+        sbottom_regionC_bkgonly_json, sbottom_regionC_1600_850_60_patch_json
     )
-    assert CLs_obs == pytest.approx(0.9424009499519606, rel=1e-5)
-    # TODO: Lower tolerance to 1e-5 once Python 2.7 is dropped
+    assert CLs_obs == pytest.approx(0.711023707425625, rel=1e-5)
     assert np.all(
         np.isclose(
             np.array(CLs_exp),
             np.array(
                 [
-                    0.8906470732412857,
-                    0.9280262743211622,
-                    0.9614288407343238,
-                    0.9857553063165135,
-                    0.9971958190844394,
+                    0.2955492909588046,
+                    0.4446885457298284,
+                    0.6371473864200973,
+                    0.8336149623750603,
+                    0.9585901381554178,
                 ]
             ),
-            rtol=1e-4,
+            rtol=1e-5,
         )
     )

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -604,7 +604,7 @@ def source_2bin_2channel_coupledshapefactor():
 
 @pytest.fixture(scope='module')
 def spec_2bin_2channel_coupledshapefactor(
-    source=source_2bin_2channel_coupledshapefactor()
+    source=source_2bin_2channel_coupledshapefactor(),
 ):
     spec = {
         'channels': [


### PR DESCRIPTION
# Description

Resolves #518 

Add a regression test that uses the observed and expected CLs values of the [ATLAS sbottom published likelihood](https://www.hepdata.net/record/ins1748602)

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add regression test on ATLAS sbottom public likelihood
   - c.f. https://www.hepdata.net/record/ins1748602
```
