### PR TITLE
fix: Correct reference check in GitHub Actions publish to TestPyPI step

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -30,13 +30,13 @@ jobs:
         python -m pep517.build --source --binary --out-dir dist/ .
     - name: Publish distribution 📦 to Test PyPI
       # every PR will trigger a push event on master, so check the push event is actually coming from master
-      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == "diana-hep/pyhf"
       uses: pypa/gh-action-pypi-publish@v1.0.0a0
       with:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution 📦 to PyPI
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+      if: success() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && github.repository == "diana-hep/pyhf"
       uses: pypa/gh-action-pypi-publish@v1.0.0a0
       with:
         password: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -26,6 +26,7 @@ jobs:
       run: |
         python -m pep517.build --source --binary --out-dir dist/ .
     - name: Publish distribution 📦 to Test PyPI
+      # every PR will trigger a push event on master, so check the push event is actually coming from master
       if: github.event_name == 'push' && github.ref == 'refs/heads/master'
       uses: pypa/gh-action-pypi-publish@v1.0.0a0
       env:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         python -m pep517.build --source --binary --out-dir dist/ .
     - name: Publish distribution 📦 to Test PyPI
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
       uses: pypa/gh-action-pypi-publish@v1.0.0a0
       env:
         IS_COMMIT_TAGGED: >-

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -30,13 +30,13 @@ jobs:
         python -m pep517.build --source --binary --out-dir dist/ .
     - name: Publish distribution 📦 to Test PyPI
       # every PR will trigger a push event on master, so check the push event is actually coming from master
-      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == "diana-hep/pyhf"
+      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'diana-hep/pyhf'
       uses: pypa/gh-action-pypi-publish@v1.0.0a0
       with:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution 📦 to PyPI
-      if: success() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && github.repository == "diana-hep/pyhf"
+      if: success() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && github.repository == 'diana-hep/pyhf'
       uses: pypa/gh-action-pypi-publish@v1.0.0a0
       with:
         password: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -29,7 +29,8 @@ jobs:
       if: github.event_name == 'push'
       uses: pypa/gh-action-pypi-publish@v1.0.0a0
       env:
-        IS_TESTPYPI: ${{ true }}
+        IS_COMMIT_TAGGED: >-
+          ${{ startsWith(github.ref, 'refs/tags') }}
       with:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -23,15 +23,15 @@ jobs:
       run: |
         python -m pip install pep517 --user
     - name: Build a binary wheel and a source tarball
+      env:
+        IS_COMMIT_TAGGED: >-
+          ${{ startsWith(github.ref, 'refs/tags') }}
       run: |
         python -m pep517.build --source --binary --out-dir dist/ .
     - name: Publish distribution 📦 to Test PyPI
       # every PR will trigger a push event on master, so check the push event is actually coming from master
       if: github.event_name == 'push' && github.ref == 'refs/heads/master'
       uses: pypa/gh-action-pypi-publish@v1.0.0a0
-      env:
-        IS_COMMIT_TAGGED: >-
-          ${{ startsWith(github.ref, 'refs/tags') }}
       with:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -30,13 +30,13 @@ jobs:
         python -m pep517.build --source --binary --out-dir dist/ .
     - name: Publish distribution 📦 to Test PyPI
       # every PR will trigger a push event on master, so check the push event is actually coming from master
-      if: success() && github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'diana-hep/pyhf'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'diana-hep/pyhf'
       uses: pypa/gh-action-pypi-publish@v1.0.0a0
       with:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution 📦 to PyPI
-      if: success() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && github.repository == 'diana-hep/pyhf'
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && github.repository == 'diana-hep/pyhf'
       uses: pypa/gh-action-pypi-publish@v1.0.0a0
       with:
         password: ${{ secrets.pypi_password }}

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as readme_md
     long_description = readme_md.read()
 
 extras_require = {
-    'tensorflow': ['tensorflow~=1.15', 'tensorflow-probability~=0.8', 'numpy~=1.16',],
+    'tensorflow': ['tensorflow~=1.15', 'tensorflow-probability~=0.8', 'numpy~=1.16'],
     'torch': ['torch~=1.2'],
     'xmlio': ['uproot'],
     'minuit': ['iminuit'],
@@ -50,14 +50,12 @@ extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 
 def _is_test_pypi():
     """
-    Determine if the CI environment has IS_TESTPYPI defined and
-    set to true (c.f. .github/workflows/publish-package.yml)
-
+    Determine if the CI environment has IS_COMMIT_TAGGED defined and
+    set to true (c.f. .github/workflows/publish-package-to-pypi.yml)
     The use_scm_version kwarg accepts a callable for the local_scheme
     configuration parameter with argument "version". This can be replaced
     with a lambda as the desired version structure is {next_version}.dev{distance}
     c.f. https://github.com/pypa/setuptools_scm/#importing-in-setuppy
-
     As the scm versioning is only desired for TestPyPI, for depolyment to PyPI the version
     controlled through bumpversion is used.
     """
@@ -65,7 +63,7 @@ def _is_test_pypi():
 
     return (
         {'local_scheme': lambda version: ''}
-        if getenv('IS_TESTPYPI') == 'true'
+        if getenv('IS_COMMIT_TAGGED') == 'false'
         else False
     )
 


### PR DESCRIPTION
# Description

This adds in changes to #639. GHA triggers pushes on PRs as well... so you can't tell if a push event comes from a PR or not. Also need to fix logic of whether to use `scm` or not depending on if we're tagged or not.

# Checklist Before Requesting Reviewer

- [x] Tests are passing
- [x] "WIP" removed from the title of the pull request
- [x] Selected an Assignee for the PR to be responsible for the log summary

# Before Merging

For the PR Assignees:

- [x] Summarize commit messages into a comprehensive review of the PR

```
* More fixes to workflow in #639, only push to testpypi on pushes on master
* Only use scm if the current commit is not tagged
* Protect forks from publishing
```