### PR TITLE
fix: Add build-system to pyproject.toml

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -5,6 +5,9 @@ on:
     - master
     tags:
     - v*
+  pull_request:
+    branches:
+    - master
 
 jobs:
   build-and-publish:
@@ -23,6 +26,7 @@ jobs:
       run: |
         python -m pep517.build --source --binary --out-dir dist/ .
     - name: Publish distribution 📦 to Test PyPI
+      if: github.event_name == 'push'
       uses: pypa/gh-action-pypi-publish@v1.0.0a0
       env:
         IS_TESTPYPI: ${{ true }}
@@ -30,7 +34,7 @@ jobs:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution 📦 to PyPI
-      if: startsWith(github.ref, 'refs/tags')
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@v1.0.0a0
       with:
         password: ${{ secrets.pypi_password }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
+[build-system]
+# Minimum requirements for the build system to execute.
+requires = ["wheel", "setuptools>=30.3.0", "attrs>=17.1", "setuptools_scm"]
+build-backend = "setuptools.build_meta"
+
 [tool.black]
 line-length = 88
 py36 = false  # Python 2 is still supported


### PR DESCRIPTION
# Description

Fixes #638

This PR needs to add `[build-system]` in [pyproject.toml](https://github.com/diana-hep/pyhf/blob/52a02de19f848e12b74f5b87de0ac9c8e60da42b/pyproject.toml) which was missing in order to run the `pypa-publishing` recipe introduced in #638. Additionally, we didn't catch this because the test workflow wasn't being run to check if we could build... now we check and we're good to go.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR
```
* Fixes PR #638
* Add build-system in pyproject.toml which was missing in order to run the PyPA-publishing recipe introduced in #638
* Make sure workflow for publish builds packages, but does not publish to TestPyPI
```