### PR TITLE
chore: Use DOI endpoint API for sbottom likelihood

### DIFF
--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -11,7 +11,7 @@ import numpy as np
 @pytest.fixture(scope='module')
 def sbottom_likelihoods_download():
     """Download the sbottom likelihoods tarball from HEPData"""
-    sbottom_HEPData_URL = "https://www.hepdata.net/record/resource/997020?view=true"
+    sbottom_HEPData_URL = "https://doi.org/10.17182/hepdata.89408.v1/r2"
     targz_filename = "sbottom_workspaces.tar.gz"
     response = requests.get(sbottom_HEPData_URL, stream=True)
     assert response.status_code == 200


### PR DESCRIPTION
# Description

The DOI (https://doi.org/10.17182/hepdata.89408.v1/r2) is shorter and more clear then the HEPData resource number (https://www.hepdata.net/record/resource/997020?view=true).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* The DOI (https://doi.org/10.17182/hepdata.89408.v1/r2) is shorter and more clear then the HEPData resource number (https://www.hepdata.net/record/resource/997020?view=true)
```
