### PR TITLE
ci: Migrate publishing from Travis CI to GitHub Actions

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,0 +1,34 @@
+name: Publish distributions
+on:
+  push:
+    branches:
+    - master
+    tags:
+    - v*
+
+jobs:
+  build-and-publish:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install pep517
+      run: |
+        python -m pip install pep517 --user
+    - name: Build a binary wheel and a source tarball
+      run: |
+        python -m pep517.build --source --binary --out-dir dist/ .
+    - name: Publish distribution 📦 to Test PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.testpypi_password }}
+        repository_url: https://test.pypi.org/legacy/
+    - name: Publish distribution 📦 to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         python -m pep517.build --source --binary --out-dir dist/ .
     - name: Publish distribution 📦 to Test PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@v1.0.0a0
       env:
         IS_TESTPYPI: ${{ true }}
       with:
@@ -32,7 +32,7 @@ jobs:
         repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@v1.0.0a0
       with:
         user: __token__
         password: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -27,10 +27,12 @@ jobs:
       env:
         IS_TESTPYPI: ${{ true }}
       with:
+        user: __token__
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@master
       with:
+        user: __token__
         password: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,4 +1,4 @@
-name: Publish distributions
+name: publish distributions
 on:
   push:
     branches:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -24,6 +24,8 @@ jobs:
         python -m pep517.build --source --binary --out-dir dist/ .
     - name: Publish distribution 📦 to Test PyPI
       uses: pypa/gh-action-pypi-publish@master
+      env:
+        IS_TESTPYPI: ${{ true }}
       with:
         password: ${{ secrets.testpypi_password }}
         repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -27,7 +27,7 @@ jobs:
       env:
         IS_TESTPYPI: ${{ true }}
       with:
-        password: ${{ secrets.testpypi_password }}
+        password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -27,12 +27,10 @@ jobs:
       env:
         IS_TESTPYPI: ${{ true }}
       with:
-        user: __token__
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@v1.0.0a0
       with:
-        user: __token__
         password: ${{ secrets.pypi_password }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,10 @@ script:
 after_success: skip
 
 # test Python 2.7 on 'push' builds
-# test docs and deploy to PyPI only when merged into master (those mereges are 'push' builds)
+# deploy to PyPI only when merged into master (those mereges are 'push' builds)
 stages:
   - name: test
     if: NOT (type IN (pull_request))
-  - name: docs
-    if: (branch = master) AND (NOT (type IN (pull_request)))
   - name: deploy
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,51 +18,6 @@ script:
 after_success: skip
 
 # test Python 2.7 on 'push' builds
-# deploy to PyPI only when merged into master (those mereges are 'push' builds)
 stages:
   - name: test
     if: NOT (type IN (pull_request))
-  - name: deploy
-
-env:
-  global:
-  - secure: fI08Hxg2PYUrvG9LHBqZZWRGGt7q4sAlWDQlwvpdrLgy/71dPOrNCiJrkhOjVBGc0/3aphgVPEu8ofHbcBWBWq4WJHmmz+nC8gEhjzn9ef0qSheLXoU+ee7ejxfIi2VD+M1BRRYSe9acHrUlXlCp4ffbpDeCF1zApGY7VWNVtuiKm8rOHDjc1aWuJ8FRpvNUbCQWi2CGop2FmzaXfYr9zC6lZlqNWD0/AckkWgig4ykrIZgYjonBl6HEF76WxRJcCyGKQQIx2MeTR0m1HXSgM3ZS2Iubf1H7xM6NJKDfgJOc8mLoDQJvP0ml0SJUL+Y1aYGoVgye1x3j4caB81DU/7OQK/0HPydCEpZekrR/1wRv3TJqPMxf/T2Kpj3mhiyM9GZg3P5sw7pS5gr3T9eqnfZor81sxtr5ZM7jUntXz7toLifz0j3mDpREgci1+u555QnakW6Xzfzz94DpKXSOLcH/iLl6EEXLvATopX2Ya822aXe9eazFAanNM/P49r91dxHYyvwse7z5Hwx+Mm71ckr1P53Z5U4QSKFOYUsWs+kw9PJWbz40Y08s6+DsCmdZ8IxWD4RCBUtqCjN+Up7ja77yuqDvYfoQbRrxYkPUYLCIeZ6bPxJYR6GWCc3F1wliRAZwmb/hnDKKSDx0mTOPA93uzDrXqF2vfRLwrd/u+00=
-
-jobs:
-  include:
-  - name: "Python 2.7"
-  - stage: deploy
-    # Tests deployment to PyPI for all commits to master
-    name: "TestPyPI deploy"
-    if: (branch = master) AND type = push
-    env:
-      # Signal that setup.py should use use_scm_version with local_scheme
-      TESTPYPI_UPLOAD: true
-    python: '3.7'
-    install: skip
-    script: skip
-    after_success: echo "Skipping after_success"
-    deploy:
-      provider: pypi
-      server: https://test.pypi.org/legacy/
-      username:
-        secure: KDi40+7LVX2E/tWtVhGB/jWrNDqNiO+dKzqkbOTP7ZvGrMu3VIVA1KbfDiWxygd5rgC7UAQcqTFbUHnwuyFAmooIhH3fDwpzpugz5zzW4Hia0eBUanarw40DHlBS0wVzw+zZoLP/wltR8Dg75vp2awPTqrvFyq444Jgzzah+xhHwTYx4VB9oeMAoiS0OSLn561pR1N+nzSRMe3R1Sl8AZtPLTCgOZ5tZARZjqiqtYXfTEaMQPj/BNmVYatsaUkCkljZjiLv/uiL6Ushz/Y0dhPdVF63dKDTM6NvDxT+pBA/+58U6RqcRmMdlYmCurgKTJ5W4VAXckHXaYwu5pvrd1pxqPJ7oNvdpDZ9JktHsQog8IxVjoij8Je5T4iE3hjEH/Jm8yKUL2WlPeyLxV0S9xmSdhTIeTZgAtbPQgP0KN7SC1ZB/S7irstJ68PilHc/ZxBbYthGu0tPOmHHye+lzVyV6qAhZkbRFarro0MgWjJR9U8vM5JHFsEvBm7ghHaKDGd75wE9MDHqxftxXGKJbZ19OlRCqnte8LA8a1Wa0E5Iw3QPaG7eq2cBp3TwwECw0ipMBBXfOz4ZIIcDRC/vcnW03zf6ziWaZ152QAVsmiJqXnzFBV7thPA28vqQtv0vAdzXO8e2lROYz18z8m2LTdvG4DiNxkNlN7KHjK1i+VEg=
-      password:
-        secure: CqHxAg2GWY+7ogMKJYCqH8Eynmc1Xhh+WocntEfsJXOgsqksmHF5q9dp6IxGwrrts1ZWbxOs80mici2LSAxtHnVBAXfiqWm5cZ6nEv6+hvAzidvGO7Q2OVs3CIVKU4jCDg2BJIBo84Whqwe6T5S+DKUDo6PYQUtIvHqnO4PmDyB2Y2rLquavMqMkh8wIfFaDj51J5zm2aNdXx4349LvlMcW2yn0/Mh1t6yP1LUCkirCPjdIAljmqmrkxscEdCepR3sXjgYggpW/RLTXtMaUc/6Pz1Ax5uU3Y/mtuXT19lC+9PiFpciuLBvM6h0RjRz87tVE4US7DfbjZIIZFdrd97eog9Jqh0cDsD+lymgzTpeEaisXtDwBlI+osUtjB5d1rWCtsIu39fBRi368SLgBH3yrbYEIuNBzczeQ1wxMmJlWflQ/6nbPEaRxKpMZVjMRngdd8rccNj0vAJxsMlzqJZ99RbUjyMQ5n1JO1GU/9mnu1NH/+gZrvoGCLBaqKQDewrTkVKAMTmm/lti9hIEpgXr+U5KyAM0dtvU3ncLCEhIV6H9KujHx8S52hz/C1OJAXwh4otC2rnuiS21XhFfADJbVtXE9lBX0ANgc/pWs11Yu38ZbfoXnx5GkALuUnw2jZ2ZeEiugu5/dqlPTmleBgkxcRsVNx8/fft3raIscIYjM=
-      distributions: "sdist bdist_wheel"
-  - stage: deploy
-    name: "PyPI deploy"
-    if: (tag =~ v[0-9\.]*)
-    python: '3.7'
-    install: skip
-    script: skip
-    after_success: echo "Skipping after_success"
-    deploy:
-      provider: pypi
-      on:
-        tags: true
-      username:
-        secure: v0vpmWdTcorBuQ1YvMNN3fUSGfbjJGWA2lIw2/GD0OsTwWUbVnBq3f5yKyEm1PHNVAsDRZZ0Hbh0YFLjcxy5nVF1COaUVFWExETDJwTyclvjEsXCpdPt24LY3VC7aLS+bkJ1qo7xqlnPOgvdiNeO/bbZqta+9D6xFUrAo8Il/DU2HzehfURPSszFBqQF4zlA+CeOhwruguXZbhsYSBE2AwJ2m4In+jnXDONuz2Y8zsLZ6z+On9U7fg6g7/5ZtY9TA4aGdUhsx06JvuJ1ZedoJmB96hdDXOYprK9v/Dy5U2h/zljhATw9Cp2dSgm/fsdB+Kw/oJNmL9lTQTOT7e75LkZO9DfCyzDRgpv0jb7zAjrxiNQXFtQqZMMAQQLRRD1I2bbR7d1+qlxajrcPv1w/FkEIT9ZDCoX4X62mFIY/owkTVOWlqPSpPsZhU5blMHO2eu4xoInx3mmerVdqGFI4qhQDqGtZVitF/8wkA7wj1OTmifubaCdivaunZWaoF1G27yEk1RaouYC4Rw4gQDftjMd63sn9gGTTAmOkEio9zJ9DhWYLHSk+T7Rvtnfqb2ySlcl4HG3/x+doy09PBAyeYaUET/oM0W7Ap9OoA7J/M936b1PkCJAyZyeNLgFkefYXNOanp96ylLxMWKOqUshR9sJE+pZHMHsVyfgn8buIs6Y=
-      password:
-        secure: p6kDYM0L6CX9RFNnBpwhWiKUijgYoUY0Alxxqb6L8csnLhuYSB5fVgqoF2Xb9YQv8OuwdBay+TbCHCdps4QnDxEitL1sF98OoN6nBv5s7RvAk1byzWoJQml16QJs2ZcH130/GBYfmAKrcy07mfWJfLrXfbncgr85v6OZkiwj4irzvMt3SBziLK5/FBLTgjwNj+JTUuG0CLkwunKO5oedQ8Ix+S3gHM3ne8osKPEJpHpxMcVWXdT/4UHqb3mn5bYHKqPGvHNJM4PpJqohhL5KZCmRA+juTNUMfh6XOWR9UokxUFQJcPSQWCDwejfaCV2jS2p/rfV+3aUGYkORvKqgVUoQMceqyCHQLKhfGnIU7L4osqehBVEKcEPVctPtqCmR1EzUmrk2penDc+mrkzl+3UL3DA7BFubVlNGfC/zetnSURI8tdUEOKecOL3mKk6IcmFXZFg0t5OvoTYtdGa9ksNV+Z8RBKX8wkEN9IPf1pH6chEW6NmPSyOGMYW4gzKwHfmPAucMY7x4zx2ypAwu+CzqBzw/TA1/D/y1eG4OvAQjrI6PekkQUt0nEqJfGWRZ0NA5f4eswlAe6lPrrpJETRaPWgUDDIn19QHA0JI9+tuabgMKHhWNMbFi6RmfLxkxmdbGrhNhbypcC368QuQNDlhaV2e1sXEaJid2GJO6DqQA=
-      distributions: "sdist bdist_wheel"

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1169739.svg)](https://doi.org/10.5281/zenodo.1169739)
 
 [![Travis Build Status](https://travis-ci.org/diana-hep/pyhf.svg?branch=master)](https://travis-ci.org/diana-hep/pyhf)
-[![GitHub Actions Status: CI](https://github.com/diana-hep/pyhf/workflows/CI/CD/badge.svg)](https://github.com/diana-hep/pyhf/actions?workflow=CI/CD)
-[![GitHub Actions Status: Publish](https://github.com/diana-hep/pyhf/workflows/Publish%20distributions/badge.svg)](https://github.com/diana-hep/pyhf/actions?workflow=Publish+distributions)
+[![GitHub Actions Status: CI](https://github.com/diana-hep/pyhf/workflows/CI/CD/badge.svg)](https://github.com/diana-hep/pyhf/actions?query=workflow%3ACI%2FCD+branch%3Amaster)
+[![GitHub Actions Status: Publish](https://github.com/diana-hep/pyhf/workflows/Publish%20distributions/badge.svg)](https://github.com/diana-hep/pyhf/actions?query=workflow%3A%22Publish+distributions%22+branch%3Amaster)
 [![Docker Automated](https://img.shields.io/docker/automated/pyhf/pyhf.svg)](https://hub.docker.com/r/pyhf/pyhf/)
 [![Code Coverage](https://codecov.io/gh/diana-hep/pyhf/graph/badge.svg?branch=master)](https://codecov.io/gh/diana-hep/pyhf?branch=master)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/diana-hep/pyhf.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/diana-hep/pyhf/latest/files/)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Travis Build Status](https://travis-ci.org/diana-hep/pyhf.svg?branch=master)](https://travis-ci.org/diana-hep/pyhf)
 [![GitHub Actions Status: CI](https://github.com/diana-hep/pyhf/workflows/CI/CD/badge.svg)](https://github.com/diana-hep/pyhf/actions?query=workflow%3ACI%2FCD+branch%3Amaster)
-[![GitHub Actions Status: Publish](https://github.com/diana-hep/pyhf/workflows/Publish%20distributions/badge.svg)](https://github.com/diana-hep/pyhf/actions?query=workflow%3A%22Publish+distributions%22+branch%3Amaster)
+[![GitHub Actions Status: Publish](https://github.com/diana-hep/pyhf/workflows/publish%20distributions/badge.svg)](https://github.com/diana-hep/pyhf/actions?query=workflow%3A%22publish+distributions%22+branch%3Amaster)
 [![Docker Automated](https://img.shields.io/docker/automated/pyhf/pyhf.svg)](https://hub.docker.com/r/pyhf/pyhf/)
 [![Code Coverage](https://codecov.io/gh/diana-hep/pyhf/graph/badge.svg?branch=master)](https://codecov.io/gh/diana-hep/pyhf?branch=master)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/diana-hep/pyhf.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/diana-hep/pyhf/latest/files/)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.1169739.svg)](https://doi.org/10.5281/zenodo.1169739)
 
 [![Travis Build Status](https://travis-ci.org/diana-hep/pyhf.svg?branch=master)](https://travis-ci.org/diana-hep/pyhf)
-[![GitHub Actions Status](https://github.com/diana-hep/pyhf/workflows/CI/CD/badge.svg)](https://github.com/diana-hep/pyhf/actions)
+[![GitHub Actions Status: CI](https://github.com/diana-hep/pyhf/workflows/CI/CD/badge.svg)](https://github.com/diana-hep/pyhf/actions?workflow=CI/CD)
+[![GitHub Actions Status: Publish](https://github.com/diana-hep/pyhf/workflows/Publish%20distributions/badge.svg)](https://github.com/diana-hep/pyhf/actions?workflow=Publish+distributions)
 [![Docker Automated](https://img.shields.io/docker/automated/pyhf/pyhf.svg)](https://hub.docker.com/r/pyhf/pyhf/)
 [![Code Coverage](https://codecov.io/gh/diana-hep/pyhf/graph/badge.svg?branch=master)](https://codecov.io/gh/diana-hep/pyhf?branch=master)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/diana-hep/pyhf.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/diana-hep/pyhf/latest/files/)

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -18,3 +18,15 @@ Then setup the Git pre-commit hook for `Black <https://github.com/psf/black>`__ 
 .. code-block:: console
 
     pre-commit install
+
+Publishing
+----------
+
+Publishing to `PyPI <https://pypi.org/project/pyhf/>`__ and `TestPyPI <https://test.pypi.org/project/pyhf/>`__
+is automated through the `PyPA's PyPI publish GitHub Action <https://github.com/pypa/gh-action-pypi-publish>`__.
+To publish a release to PyPI one simply needs to run :code:`bumpversion` to update the
+release version and get a tagged commit and then push the commit and tag to :code:`master` with
+
+.. code-block:: console
+
+    git push origin master --tags

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -24,8 +24,14 @@ Publishing
 
 Publishing to `PyPI <https://pypi.org/project/pyhf/>`__ and `TestPyPI <https://test.pypi.org/project/pyhf/>`__
 is automated through the `PyPA's PyPI publish GitHub Action <https://github.com/pypa/gh-action-pypi-publish>`__.
-To publish a release to PyPI one simply needs to run :code:`bumpversion` to update the
-release version and get a tagged commit and then push the commit and tag to :code:`master` with
+To publish a release to PyPI one simply needs to run
+
+.. code-block:: console
+
+    bumpversion [major|minor|patch]
+
+to update the release version and get a tagged commit and then push the commit
+and tag to :code:`master` with
 
 .. code-block:: console
 

--- a/docs/governance/ROADMAP.md
+++ b/docs/governance/ROADMAP.md
@@ -1,4 +1,4 @@
-# pyhf 2019 into 2020 Roadmap (Issue #561)
+# pyhf 2019 into 2020 Roadmap (Issue [#561](https://github.com/diana-hep/pyhf/issues/561))
 
 ## Overview and Goals
 

--- a/docs/governance/ROADMAP.md
+++ b/docs/governance/ROADMAP.md
@@ -1,4 +1,4 @@
-# pyhf 2019 into 2020 Roadmap
+# pyhf 2019 into 2020 Roadmap (Issue #561)
 
 ## Overview and Goals
 
@@ -39,7 +39,7 @@ The roadmap will be executed over mostly Quarter 3 of 2019 through Quarter 1 of 
       - [ ] Add small case studies with published sbottom likelihood from HEPData
    - [ ] Move to [scikit-hep](https://github.com/scikit-hep) GitHub organization [2019-Q3]
    - [ ] Develop a release schedule/criteria [2019-Q4]
-   - [ ] Automate deployment with Azure pipeline (talk with Henry Schreiner) (Issue #517) [2019-Q3]
+   - [x] Automate deployment with ~~Azure pipeline (talk with Henry Schreiner) (Issue #517)~~ GitHub Actions (Issue #508) [2019-Q3]
    - [ ] Finalize logo and add it to website (Issue #453) [2019-Q3 → 2019-Q4]
    - [ ] Write submission to [JOSS](https://joss.theoj.org/) (Issue #502) and write submission to [pyOpenSci](https://www.pyopensci.org/) [2019-Q4 → 2020-Q2]
    - [ ] Contribute to [IRIS-HEP Analysis Systems Milestones](https://docs.google.com/spreadsheets/d/1VKpHlQWXu_p8AUv5E5H_BzqF_i7hh2Z-Id0XPwNHu8o/edit#gid=1864915304) "[Initial roadmap for ecosystem coherency](https://github.com/iris-hep/project-milestones/issues/8)" and "[Initial roadmap for high-level cyberinfrastructure components of analysis system](https://github.com/iris-hep/project-milestones/issues/11)" [2019-Q4 → 2020-Q2]

--- a/setup.py
+++ b/setup.py
@@ -50,8 +50,8 @@ extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 
 def _is_test_pypi():
     """
-    Determine if the Travis CI environment has TESTPYPI_UPLOAD defined and
-    set to true (c.f. .travis.yml)
+    Determine if the CI environment has IS_TESTPYPI defined and
+    set to true (c.f. .github/workflows/publish-package.yml)
 
     The use_scm_version kwarg accepts a callable for the local_scheme
     configuration parameter with argument "version". This can be replaced
@@ -65,7 +65,7 @@ def _is_test_pypi():
 
     return (
         {'local_scheme': lambda version: ''}
-        if getenv('TESTPYPI_UPLOAD') == 'true'
+        if getenv('IS_TESTPYPI') == 'true'
         else False
     )
 


### PR DESCRIPTION
# Description

Resolves #508

Migrate the publication of the distributions from Travis CI to GitHub Actions using the [PyPA's "PyPI publish GitHub Action"](https://github.com/pypa/gh-action-pypi-publish) using [PyPI's API token](https://pypi.org/help/#apitoken). This workflow publishes to TestPyPI on every commit to `master` and published to PyPI on every tag that is pushed to `master`. Thus, to publish, one simply just needs to run `bumpversion` on `master` and then do `git push origin master --tags`.

Many thanks go to the PyPA team for their tool and their [well written guide to it](https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/), and special thanks go to @webknjaz for his long patience and helpful advice. This workflow is based off of the PyPA example workflow and @kratsg's [workflow for `stare`](https://github.com/kratsg/stare/blob/6d063d4f12ced9c5440328b9ff12350dc53b5020/.github/workflows/publish-package-to-pypi.yml). 

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* Add publishing workflow to GitHub Actions for TestPyPI and PyPI using API tokens
* Remove publishing from Travis CI
* Add publishing section to developer docs
```
