### PR TITLE
revert: Use TensorFlow Probability release compatible with TensorFlow v1.15

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as readme_md
 
 extras_require = {
     'tensorflow': [
-        'tensorflow~=1.14',
-        'tensorflow-probability~=0.5,<0.8',
+        'tensorflow~=1.15',
+        'tensorflow-probability~=0.8',
         'numpy<=1.14.5,>=1.14.0',  # Lower of 1.14.0 instead of 1.13.3 to ensure doctest pass
     ],
     'torch': ['torch~=1.2'],

--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as readme_md
     long_description = readme_md.read()
 
 extras_require = {
-    'tensorflow': [
-        'tensorflow~=1.15',
-        'tensorflow-probability~=0.8',
-        'numpy<=1.14.5,>=1.14.0',  # Lower of 1.14.0 instead of 1.13.3 to ensure doctest pass
-    ],
+    'tensorflow': ['tensorflow~=1.15', 'tensorflow-probability~=0.8', 'numpy~=1.16',],
     'torch': ['torch~=1.2'],
     'xmlio': ['uproot'],
     'minuit': ['iminuit'],


### PR DESCRIPTION
Revert upper bound on TensorFlow Probability introduced in PR #592 and instead use a release of tfp that is compatible with TensorFlow v1.15, as it is the last TF v1.0 API release.

This should go in before release `v0.1.3` is cut.

# Description

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Use a release of tfp that is compatible with TensorFlow v1.15
   - TensorFlow v1.15 is the last TF v1.0 API release
   - Effectively reverts PR #592
* Use a NumPy release compatible with TensorFlow v1.15 requirements
```