### PR TITLE
ci: Migrate docs deployment to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
         cd docs && make html && cd -
         touch docs/_build/html/.nojekyll
     - name: Deploy docs to GitHub Pages
-      if: success()
+      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master'
       uses: crazy-max/ghaction-github-pages@v1.0.1
       with:
         target_branch: gh-pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,3 +106,11 @@ jobs:
         python -m doctest README.md
         cd docs && make html && cd -
         touch docs/_build/html/.nojekyll
+    - name: Deploy docs to GitHub Pages
+      if: success()
+      uses: crazy-max/ghaction-github-pages@v1.0.1
+      with:
+        target_branch: gh-pages
+        build_dir: docs/_build/html
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,29 +33,6 @@ env:
 jobs:
   include:
   - name: "Python 2.7"
-  - stage: docs
-    python: '3.7'
-    before_install:
-      - sudo apt-get update
-      - sudo apt-get -qq install pandoc
-      - sudo apt-get -qq install libtcmalloc-minimal4
-      - export LD_PRELOAD="/usr/lib/libtcmalloc_minimal.so.4"
-      - pip install --upgrade pip setuptools wheel
-    install:
-      - pip install --ignore-installed -U -q --no-cache-dir -e .[complete]
-      - pip freeze
-    script:
-      - python -m doctest README.md
-      - cd docs && make html && cd -
-      - touch docs/_build/html/.nojekyll
-    after_success: echo "Skipping after_success"
-    deploy:
-      provider: pages
-      skip_cleanup: true
-      github_token: $GITHUB_TOKEN
-      local_dir: docs/_build/html
-      on:
-        branch: master
   - stage: deploy
     # Tests deployment to PyPI for all commits to master
     name: "TestPyPI deploy"


### PR DESCRIPTION
# Description

Move deployment of the docs from Travis CI to GitHub Actions. This is motivated by the fact that [Travis CI is currently failing to build the docs due to changes on their end](https://travis-ci.org/diana-hep/pyhf/builds/607366695).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Move deployment on the docs from Travis CI to GitHub Actions
```
