### PR TITLE
docs: Add talks, seminars, and tutorials up through October 2019

### DIFF
--- a/docs/bib/talks.bib
+++ b/docs/bib/talks.bib
@@ -1,6 +1,17 @@
 % NB: entries with same author-title-year are not picked up:
 %     https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/117
 
+@unpublished{Heinrich20191023,
+  title  = {{HEP in the Cloud Computing and Open Science Era}},
+  author = {Lukas Heinrich},
+  year   = {2019},
+  month  = {Oct},
+  day    = {23},
+  note   = {EP-IT Data science seminar},
+  organization = {CERN},
+  url    = {https://indico.cern.ch/event/840837/},
+}
+
 @unpublished{Stark20190523,
   title  = {{New techniques for use of public likelihoods for reinterpretation of search results}},
   author = {Giordon Stark},

--- a/docs/bib/talks.bib
+++ b/docs/bib/talks.bib
@@ -12,6 +12,17 @@
   url    = {https://indico.cern.ch/event/840837/},
 }
 
+@unpublished{Feickert20191018,
+  title  = {{pyhf: pure-Python implementation of HistFactory}},
+  author = {Matthew Feickert},
+  year   = {2019},
+  month  = {Oct},
+  day    = {18},
+  note   = {PyHEP 2019 Workshop},
+  organization = {PyHEP},
+  url    = {https://indico.cern.ch/event/833895/contributions/3577824/},
+}
+
 @unpublished{Stark20190523,
   title  = {{New techniques for use of public likelihoods for reinterpretation of search results}},
   author = {Giordon Stark},

--- a/docs/bib/talks.bib
+++ b/docs/bib/talks.bib
@@ -12,6 +12,17 @@
   url    = {https://indico.desy.de/indico/event/22731/session/4/contribution/19},
 }
 
+@unpublished{Stark20191023,
+  title  = {{Likelihood Preservation and Reproduction}},
+  author = {Giordon Stark},
+  year   = {2019},
+  month  = {Oct},
+  day    = {23},
+  note   = {West Coast LHC Jamboree 2019},
+  organization = {SLAC},
+  url    = {https://indico.cern.ch/event/848030/contributions/3616614/},
+}
+
 @unpublished{Heinrich20191023,
   title  = {{HEP in the Cloud Computing and Open Science Era}},
   author = {Lukas Heinrich},

--- a/docs/bib/talks.bib
+++ b/docs/bib/talks.bib
@@ -1,6 +1,17 @@
 % NB: entries with same author-title-year are not picked up:
 %     https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/117
 
+@unpublished{Heinrich20191030,
+  title  = {{Traditional inference with machine learning tools}},
+  author = {Lukas Heinrich},
+  year   = {2019},
+  month  = {Oct},
+  day    = {30},
+  note   = {1st Pan-European Advanced School on Statistics in High Energy Physics},
+  organization = {DESY},
+  url    = {https://indico.desy.de/indico/event/22731/session/4/contribution/19},
+}
+
 @unpublished{Heinrich20191023,
   title  = {{HEP in the Cloud Computing and Open Science Era}},
   author = {Lukas Heinrich},

--- a/docs/bib/tutorials.bib
+++ b/docs/bib/tutorials.bib
@@ -1,0 +1,13 @@
+% NB: entries with same author-title-year are not picked up:
+%     https://github.com/mcmtroffaes/sphinxcontrib-bibtex/issues/117
+
+@unpublished{Heinrich20191025,
+  title  = {{Introduction to pyhf}},
+  author = {Lukas Heinrich},
+  year   = {2019},
+  month  = {Oct},
+  day    = {25},
+  note   = {(Internal) ATLAS Induction Day + Software Tutorial},
+  organization = {CERN},
+  url    = {https://indico.cern.ch/event/831761/contributions/3484275/},
+}

--- a/docs/talks.rst
+++ b/docs/talks.rst
@@ -45,6 +45,16 @@ This list will be updated with talks given on :code:`pyhf`:
    :all:
    :style: plain
 
+Tutorials
+---------
+
+This list will be updated with tutorials and schools given on :code:`pyhf`:
+
+.. bibliography:: bib/tutorials.bib
+   :list: bullet
+   :all:
+   :style: plain
+
 
 Posters
 -------


### PR DESCRIPTION
# Description

Add talks, seminars, and tutorials that have been given up through October 2019. Add a tutorial section to the talks webpage.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add Matthew PyHEP 2019 talk
* Add Lukas CERN seminar "HEP in the Cloud Computing and Open Science Era" that shows a pyhf example
* Add Giordon West Coast LHC Jamboree 2019 talk
* Add Lukas "Introduction to pyhf" tutorial given at the 2019 ATLAS Induction Day + Software Tutorial
* Add Lukas DESY stats school 2019 talk that demos pyhf
```
