### PR TITLE
ci: Remove redundant check-manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
       if: matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'
       run: |
         pyflakes src
-        check-manifest
     - name: Lint with Black
       if: matrix.python-version == 3.7 && matrix.os == 'ubuntu-latest'
       run: |


### PR DESCRIPTION
# Description

`check-manifest` is being run in the "Check MANIFEST" stage so there is no need to run it also in the "Lint with Pyflakes" stage. It seems [this was a typo on my part a long time ago](https://github.com/diana-hep/pyhf/pull/527/files#diff-e9f950f17198d3d5e3122a44230a09b9R33).

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Remove redundant check-manifest in the pyflakes lint stage
```
